### PR TITLE
fix: remove redundant class info for subclasses

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -797,23 +797,28 @@ def insert_children_on_class(app, _type, datam):
     insert_class = app.env.docfx_yaml_classes[datam[CLASS]]
     # Find the parent class using the module for subclasses of a class.
     parent_class = app.env.docfx_yaml_classes.get(datam[MODULE])
-    if parent_class:
-        insert_class += parent_class
+
     # Find the class which the datam belongs to
     for obj in insert_class:
         if obj['type'] != CLASS:
             continue
         # Add subclass & methods & attributes & properties to class
         if _type in [METHOD, ATTRIBUTE, PROPERTY, CLASS] and \
-                (
-                  # If obj is either method, attr or prop of a class and not self, or
-                  (obj[CLASS] == datam[CLASS] and obj != datam) or \
-                  # If datam is a subclass of another class.
-                  (_type == CLASS and obj['class'] == datam['module'])
-                ):
+          (obj[CLASS] == datam[CLASS] and obj != datam):
             obj['children'].append(datam['uid'])
             obj['references'].append(_create_reference(datam, parent=obj['uid']))
             insert_class.append(datam)
+
+    # If there is a parent class, determine if current class is a subclass.
+    if not parent_class:
+        return
+    for obj in parent_class:
+        if obj['type'] != CLASS:
+            continue
+        if _type == CLASS and obj['class'] == datam['module']:
+            # No need to add datam to the parent class.
+            obj['children'].append(datam['uid'])
+            obj['references'].append(_create_reference(datam, parent=obj['uid']))
 
 
 def insert_children_on_function(app, _type, datam):


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

Previously when I simply concatenated the `parent_class` info to `insert_class` to combine the list and iterate through the combined list of the two, unfortunate things happened.

* `insert_class` is a pointer reference to `app.env.docfx_yaml_classes[datam[CLASS]]`, so modifying `insert_class` reflects the data stored in `app.env.docfx_yaml_classes` and we took advantage of that below.
* When I extended `insert_class` with `parent_class`, that's where the duplication happened by echoing the `parent_class` data literally onto the corresponding `app.env.docfx_yaml_classes[datam[CLASS]]`.

This is now avoided by handling them separately.

Also, when adding the `subclass` to its parent we only need to include its info in the reference and under `children` section of the yaml, so we do not need to append `datam` to the parent class, since this would be redundant information we echo onto the parent class.

Fixes #86 

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
