### PR TITLE
fix: update dependency requirements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,4 +25,7 @@ jobs:
       - name: Run unittest
         run: |
           tox -e unittest
+      - name: Run librarytest
+        run: |
+          tox -e librarytest
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # google-resumable-media-python requires manual update as this repo isn't templated.
-sphinxcontrib.napoleon
 sphinx==4.0.2
 -e .
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # google-resumable-media-python requires manual update as this repo isn't templated.
-sphinxcontrib.napoleon 
 sphinx==4.0.2
 -e .
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # google-resumable-media-python requires manual update as this repo isn't templated.
+sphinxcontrib.napoleon
 sphinx==4.0.2
 -e .
 tox

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ version = '0.3.0'
 dependencies = [
     'PyYAML',
     'sphinx',
+    'sphinxcontrib.napoleon',
     'unidecode',
     'wheel>=0.24.0'
 ]

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,10 @@ description = 'Sphinx Python Domain to DocFX YAML Generator'
 version = '0.3.0'
 dependencies = [
     'PyYAML',
-    'wheel>=0.24.0',
     'sphinx',
-    'unidecode'
+    'sphinxcontrib.napoleon',
+    'unidecode',
+    'wheel>=0.24.0'
 ]
 
 packages = setuptools.find_packages('.', exclude=['tests'])

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ version = '0.3.0'
 dependencies = [
     'PyYAML',
     'sphinx',
-    'sphinxcontrib.napoleon',
     'unidecode',
     'wheel>=0.24.0'
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,13 @@ deps =
 commands =
     python3 -m unittest tests/test_unit.py
 
+[testenv:librarytest]
+deps =
+    sphinx_rtd_theme
+changedir = {toxinidir}/docs
+commands =
+    sphinx-build -D extensions=sphinx.ext.autodoc,sphinx.ext.autosummary,docfx_yaml.extension,sphinx.ext.intersphinx,sphinx.ext.coverage,sphinx.ext.napoleon,sphinx.ext.todo,sphinx.ext.viewcode -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html
+
 [testenv:lint]
 deps =
     {[testenv]deps}


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

Missed adding `sphinxcontrib.napoleon` import in `setup.py` instead of adding it in `requirements.txt`. Will need to release 0.3.1 to allow docs builds to work across Client Libraries.

Fixes #47 

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
