### PR TITLE
feat: add subclasses to children and reference

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -767,7 +767,7 @@ def insert_children_on_module(app, _type, datam):
                         datam['references'].append(_create_reference(obj, parent=module))
                         break
 
- 
+
 def insert_children_on_class(app, _type, datam):
     """
     Insert children of a specific class

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -767,7 +767,7 @@ def insert_children_on_module(app, _type, datam):
                         datam['references'].append(_create_reference(obj, parent=module))
                         break
 
-
+ 
 def insert_children_on_class(app, _type, datam):
     """
     Insert children of a specific class
@@ -776,13 +776,22 @@ def insert_children_on_class(app, _type, datam):
         return
 
     insert_class = app.env.docfx_yaml_classes[datam[CLASS]]
+    # Find the parent class using the module for subclasses of a class.
+    parent_class = app.env.docfx_yaml_classes.get(datam[MODULE])
+    if parent_class:
+        insert_class += parent_class
     # Find the class which the datam belongs to
     for obj in insert_class:
         if obj['type'] != CLASS:
             continue
-        # Add methods & attributes & properties to class
-        if _type in [METHOD, ATTRIBUTE, PROPERTY] and \
-                obj[CLASS] == datam[CLASS]:
+        # Add subclass & methods & attributes & properties to class
+        if _type in [METHOD, ATTRIBUTE, PROPERTY, CLASS] and \
+                (
+                  # If obj is either method, attr or prop of a class and not self, or
+                  (obj[CLASS] == datam[CLASS] and obj != datam) or \
+                  # If obj is a subclass of another class.
+                  (_type == CLASS and obj['class'] == datam['module'])
+                ):
             obj['children'].append(datam['uid'])
             obj['references'].append(_create_reference(datam, parent=obj['uid']))
             insert_class.append(datam)


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

The function `insert_children_on_class` only cared about underlying class methods, attributes and properties, which left out subclasses of a class. 

To make that happen, search for the parent class by using `datam['module']` and see if there is a parent class that exists, then check that both types are `class` so we don't accidentally insert anything else when we retrieve classes from `app.env.docfx_yaml_classes.get(datam[MODULE])`. 

When actually inserting the children, we separate whether it's class items we're looking for such as attributes, properties and methods, or if it is a subclass of a class with the nested if condition.

Fixes internally filed issue.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
