### PR TITLE
feat!: add markdown page support

### DIFF
--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -33,7 +33,7 @@ python3 -m pip install --user gcp-docuploader
 python3 -m pip install -e .
 python3 -m pip install recommonmark
 # Required for some client libraries:
-python3 -m pip install --user django==2.2
+python3 -m pip install --user django==2.2,ipython
 
 # Retrieve unique repositories to regenerate the YAML with.
 for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t- -k5,5); do
@@ -100,7 +100,8 @@ for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t
     # Test running with the plugin version locally.
     if [[ "${TEST_PLUGIN}" == "true" ]]; then
       # --no-use-pep517 is required for django-spanner install issue: see https://github.com/pypa/pip/issues/7953
-      python3 -m pip install --user --no-use-pep517 -e .
+      python3 -m pip install --user --no-use-pep517 -e .[all]
+      sphinx-build -M markdown docs/ docs/_build/
       sphinx-build -T -N -D extensions=sphinx.ext.autodoc,sphinx.ext.autosummary,docfx_yaml.extension,sphinx.ext.intersphinx,sphinx.ext.coverage,sphinx.ext.napoleon,sphinx.ext.todo,sphinx.ext.viewcode,recommonmark -b html -d docs/_build/doctrees/ docs/ docs/_build/html/
       continue
     fi

--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -33,7 +33,7 @@ python3 -m pip install --user gcp-docuploader
 python3 -m pip install -e .
 python3 -m pip install recommonmark
 # Required for some client libraries:
-python3 -m pip install --user django==2.2,ipython
+python3 -m pip install --user django==2.2 ipython
 
 # Retrieve unique repositories to regenerate the YAML with.
 for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t- -k5,5); do
@@ -101,7 +101,6 @@ for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t
     if [[ "${TEST_PLUGIN}" == "true" ]]; then
       # --no-use-pep517 is required for django-spanner install issue: see https://github.com/pypa/pip/issues/7953
       python3 -m pip install --user --no-use-pep517 -e .[all]
-      sphinx-build -M markdown docs/ docs/_build/
       sphinx-build -T -N -D extensions=sphinx.ext.autodoc,sphinx.ext.autosummary,docfx_yaml.extension,sphinx.ext.intersphinx,sphinx.ext.coverage,sphinx.ext.napoleon,sphinx.ext.todo,sphinx.ext.viewcode,recommonmark -b html -d docs/_build/doctrees/ docs/ docs/_build/html/
       continue
     fi

--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -74,7 +74,7 @@ for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t
   fi
 
   for tag in ${GITHUB_TAGS}; do
-    git checkout ${tag}
+    #git checkout ${tag}
 
     # Use the latest noxfile for all tags.
     cp ../"noxfile.py" .

--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -74,7 +74,7 @@ for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t
   fi
 
   for tag in ${GITHUB_TAGS}; do
-    #git checkout ${tag}
+    git checkout ${tag}
 
     # Use the latest noxfile for all tags.
     cp ../"noxfile.py" .

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1051,10 +1051,17 @@ def extract_header_from_markdown(mdfile_iterator):
 def find_markdown_pages(app, outdir):
     # Use this to ignore markdown files that are unnecessary.
     files_to_ignore = [
-        "index.md",     # merge index.md and README.md and index.yaml later
+        "index.md",     # merge index.md and README.md and index.yaml later.
+                        # See https://github.com/googleapis/sphinx-docfx-yaml/issues/105.
+
         "reference.md", # Reference docs overlap with Overview. Will try and incorporate this in later.
+                        # See https://github.com/googleapis/sphinx-docfx-yaml/issues/106.
+
         "readme.md",    # README does not seem to work in cloud site
+                        # See https://github.com/googleapis/sphinx-docfx-yaml/issues/107.
+
         "upgrading.md", # Currently the formatting breaks, will need to come back to it.
+                        # See https://github.com/googleapis/sphinx-docfx-yaml/issues/108.
     ]
 
     markdown_dir = Path(app.builder.outdir).parent / "markdown"

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -85,6 +85,12 @@ PROPERTY = 'property'
 
 
 def run_sphinx_markdown():
