### PR TITLE
chore: allow testing plugin without running nox

### DIFF
--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -30,6 +30,8 @@ gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS
 # Install dependencies.
 python3 -m pip install --user --quiet --upgrade nox
 python3 -m pip install --user gcp-docuploader
+python3 -m pip install -e .
+python3 -m pip install recommonmark
 
 # Retrieve unique repositories to regenerate the YAML with.
 for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t- -k5,5); do
@@ -93,6 +95,12 @@ for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t
     ## upload docs
     # python3 -m docuploader upload docs/_build/html --metadata-file docs.metadata --staging-bucket "${STAGING_BUCKET}"
 
+    # Test running with the plugin version locally.
+    if [[ ${TEST_PLUGIN} == "true" ]]; then
+      python3 -m pip install -e .
+      sphinx-build -T -N -D extensions=sphinx.ext.autodoc,sphinx.ext.autosummary,docfx_yaml.extension,sphinx.ext.intersphinx,sphinx.ext.coverage,sphinx.ext.napoleon,sphinx.ext.todo,sphinx.ext.viewcode,recommonmark -b html -d docs/_build/doctrees/ docs/ docs/_build/html/
+      continue
+    fi
 
     # Build YAML tarballs for Cloud-RAD.
     nox -s docfx

--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -96,7 +96,7 @@ for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t
     # python3 -m docuploader upload docs/_build/html --metadata-file docs.metadata --staging-bucket "${STAGING_BUCKET}"
 
     # Test running with the plugin version locally.
-    if [[ ${TEST_PLUGIN} == "true" ]]; then
+    if [[ "${TEST_PLUGIN}" == "true" ]]; then
       python3 -m pip install -e .
       sphinx-build -T -N -D extensions=sphinx.ext.autodoc,sphinx.ext.autosummary,docfx_yaml.extension,sphinx.ext.intersphinx,sphinx.ext.coverage,sphinx.ext.napoleon,sphinx.ext.todo,sphinx.ext.viewcode,recommonmark -b html -d docs/_build/doctrees/ docs/ docs/_build/html/
       continue

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -26,6 +26,7 @@ pass_down_envvars+=(
     "V2_STAGING_BUCKET"
     "NOX_SESSION"
     "FORCE_GENERATE_ALL_TAGS"   # Regenerates YAML for all versions if set to true.
+    "TEST_PLUGIN"
 )
 
 # Prevent unintentional override on the default image.

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -26,7 +26,7 @@ pass_down_envvars+=(
     "V2_STAGING_BUCKET"
     "NOX_SESSION"
     "FORCE_GENERATE_ALL_TAGS"   # Regenerates YAML for all versions if set to true.
-    "TEST_PLUGIN"
+    "TEST_PLUGIN"               # Test current plugin version without updating the docs.
 )
 
 # Prevent unintentional override on the default image.


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

Minor update to the testing script for the plugin for running the plugin across all Python client libraries. If `TEST_PLUGIN=true` is passed on, it will simply run `sphinx-build` with the default sphinx installed based on the version of the hash passed in, allowing us to test the newer versions of the plugin more effectively. We could also make this as part of a presubmit test when needed (expected to take ~30 minutes to run).

When the environmental variable above is passed, it will not update any docs.

Fixes #68 

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
