### PR TITLE
chore: fix test-plugin for generate-docs job

### DIFF
--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -32,6 +32,8 @@ python3 -m pip install --user --quiet --upgrade nox
 python3 -m pip install --user gcp-docuploader
 python3 -m pip install -e .
 python3 -m pip install recommonmark
+# Required for some client libraries:
+python3 -m pip install --user django==2.2
 
 # Retrieve unique repositories to regenerate the YAML with.
 for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t- -k5,5); do
@@ -97,7 +99,8 @@ for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t
 
     # Test running with the plugin version locally.
     if [[ "${TEST_PLUGIN}" == "true" ]]; then
-      python3 -m pip install -e .
+      # --no-use-pep517 is required for django-spanner install issue: see https://github.com/pypa/pip/issues/7953
+      python3 -m pip install --user --no-use-pep517 -e .
       sphinx-build -T -N -D extensions=sphinx.ext.autodoc,sphinx.ext.autosummary,docfx_yaml.extension,sphinx.ext.intersphinx,sphinx.ext.coverage,sphinx.ext.napoleon,sphinx.ext.todo,sphinx.ext.viewcode,recommonmark -b html -d docs/_build/doctrees/ docs/ docs/_build/html/
       continue
     fi


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

There has been some issue trying to run the job from python-django-spanner:
* some dependencies are only installed through Nox. django-spanner seems to be the only product requiring one-off touch, maintaining a separate `requirements.txt` file or adding here doesn't seem to make much of a difference.
* Supposedly there's an issue when trying to install django-spanner into user site directory on the logs. Adding `--no-use-pep517` to work around this issue.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
