### PR TITLE
fix: handle entries that cannot be disambiguated

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -796,6 +796,9 @@ def find_unique_name(package_name, entries):
         if name != "google" and name != "cloud" and entries[name] == 1:
             return [name, package_name[-1]]
 
+    # If there is no way to disambiguate, return the identifier name
+    return [package_name[-1]]
+
 # Used to disambiguate names that have same entries.
 def disambiguate_toc_name(toc_yaml):
     name_entries = {}

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -49,6 +49,21 @@ class TestGenerate(unittest.TestCase):
         self.assertEqual(yaml_want, yaml_got)
 
 
+    def test_disambiguate_toc_name_duplicate(self):
+
+        want_file = open('tests/yaml_post_duplicate.yaml', 'r')
+        yaml_want = load(want_file, Loader=Loader)
+
+        test_file = open('tests/yaml_pre_duplicate.yaml', 'r')
+        yaml_got = load(test_file, Loader=Loader)
+        disambiguate_toc_name(yaml_got)
+
+        want_file.close()
+        test_file.close()
+
+        self.assertEqual(yaml_want, yaml_got)
+
+
     def test_reference_in_summary(self):
         lines_got = """
 If a ``stream`` is attached to this download, then the downloaded

--- a/tests/yaml_post_duplicate.yaml
+++ b/tests/yaml_post_duplicate.yaml
@@ -1,0 +1,34 @@
+[
+   {
+      "name":"client_info",
+      "uidname":"google.api_core.client_info",
+      "items":[
+         {
+            "name":"Overview",
+            "uidname":"google.api_core.client_info",
+            "uid":"google.api_core.client_info"
+         },
+         {
+            "name":"ClientInfo",
+            "uidname":"google.api_core.client_info.ClientInfo",
+            "uid":"google.api_core.client_info.ClientInfo"
+         }
+      ]
+   },
+   {
+      "name":"gapic_v1.client_info",
+      "uidname":"google.api_core.gapic_v1.client_info",
+      "items":[
+         {
+            "name":"Overview",
+            "uidname":"google.api_core.gapic_v1.client_info",
+            "uid":"google.api_core.gapic_v1.client_info"
+         },
+         {
+            "name":"ClientInfo",
+            "uidname":"google.api_core.gapic_v1.client_info.ClientInfo",
+            "uid":"google.api_core.gapic_v1.client_info.ClientInfo"
+         }
+      ]
+   },
+]

--- a/tests/yaml_pre_duplicate.yaml
+++ b/tests/yaml_pre_duplicate.yaml
@@ -1,0 +1,34 @@
+[
+   {
+      "name":"client_info",
+      "uidname":"google.api_core.client_info",
+      "items":[
+         {
+            "name":"Overview",
+            "uidname":"google.api_core.client_info",
+            "uid":"google.api_core.client_info"
+         },
+         {
+            "name":"ClientInfo",
+            "uidname":"google.api_core.client_info.ClientInfo",
+            "uid":"google.api_core.client_info.ClientInfo"
+         }
+      ]
+   },
+   {
+      "name":"client_info",
+      "uidname":"google.api_core.gapic_v1.client_info",
+      "items":[
+         {
+            "name":"Overview",
+            "uidname":"google.api_core.gapic_v1.client_info",
+            "uid":"google.api_core.gapic_v1.client_info"
+         },
+         {
+            "name":"ClientInfo",
+            "uidname":"google.api_core.gapic_v1.client_info.ClientInfo",
+            "uid":"google.api_core.gapic_v1.client_info.ClientInfo"
+         }
+      ]
+   },
+]


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

When given entries like in the unit test:

```
{
   "name": "client_info",
   "uidname":"google.api_core.client_info",
   ...
},
{
   "name": "client_info",
   "uidname":"google.api_core.gapic_v1.client_info",
   ...
}
```
the above entries, since they're in the same level, forms the following name map:
```
name_entries: {'client_info': {'google': 2, 'api_core': 2, 'client_info': 2, 'gapic_v1': 1}, ...
```
which the client_info on the bottom entry can be disambiguated, but with the given logic we cannot disambiguate the top entry for `client_info`. To work this out, in this case we'll simply return the last entry (same as `"name"`).

Fixes #58 

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR