### PR TITLE
feat: process xrefs properly

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -209,15 +209,33 @@ def _resolve_reference_in_module_summary(pattern, lines):
                     # match string like ':func:`~***`' or ':func:`***`'
                     index = matched_str.index('~') if '~' in matched_str else matched_str.index('`')
                     ref_name = matched_str[index+1:-1]
+
+                index = ref_name.rfind('.') + 1
+                # Find the last component of the target. "~Queue.get" only returns <xref:get>
+                ref_name = ref_name[index:]
+
             else:
                 index = matched_str.rfind('.') + 1
                 if index == 0:
                     # If there is no dot, push index to not include tilde
                     index = 1
-                # Find the last component of the target. "~Queue.get" only returns <xref:get>
                 ref_name = matched_str[index:]
-            xrefs.append(matched_str)
-            new_line = new_line.replace(matched_str, '<xref:{}>'.format(ref_name))
+
+            # Check to see if we should create an xref for it.
+            if 'google.cloud' in matched_str:
+                new_line = new_line.replace(matched_str, '<xref:{}>'.format(ref_name))
+            # If it not a Cloud library, don't create xref for it.
+            else:
+                new_line = new_line.replace(matched_str, '`{}`'.format(ref_name))
+
+            # Find the uid to add for xref
+            index = matched_str.find("google.cloud")
+            if index > -1:
+                xref = matched_str[index:]
+                while not xref[-1].isalnum():
+                    xref = xref[:-1]
+                xrefs.append(xref)
+
         new_lines.append(new_line)
     return new_lines, xrefs
 
@@ -289,6 +307,8 @@ def _extract_signature(obj_sig):
 # Given documentation docstring, parse them into summary_info.
 def _extract_docstring_info(summary_info, summary, name):
     top_summary = ""
