### PR TITLE
feat: add subPackage types for better classification

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -588,7 +588,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
 
     # If there is no summary, add a short snippet.
     else:
-        datam['summary'] = "API documentation for `{}` {}.".format(name, _type)
+        datam['summary'] = "API documentation for `{}` {}.".format(short_name, _type)
 
     if args or sig or summary_info:
         datam['syntax'] = {}
@@ -877,7 +877,6 @@ def build_finished(app, exception):
         if 'source' in obj and 'path' in obj['source'] and obj['source']['path']:
             if obj['source']['path'].endswith(INITPY):
                 obj['type'] = 'subPackage'
-                obj['summary'] = "API documentation for `{}` package.".format(obj['name'])
                 return
 
         for child_uid in obj['children']:
@@ -1134,6 +1133,8 @@ def build_finished(app, exception):
                 obj_full_name = obj['fullName']
                 if disambiguated_names.get(obj_full_name):
                     obj['name'] = disambiguated_names[obj_full_name]
+                    if obj['type'] == 'subPackage':
+                        obj['summary'] = "API documentation for `{}` package.".format(obj['name'])
       
         # data is formatted as [yaml_data, references]
         yaml_data, references = data

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -876,7 +876,7 @@ def build_finished(app, exception):
     def convert_module_to_package_if_needed(obj):
         if 'source' in obj and 'path' in obj['source'] and obj['source']['path']:
             if obj['source']['path'].endswith(INITPY):
-                obj['type'] = 'package'
+                obj['type'] = 'subPackage'
                 return
 
         for child_uid in obj['children']:

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -588,7 +588,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
 
     # If there is no summary, add a short snippet.
     else:
-        datam['summary'] = "API documentation for `{}` {}.".format(short_name, _type)
+        datam['summary'] = f"API documentation for `{short_name}` {_type}."
 
     if args or sig or summary_info:
         datam['syntax'] = {}

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -588,7 +588,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
 
     # If there is no summary, add a short snippet.
     else:
-        datam['summary'] = "API documentation for {} {}.".format(name, _type)
+        datam['summary'] = "API documentation for `{}` {}.".format(name, _type)
 
     if args or sig or summary_info:
         datam['syntax'] = {}
@@ -877,6 +877,7 @@ def build_finished(app, exception):
         if 'source' in obj and 'path' in obj['source'] and obj['source']['path']:
             if obj['source']['path'].endswith(INITPY):
                 obj['type'] = 'subPackage'
+                obj['summary'] = "API documentation for `{}` package.".format(obj['name'])
                 return
 
         for child_uid in obj['children']:


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

A simple change to convert smaller packages as "subPackage" types. Using this to differentiate the sub packages within a package (client library), and to help label these as part of "packages" for template.  

This will help create `packages` section for non-module entries, making the main overview pages much cleaner and nicer :)

Fixes internally filed issue.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
