### PR TITLE
fix: handle more xrefs and keep long uid

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -73,9 +73,9 @@ REFMETHOD = 'meth'
 REFFUNCTION = 'func'
 INITPY = '__init__.py'
 # Regex expression for checking references of pattern like ":class:`~package_v1.module`"
-REF_PATTERN = ':(py:)?(func|class|meth|mod|ref|attr|exc):`~?[a-zA-Z0-9_\.<> ]*?`'
+REF_PATTERN = ':(py:)?(func|class|meth|mod|ref|attr|exc):`~?[a-zA-Z0-9_\.<> ]*(\(\))?`'
 # Regex expression for checking references of pattern like "~package_v1.subpackage.module"
-REF_PATTERN_LAST = '~(([a-zA-Z0-9_<>]*\.)*[a-zA-Z0-9_<>]*)'
+REF_PATTERN_LAST = '~([a-zA-Z0-9_<>]*\.)*[a-zA-Z0-9_<>]*(\(\))?'
 
 PROPERTY = 'property'
 
@@ -234,6 +234,12 @@ def _resolve_reference_in_module_summary(pattern, lines):
                 new_line = new_line.replace(matched_str, '<xref uid=\"{}\">{}</xref>'.format(xref, ref_name))
             # If it not a Cloud library, don't create xref for it.
             else:
+                # Carefully extract the original uid
+                if pattern == REF_PATTERN:
+                    index = matched_str.index('~') if '~' in matched_str else matched_str.index('`')
+                    ref_name = matched_str[index+1:-1]
+                else:
+                    ref_name = matched_str[1:]
                 new_line = new_line.replace(matched_str, '`{}`'.format(ref_name))
 
         new_lines.append(new_line)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -136,6 +136,50 @@ Raises:
         self.assertEqual(lines_got, lines_want)
 
 
+    # Test for added xref coverage and third party xrefs staying as-is
+    def test_reference_in_summary_more_xrefs(self):
+        lines_got = """
+If a ~dateutil.time.stream() is attached to this download, then the downloaded
+resource will be written to the stream.
+
+Args:
+    transport (~google.cloud.requests.Session()): A ``requests`` object which can
+        make authenticated requests.
+
+    timeout (Optional[Union[float, Tuple[float, float]]]):
+        The number of seconds to wait for the server response.
+        Depending on the retry strategy, a request may be repeated
+        several times using the same timeout each time.
+
+        Can also be passed as a :func:`~google.cloud.requests.tuple()` (connect_timeout, read_timeout).
+        See :meth:`google.cloud.requests.Session.request()` documentation for details.
+"""
+        lines_got = lines_got.split("\n")
+        # Resolve over different regular expressions for different types of reference patterns.
+        lines_got, xrefs = _resolve_reference_in_module_summary(REF_PATTERN, lines_got)
+        lines_got, xrefs = _resolve_reference_in_module_summary(REF_PATTERN_LAST, lines_got)
+
+        lines_want = """
+If a `dateutil.time.stream()` is attached to this download, then the downloaded
+resource will be written to the stream.
+
+Args:
+    transport (<xref uid="google.cloud.requests.Session">Session()</xref>): A ``requests`` object which can
+        make authenticated requests.
+
+    timeout (Optional[Union[float, Tuple[float, float]]]):
+        The number of seconds to wait for the server response.
+        Depending on the retry strategy, a request may be repeated
+        several times using the same timeout each time.
+
+        Can also be passed as a <xref uid="google.cloud.requests.tuple">tuple()</xref> (connect_timeout, read_timeout).
+        See <xref uid="google.cloud.requests.Session.request">request()</xref> documentation for details.
+"""
+        lines_want = lines_want.split("\n")
+
+        self.assertEqual(lines_got, lines_want)
+
+
     # Variables used for testing _extract_docstring_info
     top_summary1_want = "\nSimple test for docstring.\n\n"
     summary_info1_want = {

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -102,9 +102,14 @@ Raises:
         finished.
 """
         lines_got = lines_got.split("\n")
+        xrefs_got = []
         # Resolve over different regular expressions for different types of reference patterns.
         lines_got, xrefs = _resolve_reference_in_module_summary(REF_PATTERN, lines_got)
+        for xref in xrefs:
+            xrefs_got.append(xref)
         lines_got, xrefs = _resolve_reference_in_module_summary(REF_PATTERN_LAST, lines_got)
+        for xref in xrefs:
+            xrefs_got.append(xref)
 
         lines_want = """
 If a ``stream`` is attached to this download, then the downloaded
@@ -132,8 +137,17 @@ Raises:
         finished.
 """
         lines_want = lines_want.split("\n")
+        xrefs_want = [
+          "google.cloud.requests.Session",
+          "google.cloud.requests.Session.request",
+          "google.cloud.requests.Response",
+          "google.cloud.resumable_media.common.DataCorruption"
+        ]
 
         self.assertEqual(lines_got, lines_want)
+        self.assertCountEqual(xrefs_got, xrefs_want)
+        # assertCountEqual is a misleading name but checks that two lists contain
+        # same items regardless of order, as long as items in list are sortable.
 
 
     # Test for added xref coverage and third party xrefs staying as-is
@@ -155,9 +169,14 @@ Args:
         See :meth:`google.cloud.requests.Session.request()` documentation for details.
 """
         lines_got = lines_got.split("\n")
+        xrefs_got = []
         # Resolve over different regular expressions for different types of reference patterns.
         lines_got, xrefs = _resolve_reference_in_module_summary(REF_PATTERN, lines_got)
+        for xref in xrefs:
+            xrefs_got.append(xref)
         lines_got, xrefs = _resolve_reference_in_module_summary(REF_PATTERN_LAST, lines_got)
+        for xref in xrefs:
+            xrefs_got.append(xref)
 
         lines_want = """
 If a `dateutil.time.stream()` is attached to this download, then the downloaded
@@ -176,8 +195,16 @@ Args:
         See <xref uid="google.cloud.requests.Session.request">request()</xref> documentation for details.
 """
         lines_want = lines_want.split("\n")
+        xrefs_want = [
+          "google.cloud.requests.Session",
+          "google.cloud.requests.tuple",
+          "google.cloud.requests.Session.request"
+        ]
 
         self.assertEqual(lines_got, lines_want)
+        self.assertCountEqual(xrefs_got, xrefs_want)
+        # assertCountEqual is a misleading name but checks that two lists contain
+        # same items regardless of order, as long as items in list are sortable.
 
 
     # Variables used for testing _extract_docstring_info


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

Editing the regex to look for REF_PATTERN to include parenthesis; however I don't think we should be expecting any cross references that extend beyond the parenthesis. That would mess up trying to find its UID as well, and I don't think that would work naturally either way (How would they show up in its original place?)

When we encounter non-Cloud and third party references, we've been simplifying them which could make them confusing to see. They will still be emphasized by being put in ``, without the additional xref identifiers like `:func:` and other non-alphanumeric characters.

Updated with a new unittest case to reflect upon the changes.

Fixes #84 

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
