### PR TITLE
fix: parse xrefs differently with new xref format

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -460,12 +460,13 @@ def _extract_docstring_info(summary_info, summary, name):
                 elif ':raises' in cur_type and 'xref' in parsed_text[index]:
                     arg_name = f'{parsed_text[index]} {parsed_text[index+1][:-1]}'
                     index += 1
-                # Other forms will not be processed properly, likely a formatting issue.
-                else:
-                    raise ValueError(f"Encountered wrong formatting, please check docstring for {name}")
-                # Initialize empty dictionary if it doesn't exist already
-                if arg_name not in summary_info[var_types[cur_type]] and ':raises' not in cur_type:
-                    summary_info[var_types[cur_type]][arg_name] = {}
+
+                try:
+                    # Initialize empty dictionary if it doesn't exist already
+                    if arg_name not in summary_info[var_types[cur_type]] and ':raises' not in cur_type:
+                        summary_info[var_types[cur_type]][arg_name] = {}
+                except KeyError:
+                    raise KeyError(f"Encountered wrong formatting, please check docstring for {name}")
 
             # Empty target string
             words = []

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -327,23 +327,34 @@ def _extract_docstring_info(summary_info, summary, name):
     }
     
     initial_index = -1
+    front_tag = '<xref'
+    end_tag = '/xref>'
+    end_len = len(end_tag)
         
     # Prevent GoogleDocstring crashing on custom types and parse all xrefs to normal
-    if '<xref' in parsed_text:
+    if front_tag in parsed_text:
         type_pairs = []
-        initial_index = max(0, parsed_text.find('<xref'))
+        # Constant length for end of xref tag
+        initial_index = max(0, parsed_text.find(front_tag))
 
         summary_part = parsed_text[initial_index:]
        
         # Remove all occurrences of "<xref uid="uid">text</xref>"
-        while "<xref" in summary_part:
+        while front_tag in summary_part:
 
             # Expecting format of "<xref uid="uid">text</xref>"
-            if "<xref" in summary_part:
-                initial_index += summary_part.find("<xref")
-                original_type = parsed_text[initial_index:initial_index+(parsed_text[initial_index:].find('/xref>'))+6]
+            if front_tag in summary_part:
+                # Retrieve the index for starting position of xref tag
+                initial_index += summary_part.find(front_tag)
+
+                # Find the index of the end of xref tag, relative to the start of xref tag
+                end_tag_index = initial_index + parsed_text[initial_index:].find(end_tag) + end_len
+
+                # Retrieve the entire xref tag
+                original_type = parsed_text[initial_index:end_tag_index]
                 initial_index += len(original_type)
                 original_type = " ".join(filter(None, re.split(r'\n|  |\|\s|\t', original_type)))
+
                 # Extract text from "<xref uid="uid">text</xref>"
                 index = original_type.find(">")
                 safe_type = 'xref_' + original_type[index+1:index+(original_type[index:].find("<"))]

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -329,19 +329,19 @@ def _extract_docstring_info(summary_info, summary, name):
     initial_index = -1
         
     # Prevent GoogleDocstring crashing on custom types and parse all xrefs to normal
-    if '<xref:' in parsed_text:
+    if '<xref' in parsed_text:
         type_pairs = []
         initial_index = max(0, parsed_text.find('<xref'))
 
         summary_part = parsed_text[initial_index:]
        
         # Remove all occurrences of "<xref:type>"
-        while "<xref:" in summary_part:
+        while "<xref" in summary_part:
 
             # Expecting format of "<xref:type>:"
-            if "<xref:" in summary_part:
+            if "<xref" in summary_part:
                 initial_index += summary_part.find("<xref")
-                original_type = parsed_text[initial_index:initial_index+(parsed_text[initial_index:].find('>'))+1]
+                original_type = parsed_text[initial_index:initial_index+(parsed_text[initial_index:].find('/xref>'))+6]
                 initial_index += len(original_type)
                 original_type = " ".join(filter(None, re.split(r'\n|  |\|\s|\t', original_type)))
                 safe_type = 'xref_' + original_type[6:-1]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -335,6 +335,15 @@ Description of docstring which should fail.
         with self.assertRaises(ValueError):
             _extract_docstring_info({}, summary4, "error string")
 
+        summary5 = """
+Description of malformed docstring.
+
+Raises:
+    Error that should fail: if condition `x`.
+"""
+        with self.assertRaises(KeyError):
+            _extract_docstring_info({}, summary5, "malformed docstring")
+
 
     def test_extract_docstring_info_with_xref(self):
         ## Test with xref included in the summary, ensure they're processed as-is

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -341,7 +341,7 @@ Description of docstring which should fail.
         summary_info_want = {
             'variables': {
                 'arg1': {
-                    'var_type': '<xref:google.spanner_v1.type.Type>',
+                    'var_type': '<xref uid="google.spanner_v1.type.Type">Type</xref>',
                     'description': 'simple description.'
                 },
                 'arg2': {
@@ -351,13 +351,13 @@ Description of docstring which should fail.
             },
             'returns': [
                 {
-                    'var_type': '<xref:Pair>', 
+                    'var_type': '<xref uid="Pair">Pair</xref>', 
                     'description': 'simple description for return value.'
                 }
             ],
             'exceptions': [
                 {
-                    'var_type': '<xref:SpannerException>', 
+                    'var_type': '<xref uid="SpannerException">SpannerException</xref>', 
                     'description': 'if `condition x`.'
                 }
             ]
@@ -366,15 +366,15 @@ Description of docstring which should fail.
         summary = """
 Simple test for docstring.
 
-:type arg1: <xref:google.spanner_v1.type.Type>
+:type arg1: <xref uid="google.spanner_v1.type.Type">Type</xref>
 :param arg1: simple description.
 :param arg2: simple description for `arg2`.
 :type arg2: ~google.spanner_v1.type.dict
 
-:rtype: <xref:Pair>
+:rtype: <xref uid="Pair">Pair</xref>
 :returns: simple description for return value.
 
-:raises <xref:SpannerException>: if `condition x`. 
+:raises <xref uid="SpannerException">SpannerException</xref>: if `condition x`. 
 """
 
         summary_info_got = {
@@ -384,10 +384,10 @@ Simple test for docstring.
         }
 
         top_summary_got = _extract_docstring_info(summary_info_got, summary, "")
-
+        self.maxDiff = None
         # Same as the top summary from previous example, compare with that
         self.assertEqual(top_summary_got, self.top_summary1_want)
-        self.assertEqual(summary_info_got, summary_info_want)
+        self.assertDictEqual(summary_info_got, summary_info_want)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

Updating xref parser to accommodate the new and only xref format: `<xref uid="uid">text</xref>`.

We need to be careful on two parts:
* 1) Carefully extracting only `text` portion to replace so GoogleDocstring doesn't complain on the leftover xref syntax
* 2) Carefully parse through the docstring as we strip whitespace as well, handled by looking at one token ahead when necessary. 

Fixes #89 
Fixes https://github.com/googleapis/python-firestore/issues/408

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
