### PR TITLE
feat: shorten function names shown on pages

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -124,6 +124,7 @@ def _get_cls_module(_type, name):
     Foo
 
     """
+
     cls = None
     if _type in [FUNCTION, EXCEPTION]:
         module = '.'.join(name.split('.')[:-1])
@@ -145,7 +146,7 @@ def _create_reference(datam, parent, is_external=False):
         'uid': datam['uid'],
         'parent': parent,
         'isExternal': is_external,
-        'name': datam['name'],
+        'name': datam['source']['id'],
         'fullName': datam['fullName'],
     }
 
@@ -304,6 +305,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
                     # Match the defaults with the count
                     if 'object at 0x' not in str(default):
                         args[len(args) - cut_count + count]['defaultValue'] = str(default)
+
     except Exception as e:
         print("Can't get argspec for {}: {}. Exception: {}".format(type(obj), name, e))
 
@@ -733,7 +735,8 @@ def build_finished(app, exception):
                     convert_module_to_package_if_needed(obj)
 
                 if obj['type'] == 'method':
-                    obj['namewithoutparameters'] = obj['source']['id']
+                    # Update the name to use shorter name to show
+                    obj['name'] = obj['source']['id']
 
                 # To distinguish distribution package and import package
                 if obj.get('type', '') == 'package' and obj.get('kind', '') != 'distribution':


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

Shortening the function name entries by using `obj['source']['id']` which simply shows its shorter name such as `update_backup` rather than `update_backup(request: Optional[google.cloud.spanner_admin_database_v1.types.backup.UpdateBackupRequest] = None, *, backup: Optional[google.cloud.spanner_admin_database_v1.types.backup.Backup] = None, update_mask: Optional[google.protobuf.field_mask_pb2.FieldMask] = None, retry: google.api_core.retry.Retry = <object object>, timeout: Optional[float] = None, metadata: Sequence[Tuple[str, str]] = ())`.

Removing usage of `namewithoutparameters` since it doesn't get used and seems redundant in this case.

Updated to make use of shorter names in the references as well. 

Fixes #21 

- [X] Tests pass
- [ ] Appropriate changes to README are included in PR
