### PR TITLE
fix: remove function and method name override

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -384,9 +384,6 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
         datam['children'] = []
         datam['references'] = []
 
-    if _type in [FUNCTION, METHOD]:
-        datam['name'] = app.env.docfx_signature_funcs_methods.get(name, datam['name'])
-
     return datam
 
 


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

We opted to shorten the names displayed on the functions so that we don't show duplicated name and syntax to the users. The syntax is already captured inside `syntax['content']` field, so no need to duplicate it back into the name field.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