+    cwd = os.getcwd()
+    # Skip running sphinx-build for Markdown for some unit test
+    if "docs" in cwd:
+        return
+
+
     return shell.run(
         [
             "sphinx-build",

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1033,17 +1033,17 @@ def pretty_package_name(package_group):
 
 
 # For a given markdown file, extract its header line.
-def extract_header_from_markdown(mdfile_iterator)
+def extract_header_from_markdown(mdfile_iterator):
     for header_line in mdfile_iterator:
         # Ignore licenses and other non-headers prior to the header.
         if "#" in header_line:
             break
 
-    if header_line.count("#") > 1:
-        raise ValueError(f"The first header of {mdfile} is not a h1 header: {header_line}")
+    if header_line.count("#") != 1:
+        raise ValueError(f"The first header of {mdfile_iterator.name} is not a h1 header: {header_line}")
 
     # Extract the header name.
-    return name = header_line.strip("#").strip()
+    return header_line.strip("#").strip()
 
 
 # Given generated markdown files, incorporate them into the docfx_yaml output.

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -47,6 +47,8 @@ from .monkeypatch import patch_docfields
 from .directives import RemarksDirective, TodoDirective
 from .nodes import remarks
 
+import subprocess
+from docuploader import shell
 
 class Bcolors:
     HEADER = '\033[95m'
@@ -82,7 +84,24 @@ REF_PATTERN_LAST = '~([a-zA-Z0-9_<>]*\.)*[a-zA-Z0-9_<>]*(\(\))?'
 PROPERTY = 'property'
 
 
+def run_sphinx_markdown():
+    return shell.run(
+        [
+            "sphinx-build",
+            "-M",
+            "markdown",
+            "docs/",
+            "docs/_build",
+        ],
+        hide_output=False
+    )
+
+
 def build_init(app):
+    print("Running sphinx-build with Markdown first...")
+    run_sphinx_markdown()
+
+
     """
     Set up environment data
     """

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -84,12 +84,12 @@ REF_PATTERN_LAST = '~([a-zA-Z0-9_<>]*\.)*[a-zA-Z0-9_<>]*(\(\))?'
 PROPERTY = 'property'
 
 
+# Run sphinx-build with Markdown builder in the plugin.
 def run_sphinx_markdown():
     cwd = os.getcwd()
     # Skip running sphinx-build for Markdown for some unit test
     if "docs" in cwd:
         return
-
 
     return shell.run(
         [
@@ -1031,6 +1031,8 @@ def pretty_package_name(package_group):
     return " ".join(capitalized_name)
 
 
+# Given generated markdown files, incorporate them into the docfx_yaml output.
+# The markdown file metadata will be added to top level of the TOC.
 def find_markdown_pages(app, outdir):
     # Use this to ignore markdown files that are unnecessary.
     files_to_ignore = [
@@ -1112,6 +1114,7 @@ def build_finished(app, exception):
     ))
     ensuredir(normalized_outdir)
 
+    # Add markdown pages to the configured output directory.
     find_markdown_pages(app, normalized_outdir)
 
     toc_yaml = []
@@ -1301,6 +1304,7 @@ def build_finished(app, exception):
                   'uid': uid
                 })
 
+    # Exit if there are no generated YAML pages or Markdown pages.
     if len(toc_yaml) == 0 and len(app.env.markdown_pages) == 0:
         raise RuntimeError("No documentation for this module.")
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ name = 'gcp-sphinx-docfx-yaml'
 description = 'Sphinx Python Domain to DocFX YAML Generator'
 version = '0.5.2'
 dependencies = [
+    'gcp-docuploader',
     'PyYAML',
     'sphinx',
     'sphinx-markdown-builder',

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ version = '0.5.2'
 dependencies = [
     'PyYAML',
     'sphinx',
+    'sphinx-markdown-builder',
     'sphinxcontrib.napoleon',
     'unidecode',
     'wheel>=0.24.0'

--- a/tests/markdown_example.md
+++ b/tests/markdown_example.md
@@ -1,0 +1,4 @@
+#Test header for a simple markdown file.  
+
+##Content header
+This is a simple line followed by an h2 header.

--- a/tests/markdown_example_bad.md
+++ b/tests/markdown_example_bad.md
@@ -1,0 +1,4 @@
+##Test header for a simple markdown file.  
+
+##Content header
+This is a simple line followed by an h2 header.

--- a/tests/markdown_example_header.md
+++ b/tests/markdown_example_header.md
@@ -1,0 +1,18 @@
+<!--
+Copyright 2021 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+
+#Test header for a simple markdown file.  
+
+##Content header
+This is a simple line followed by an h2 header.

--- a/tests/markdown_example_header.md
+++ b/tests/markdown_example_header.md
@@ -12,7 +12,7 @@ limitations under the License.
 -->
 
 
-#Test header for a simple markdown file.  
+#  Test header for a simple markdown file.
 
 ##Content header
 This is a simple line followed by an h2 header.

--- a/tests/markdown_example_noheader.md
+++ b/tests/markdown_example_noheader.md
@@ -1,0 +1,5 @@
+This is a simple markdown file with no header.
+
+When running the test on this file to extract its header,
+
+it should throw an exception.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -7,6 +7,7 @@ from docfx_yaml.extension import _extract_docstring_info
 from docfx_yaml.extension import find_package_group
 from docfx_yaml.extension import pretty_package_name
 from docfx_yaml.extension import group_by_package
+from docfx_yaml.extension import extract_header_from_markdown
 
 import unittest
 
@@ -396,7 +397,6 @@ Simple test for docstring.
         }
 
         top_summary_got = _extract_docstring_info(summary_info_got, summary, "")
-        self.maxDiff = None
         # Same as the top summary from previous example, compare with that
         self.assertEqual(top_summary_got, self.top_summary1_want)
         self.assertDictEqual(summary_info_got, summary_info_want)
@@ -536,6 +536,43 @@ Simple test for docstring.
         toc_yaml_got = group_by_package(toc_yaml)
 
         self.assertCountEqual(toc_yaml_got, toc_yaml_want)
+
+
+    def test_extract_header_from_markdown(self):
+        # Check the header for a normal markdown file.
+        header_line_want = "Test header for a simple markdown file."
+
+        mdfile = open('tests/markdown_example.md', 'r')
+        header_line_got = extract_header_from_markdown(mdfile)
+
+        self.assertEqual(header_line_got, header_line_want)
+        mdfile.close()
+
+        # The header should be the same even with the license header.
+        header_line_with_license_want = header_line_want
+
+        mdfile = open('tests/markdown_example_header.md', 'r')
+        header_line_with_license_got = extract_header_from_markdown(mdfile)
+
+        self.assertEqual(header_line_with_license_got, header_line_with_license_want)
+        mdfile.close()
+
+
+    def test_extract_header_from_markdown_check_error(self):
+        # Check an exception is thrown for markdown files that's not well
+        # formatted.
+        mdfile = open('tests/markdown_example_bad.md', 'r')
+        with self.assertRaises(ValueError):
+            header_line = extract_header_from_markdown(mdfile)
+
+        mdfile.close()
+
+        mdfile = open('tests/markdown_example_noheader.md', 'r')
+        with self.assertRaises(ValueError):
+            header_line = extract_header_from_markdown(mdfile)
+
+        mdfile.close()
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding support for markdown pages generated by Sphinx. While Sphinx by nature output `.html` suffix documents, using the [`sphinx-markdown-builder`](https://pythonrepo.com/repo/clayrisser-sphinx-markdown-builder-python-documentation#sphinx-markdown-builder) allows the docs to be generated in Markdown format.

Using this, takes markdown pages from the top level pages (not for the library files) and adds them to the top level TOC. Retrieves their title as the name to put in the TOC, with their link being the `.md` suffixed files in the top directory (not in `exmaples` directory or anywhere else, same level as `toc.yaml` file). Some files are ignored at the moment due to conflicts in devsite or because `doc-pipeline` tries to process them and convert them into unreadable formats. 

I will file issues to track for supporting some of those files, and add any more restrictions we should add to make sure they look decent for cloud site while recovering as many pages as we can. If this can be fixed from `doc-pipeline` I'll try and resolve it, but if it's issue on the cloud site we will need to work around it; for example, README file.

Added `sphinx-markdown-builder` into the plugin, so we don't need to distribute it to 120+ repos.

No unit test will be added as it relies on the Sphinx App for now, it will be incorporated in #44.

Fixes internally filed issue.