+    # Return clean summary if returning early.
+    parsed_text = summary
 
     # Initialize known types needing further processing.
     var_types = {
@@ -303,56 +323,38 @@ def _extract_docstring_info(summary_info, summary, name):
     initial_index = -1
         
     # Prevent GoogleDocstring crashing on custom types and parse all xrefs to normal
-    if '~' in summary or '<xref:' in summary:
+    if '<xref:' in parsed_text:
         type_pairs = []
-        # Find first character after one of the three combination
-        initial_index = min(
-          max(0, summary.find('~')), 
-          max(0, summary.find('<xref'))
-        )
+        initial_index = max(0, parsed_text.find('<xref'))
 
-        summary_part = summary[initial_index:]
+        summary_part = parsed_text[initial_index:]
        
-        # Remove all occurrences of "~xref" and "<xref:type>"
-        while '~' in summary_part or "<xref:" in summary_part:
-
-            # Expecting format of "~xref"
-            if '~' in summary_part:
-                initial_index += summary_part.find('~')
-                original_type = summary[initial_index:initial_index+(summary[initial_index:].find(':'))]
-                initial_index += len(original_type)
-                original_type = " ".join(filter(None, re.split(r'\n|  |\|\s|\t', original_type)))
-                safe_type = original_type[1:]
+        # Remove all occurrences of "<xref:type>"
+        while "<xref:" in summary_part:
 
             # Expecting format of "<xref:type>:"
-            elif "<xref:" in summary_part:
+            if "<xref:" in summary_part:
                 initial_index += summary_part.find("<xref")
-                original_type = summary[initial_index:initial_index+(summary[initial_index:].find('>'))+1]
+                original_type = parsed_text[initial_index:initial_index+(parsed_text[initial_index:].find('>'))+1]
                 initial_index += len(original_type)
                 original_type = " ".join(filter(None, re.split(r'\n|  |\|\s|\t', original_type)))
-                safe_type = original_type[6:-1]
+                safe_type = 'xref_' + original_type[6:-1]
             else:
                 raise ValueError("Encountered unexpected type in Exception docstring.")
 
             type_pairs.append([original_type, safe_type])
-            summary_part = summary[initial_index:]
+            summary_part = parsed_text[initial_index:]
 
         # Replace all the found occurrences
         for pairs in type_pairs:
             original_type, safe_type = pairs[0], pairs[1]
-            summary = summary.replace(original_type, safe_type)
+            parsed_text = parsed_text.replace(original_type, safe_type)
         
     # Clean the string by cleaning newlines and backlashes, then split by white space.
     config = Config(napoleon_use_param=True, napoleon_use_rtype=True)
     # Convert Google style to reStructuredText
-    parsed_text = str(GoogleDocstring(summary, config))
+    parsed_text = str(GoogleDocstring(parsed_text, config))
     
-    # Revert back to original type
-    if initial_index > -1:
-        for pairs in type_pairs:
-            original_type, safe_type = pairs[0], pairs[1]
-            parsed_text = parsed_text.replace(safe_type, original_type)
-
     # Trim the top summary but maintain its formatting.
     indexes = []
     for types in var_types:
@@ -380,6 +382,12 @@ def _extract_docstring_info(summary_info, summary, name):
 
     top_summary = parsed_text[:index]
     parsed_text = parsed_text[index:]
+
+    # Revert back to original type
+    if initial_index > -1:
+        for pairs in type_pairs:
+            original_type, safe_type = pairs[0], pairs[1]
+            parsed_text = parsed_text.replace(safe_type, original_type)
 
     # Clean up whitespace and other characters
     parsed_text = " ".join(filter(None, re.split(r'\|\s', parsed_text))).split()
@@ -583,11 +591,13 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
         for xref in xrefs:
             if xref not in app.env.docfx_xrefs:
                 app.env.docfx_xrefs[xref] = ''
+
         # REF_PATTERN_LAST checks for patterns like "~package.module"
         lines, xrefs = _resolve_reference_in_module_summary(REF_PATTERN_LAST, lines)
         for xref in xrefs:
             if xref not in app.env.docfx_xrefs:
                 app.env.docfx_xrefs[xref] = ''
+
         summary = app.docfx_transform_string('\n'.join(_refact_example_in_module_summary(lines)))
     
         # Extract summary info into respective sections.
@@ -1172,11 +1182,12 @@ def build_finished(app, exception):
                 raise ValueError("Unable to dump object\n{0}".format(yaml_data)) from e
 
         file_name_set.add(filename)
-    
+
     xref_file = os.path.join(normalized_outdir, 'xrefs.yml')
     with open(xref_file, 'w') as xref_file_obj:
         for xref in app.env.docfx_xrefs:
             xref_file_obj.write(f'{xref}\n')
+
 
 def missing_reference(app, env, node, contnode):
     reftarget = ''

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1194,11 +1194,13 @@ def build_finished(app, exception):
 
         file_name_set.add(filename)
 
+    '''
+    # TODO: handle xref for other products.
     xref_file = os.path.join(normalized_outdir, 'xrefs.yml')
     with open(xref_file, 'w') as xref_file_obj:
         for xref in app.env.docfx_xrefs:
             xref_file_obj.write(f'{xref}\n')
-
+    '''
 
 def missing_reference(app, env, node, contnode):
     reftarget = ''

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -221,13 +221,6 @@ def _resolve_reference_in_module_summary(pattern, lines):
                     index = 1
                 ref_name = matched_str[index:]
 
-            # Check to see if we should create an xref for it.
-            if 'google.cloud' in matched_str:
-                new_line = new_line.replace(matched_str, '<xref:{}>'.format(ref_name))
-            # If it not a Cloud library, don't create xref for it.
-            else:
-                new_line = new_line.replace(matched_str, '`{}`'.format(ref_name))
-
             # Find the uid to add for xref
             index = matched_str.find("google.cloud")
             if index > -1:
@@ -235,6 +228,13 @@ def _resolve_reference_in_module_summary(pattern, lines):
                 while not xref[-1].isalnum():
                     xref = xref[:-1]
                 xrefs.append(xref)
+
+            # Check to see if we should create an xref for it.
+            if 'google.cloud' in matched_str:
+                new_line = new_line.replace(matched_str, '<xref uid=\"{}\">{}</xref>'.format(xref, ref_name))
+            # If it not a Cloud library, don't create xref for it.
+            else:
+                new_line = new_line.replace(matched_str, '`{}`'.format(ref_name))
 
         new_lines.append(new_line)
     return new_lines, xrefs

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -81,7 +81,7 @@ If a ``stream`` is attached to this download, then the downloaded
 resource will be written to the stream.
 
 Args:
-    transport (~requests.Session): A ``requests`` object which can
+    transport (~google.cloud.requests.Session): A ``requests`` object which can
         make authenticated requests.
 
     timeout (Optional[Union[float, Tuple[float, float]]]):
@@ -90,22 +90,21 @@ Args:
         several times using the same timeout each time.
 
         Can also be passed as a tuple (connect_timeout, read_timeout).
-        See :meth:`requests.Session.request` documentation for details.
+        See :meth:`google.cloud.requests.Session.request` documentation for details.
 
 Returns:
-    ~requests.Response: The HTTP response returned by ``transport``.
+    ~google.cloud.requests.Response: The HTTP response returned by ``transport``.
 
 Raises:
-    ~google.resumable_media.common.DataCorruption: If the download's
+    ~google.cloud.resumable_media.common.DataCorruption: If the download's
         checksum doesn't agree with server-computed checksum.
     ValueError: If the current :class:`Download` has already
         finished.
 """
         lines_got = lines_got.split("\n")
-
         # Resolve over different regular expressions for different types of reference patterns.
-        lines_got = _resolve_reference_in_module_summary(REF_PATTERN, lines_got)
-        lines_got = _resolve_reference_in_module_summary(REF_PATTERN_LAST, lines_got)
+        lines_got, xrefs = _resolve_reference_in_module_summary(REF_PATTERN, lines_got)
+        lines_got, xrefs = _resolve_reference_in_module_summary(REF_PATTERN_LAST, lines_got)
 
         lines_want = """
 If a ``stream`` is attached to this download, then the downloaded
@@ -121,7 +120,7 @@ Args:
         several times using the same timeout each time.
 
         Can also be passed as a tuple (connect_timeout, read_timeout).
-        See <xref:requests.Session.request> documentation for details.
+        See <xref:request> documentation for details.
 
 Returns:
     <xref:Response>: The HTTP response returned by ``transport``.
@@ -129,7 +128,7 @@ Returns:
 Raises:
     <xref:DataCorruption>: If the download's
         checksum doesn't agree with server-computed checksum.
-    ValueError: If the current <xref:Download> has already
+    ValueError: If the current `Download` has already
         finished.
 """
         lines_want = lines_want.split("\n")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -111,7 +111,7 @@ If a ``stream`` is attached to this download, then the downloaded
 resource will be written to the stream.
 
 Args:
-    transport (<xref:Session>): A ``requests`` object which can
+    transport (<xref uid="google.cloud.requests.Session">Session</xref>): A ``requests`` object which can
         make authenticated requests.
 
     timeout (Optional[Union[float, Tuple[float, float]]]):
@@ -120,13 +120,13 @@ Args:
         several times using the same timeout each time.
 
         Can also be passed as a tuple (connect_timeout, read_timeout).
-        See <xref:request> documentation for details.
+        See <xref uid="google.cloud.requests.Session.request">request</xref> documentation for details.
 
 Returns:
-    <xref:Response>: The HTTP response returned by ``transport``.
+    <xref uid="google.cloud.requests.Response">Response</xref>: The HTTP response returned by ``transport``.
 
 Raises:
-    <xref:DataCorruption>: If the download's
+    <xref uid="google.cloud.resumable_media.common.DataCorruption">DataCorruption</xref>: If the download's
         checksum doesn't agree with server-computed checksum.
     ValueError: If the current `Download` has already
         finished.


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

While resolving the summary, now it fully handles xrefs by shortening references from `google.cloud.long.product.name` to `<xref uid="uid">name</xref>` to allow xrefs to be used in devsite.

After handling that, `_extract_docstring_info` needed to be updated to 
* no longer care about `~xrefs` type, and only `<xref:name>` type
* handle duplicates carefully, and only handle xrefs in non-top_summary part

Then extract xrefs as needed, for now we'll only extract xrefs for Cloud libraries.

It's quite hard to put other product xrefs into `devsite://lang/package` as python package names can heavily differ and is hard to extract from the UID of the xref at this context. For now, I'll be storing them in full UID and handle it in doc-pipeline where I can more easily figure out package based on the UID. I'm tempted to store this in the plugin (`map<uid: package>`), but I'll have to think harder on that. Any suggestions?

Fixes internally filed issue.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
