### PR TITLE
feat: group left-nav entries into versions and groups

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -958,6 +958,7 @@ def disambiguate_toc_name(toc_yaml):
 
     return disambiguated_names
 
+
 def group_by_package(toc_yaml):
     new_toc_yaml = []
     package_groups = {}
@@ -968,7 +969,6 @@ def group_by_package(toc_yaml):
             package_groups[package_group] = {
                 "name": package_name,
                 "uidname": package_group,
-                "uid": package_group,
                 "items": []
             }
         package_groups[package_group]['items'].append(module)
@@ -978,10 +978,11 @@ def group_by_package(toc_yaml):
 
     return new_toc_yaml
 
+
 # Given the full uid, return the package group including its prefix.
 def find_package_group(uid):
     return ".".join(uid.split(".")[:3])
-    
+
 
 # Given the package group, make its name presentable.
 def pretty_package_name(package_group):
@@ -992,6 +993,7 @@ def pretty_package_name(package_group):
     # Capitalize the first letter of each package name part
     capitalized_name = [part.capitalize() for part in split_name.split("_")]
     return " ".join(capitalized_name)
+
 
 def build_finished(app, exception):
     """
@@ -1243,14 +1245,15 @@ def build_finished(app, exception):
     index_file = os.path.join(normalized_outdir, 'index.yml')
     index_children = []
     index_references = []
-    for item in toc_yaml_with_uid:
-        index_children.append(item.get('uidname', ''))
-        index_references.append({
-            'uid': item.get('uidname', ''),
-            'name': item.get('name', ''),
-            'fullname': item.get('uidname', ''),
-            'isExternal': False
-        })
+    for package in toc_yaml_with_uid:
+        for item in package.get("items"):
+            index_children.append(item.get('uidname', ''))
+            index_references.append({
+                'uid': item.get('uidname', ''),
+                'name': item.get('name', ''),
+                'fullname': item.get('uidname', ''),
+                'isExternal': False
+            })
     with open(index_file, 'w') as index_file_obj:
         index_file_obj.write('### YamlMime:UniversalReference\n')
         dump(

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -959,6 +959,7 @@ def disambiguate_toc_name(toc_yaml):
     return disambiguated_names
 
 
+# Combines toc_yaml entries with similar version headers.
 def group_by_package(toc_yaml):
     new_toc_yaml = []
     package_groups = {}

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -4,6 +4,9 @@ from docfx_yaml.extension import _resolve_reference_in_module_summary
 from docfx_yaml.extension import REF_PATTERN
 from docfx_yaml.extension import REF_PATTERN_LAST
 from docfx_yaml.extension import _extract_docstring_info
+from docfx_yaml.extension import find_package_group
+from docfx_yaml.extension import pretty_package_name
+from docfx_yaml.extension import group_by_package
 
 import unittest
 
@@ -397,6 +400,143 @@ Simple test for docstring.
         # Same as the top summary from previous example, compare with that
         self.assertEqual(top_summary_got, self.top_summary1_want)
         self.assertDictEqual(summary_info_got, summary_info_want)
+
+
+    def test_find_package_group(self):
+        package_group_want = "google.cloud.spanner_v1beta2"
+        uid = "google.cloud.spanner_v1beta2.services.admin_database_v1.types"
+
+        package_group_got = find_package_group(uid)
+        self.assertEqual(package_group_got, package_group_want)
+
+
+    def test_pretty_package_name(self):
+        package_name_want = "Spanner V1beta2"
+        package_group = "google.cloud.spanner_v1beta2"
+
+        package_name_got = pretty_package_name(package_group)
+        self.assertEqual(package_name_got, package_name_want)
+
+
+    def test_group_by_package(self):
+        toc_yaml_want = [
+            {
+                "name": "Spanner Admin Database V1",
+                "uidname":"google.cloud.spanner_admin_database_v1",
+                "items": [
+                    {
+                      "name":"database_admin",
+                      "uidname":"google.cloud.spanner_admin_database_v1.services.database_admin",
+                      "items":[
+                          {
+                            "name":"Overview",
+                            "uidname":"google.cloud.spanner_admin_database_v1.services.database_admin",
+                            "uid":"google.cloud.spanner_admin_database_v1.services.database_admin"
+                          },
+                          {
+                            "name":"ListBackupOperationsAsyncPager",
+                            "uidname":"google.cloud.spanner_admin_database_v1.services.database_admin.pagers.ListBackupOperationsAsyncPager",
+                            "uid":"google.cloud.spanner_admin_database_v1.services.database_admin.pagers.ListBackupOperationsAsyncPager"
+                          }
+                      ]
+                    },
+                    {
+                      "name":"spanner_admin_database_v1.types",
+                      "uidname":"google.cloud.spanner_admin_database_v1.types",
+                      "items":[
+                          {
+                            "name":"Overview",
+                            "uidname":"google.cloud.spanner_admin_database_v1.types",
+                            "uid":"google.cloud.spanner_admin_database_v1.types"
+                          },
+                          {
+                            "name":"BackupInfo",
+                            "uidname":"google.cloud.spanner_admin_database_v1.types.BackupInfo",
+                            "uid":"google.cloud.spanner_admin_database_v1.types.BackupInfo"
+                          }
+                      ]
+                    },
+                ]
+            },
+            {
+                "name": "Spanner V1",
+                "uidname":"google.cloud.spanner_v1",
+                "items": [
+                    {
+                      "name":"pool",
+                      "uidname":"google.cloud.spanner_v1.pool",
+                      "items":[
+                          {
+                            "name":"Overview",
+                            "uidname":"google.cloud.spanner_v1.pool",
+                            "uid":"google.cloud.spanner_v1.pool"
+                          },
+                          {
+                            "name":"AbstractSessionPool",
+                            "uidname":"google.cloud.spanner_v1.pool.AbstractSessionPool",
+                            "uid":"google.cloud.spanner_v1.pool.AbstractSessionPool"
+                          }
+                      ]
+                    }
+                ]
+            }
+        ]
+
+        toc_yaml = [
+            {
+              "name":"database_admin",
+              "uidname":"google.cloud.spanner_admin_database_v1.services.database_admin",
+              "items":[
+                  {
+                    "name":"Overview",
+                    "uidname":"google.cloud.spanner_admin_database_v1.services.database_admin",
+                    "uid":"google.cloud.spanner_admin_database_v1.services.database_admin"
+                  },
+                  {
+                    "name":"ListBackupOperationsAsyncPager",
+                    "uidname":"google.cloud.spanner_admin_database_v1.services.database_admin.pagers.ListBackupOperationsAsyncPager",
+                    "uid":"google.cloud.spanner_admin_database_v1.services.database_admin.pagers.ListBackupOperationsAsyncPager"
+                  }
+              ]
+            },
+            {
+              "name":"spanner_admin_database_v1.types",
+              "uidname":"google.cloud.spanner_admin_database_v1.types",
+              "items":[
+                  {
+                    "name":"Overview",
+                    "uidname":"google.cloud.spanner_admin_database_v1.types",
+                    "uid":"google.cloud.spanner_admin_database_v1.types"
+                  },
+                  {
+                    "name":"BackupInfo",
+                    "uidname":"google.cloud.spanner_admin_database_v1.types.BackupInfo",
+                    "uid":"google.cloud.spanner_admin_database_v1.types.BackupInfo"
+                  }
+              ]
+            },
+            {
+              "name":"pool",
+              "uidname":"google.cloud.spanner_v1.pool",
+              "items":[
+                  {
+                    "name":"Overview",
+                    "uidname":"google.cloud.spanner_v1.pool",
+                    "uid":"google.cloud.spanner_v1.pool"
+                  },
+                  {
+                    "name":"AbstractSessionPool",
+                    "uidname":"google.cloud.spanner_v1.pool.AbstractSessionPool",
+                    "uid":"google.cloud.spanner_v1.pool.AbstractSessionPool"
+                  }
+              ]
+            }
+        ]
+
+        toc_yaml_got = group_by_package(toc_yaml)
+
+        self.assertCountEqual(toc_yaml_got, toc_yaml_want)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

Currently the left-nav simply introduces all the packages and modules, which is not too helpful even after disambiguating the entries. Feedback from other Python DREs was to replicate what `googleapis.dev` has, which is by grouping them by versions (v1, v1beta, v2) as well as some group headers (v1.admin, v1.services). 

After we are done constructing the `toc_yaml`, decided to iterate through the elements after it is constructed because it's kept in a list and not dictionary by default, so it was hard to traverse through the items while processing them during its creation. Grouping by versions and applicable groups by looking at the identifier immediately after `google.cloud` prefix, pretty the name and add the entry to a collection. 

Since the new added groups don't actually exist as a YAML file, I've decided to leave the index page as-is (with some fixes). I'll come back to make the index page a lot more useful in the near future.

Added unit test coverage.

Fixes internally filed issue.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
