### PR TITLE
feat: Add support for Property and missing content

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -312,7 +312,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
                 lines = inspect.getdoc(obj)
                 lines = lines.split("\n") if lines else []
             except Exception as e:
-                print("couldn't getdoc from method, function. Exception: {}".format(e))
+                print("couldn't getdoc from method, function: {}".format(e))
 
         
         elif _type in [PROPERTY]:
@@ -397,7 +397,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
         if summary:
             top_summary = ""
 
-            # Initialize known types needing further process.
+            # Initialize known types needing further processing.
             var_types = {
                 ':rtype:': 'returns',
                 ':returns:': 'returns',
@@ -414,7 +414,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
                 if index > -1:
                     indexes.append(index)
 
-            # If we found types needing further process, locate its index,
+            # If we found types needing further processing, locate its index,
             # if we found empty array for indexes, stop processing further.
             index = min(indexes) if indexes else 0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # google-resumable-media-python requires manual update as this repo isn't templated.
+sphinxcontrib.napoleon 
 sphinx==4.0.2
 -e .
 tox

--- a/tests/example/conflict/foo.py
+++ b/tests/example/conflict/foo.py
@@ -182,3 +182,22 @@ class Foo(object):
         :param tuple arg1: Parameter arg1 of :meth:`conflict.foo.Foo.method_default_value_comma`, default value is (1,2,3).
         """
         pass
+
+    def snapshot(self, **kw):
+        """Create a snapshot to perform a set of reads with shared staleness.
+
+        See
+        https://cloud.google.com/spanner/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions.ReadOnly
+
+        :type kw: dict
+        :param kw: Passed through to
+                   :class:`~google.cloud.spanner_v1.snapshot.Snapshot` ctor.
+
+        :rtype: :class:`~google.cloud.spanner_v1.snapshot.Snapshot`
+        :returns: a snapshot bound to this session
+        :raises ValueError: if the session has not yet been created.
+        """
+        if self._session_id is None:
+            raise ValueError("Session has not been created.")
+
+        return Snapshot(self, **kw)

--- a/tests/example/format/google/foo.py
+++ b/tests/example/format/google/foo.py
@@ -36,6 +36,8 @@ def function(arg1, arg2, arg3, arg4):
 class Foo(object):
     """ Docstring of :class:`format.google.foo.Foo` class in google format.
 
+    Testing for xref with new regex: :class:`google.spanner.v1.types.ExecuteSqlRequest.QueryMode` class.
+
     Attributes:
         attr (:class:`~format.rst.enum.EnumFoo`): Docstring of :any:`format.google.foo.Foo.attr` from class docstring.
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     {[testenv]deps}
 changedir = {toxinidir}/docs
 commands =
-    sphinx-build -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
+    sphinx-build -D extensions=sphinx.ext.autodoc,sphinx.ext.autosummary,docfx_yaml.extension,sphinx.ext.intersphinx,sphinx.ext.coverage,sphinx.ext.napoleon,sphinx.ext.todo,sphinx.ext.viewcode -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

While investigating for adding support for property, I managed to add a section for content discrepancy as both fo them seem to be missing with the newer Sphinx upgrade from 1.x to 2.1.0+

This PR achieves the following:
- Adds handler for property so that they properly show in the YAML hierarchy
- Adds handler for missing documentation snippets for each entries
  - for each documentation snippet, sanitizes it into useful subsections for display in HTML pages
  - currently has handlers for `:type`, `:rtype:`, `:returns:`, `:raises`, and `:param`

@busunkim96 I added handlers for subsections based on the 5 given above from `python-spanner`, for example:

```python
    def execute_sql(
        self,
        sql,
        params=None,
        param_types=None,
        query_mode=None,
        query_options=None,
        retry=google.api_core.gapic_v1.method.DEFAULT,
        timeout=google.api_core.gapic_v1.method.DEFAULT,
    ):  
        """Perform an ``ExecuteStreamingSql`` API request.

        :type sql: str
        :param sql: SQL query statement

        :type params: dict, {str -> column value}
        :param params: values for parameter replacement.  Keys must match
                       the names used in ``sql``.

        :type param_types:
            dict, {str -> :class:`~google.spanner.v1.types.TypeCode`}
        :param param_types: (Optional) explicit types for one or more param
                            values;  overrides default type detection on the
                            back-end.

        :type query_mode:
            :class:`~google.spanner.v1.types.ExecuteSqlRequest.QueryMode`
        :param query_mode: Mode governing return of results / query plan. See:
            `QueryMode <https://cloud.google.com/spanner/reference/rpc/google.spanner.v1#google.spanner.v1.ExecuteSqlRequest.QueryMode>`_.

        :type query_options:
            :class:`~google.cloud.spanner_v1.types.ExecuteSqlRequest.QueryOptions`
            or :class:`dict`
        :param query_options: (Optional) Options that are provided for query plan stability.

        :type retry: :class:`~google.api_core.retry.Retry`
        :param retry: (Optional) The retry settings for this request.

        :type timeout: float
        :param timeout: (Optional) The timeout for this request.

        :rtype: :class:`~google.cloud.spanner_v1.streamed.StreamedResultSet`
        :returns: a result set instance which can be used to consume rows.
        """
```
given with such documentation support. Should I expect the client libraries to be accustomed to this, or should I take a more general approach and try to guess based on given parameters or simply leave them blank if I'm not given these in the documentation?

Fixes #40 

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
- [ ] Send part of this change upstream for support in missing content / handler for property
