### PR TITLE
fix: use file name instead of object name for TOC

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1165,8 +1165,11 @@ def build_finished(app, exception):
                       'uid': uid
                     })
                 else:
+                    # Extract the file name to use for new entries into the TOC
+                    # to make TOC entries consistent with filenames.
+                    file_name = obj['source']['path'].split("/")[-1][:-3]
                     toc_yaml.append({
-                      'name': node_name, 
+                      'name': file_name, 
                       'uidname': uid, 
                       'uid': uid
                     })


### PR DESCRIPTION
Before you open a pull request, note that this repository is forked from [here](https://github.com/docascode/sphinx-docfx-yaml/).
Unless the issue you're trying to solve is unique to this specific repository, 
please file an issue and/or send changes upstream to the original as well.

__________________________________________________________________

Sometimes with different entries into the file, the UID may skip from `google.cloud.package{version}.file` with an extra level with `google.cloud.package{version}.file.entry`, which omits the filename in the TOC and inputs `entry`. This is confusing for some users as they expect `entry` to come from `file` but it shows up as `entry` in the left-nav.

Fixes internally filed issue.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR
