### PR TITLE
chore: update reminder for sphinx version update on other repositories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # google-resumable-media-python requires manual update as this repo isn't templated.
+# python-api-core also requires manual update as it is not templated.
 sphinx==4.0.3
 -e .
 tox


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

Python-api-core is another repo that is not using templated Noxfile.py for various reasons (see discussion on https://github.com/googleapis/python-api-core/issues/219), and we'll need to update it manually when we need Sphinx version updates.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
