### PR TITLE
fix: use the uid for toc entries

### DIFF
--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -74,7 +74,7 @@ for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t
   fi
 
   for tag in ${GITHUB_TAGS}; do
-    git checkout ${tag}
+    #git checkout ${tag}
 
     # Use the latest noxfile for all tags.
     cp ../"noxfile.py" .

--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -74,7 +74,7 @@ for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t
   fi
 
   for tag in ${GITHUB_TAGS}; do
-    #git checkout ${tag}
+    git checkout ${tag}
 
     # Use the latest noxfile for all tags.
     cp ../"noxfile.py" .

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -983,7 +983,7 @@ def group_by_package(toc_yaml):
     for package_group in package_groups:
         new_toc_yaml.append(package_groups[package_group])
 
-    return  new_toc_yaml
+    return new_toc_yaml
 
 
 # Given the full uid, return the package group including its prefix.

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -7,7 +7,6 @@ from docfx_yaml.extension import _extract_docstring_info
 from docfx_yaml.extension import find_package_group
 from docfx_yaml.extension import pretty_package_name
 from docfx_yaml.extension import group_by_package
-from docfx_yaml.extension import check_name_with_uid
 
 import unittest
 
@@ -538,82 +537,6 @@ Simple test for docstring.
 
         self.assertCountEqual(toc_yaml_got, toc_yaml_want)
 
-
-
-    def test_check_name_with_uid(self):
-        # Test that none of these entries change.
-        toc_yaml_want = [
-            {
-                "name":"Overview",
-                "uid":"google.cloud.spanner.types"
-            },
-            {
-                "name":"Types",
-                "uid":"google.cloud.spanner_v1.Types"
-            },
-            {
-                "name":"Overview",
-                "items": [
-                    {
-                        "name":"BackupInfo",
-                        "uid":"google.cloud.spanner.types.BackupInfo"
-                    }
-                ]
-            }
-        ]
-
-        # Grab a shallow copy of the wanted toc_yaml.
-        toc_yaml = toc_yaml_want.copy()
-
-        check_name_with_uid(toc_yaml)
-        # Check that nothing changes with this given data.
-        self.assertCountEqual(toc_yaml, toc_yaml_want)
-
-
-    def test_check_name_with_uid_diff(self):
-        # Test that most of these entries change.
-        toc_yaml_want = [
-            {
-                "name":"types",
-                "uid":"google.cloud.spanner.types"
-            },
-            {
-                "name":"Types",
-                "uid":"google.cloud.spanner.Types"
-            },
-            {
-                "name":"types",
-                "items": [
-                    {
-                        "name":"BackupInfo",
-                        "uid":"google.cloud.spanner.types.BackupInfo"
-                    }
-                ]
-            }
-        ]
-
-        toc_yaml = [
-            {
-                "name":"overview",
-                "uid":"google.cloud.spanner.types"
-            },
-            {
-                "name":"types",
-                "uid":"google.cloud.spanner.Types"
-            },
-            {
-                "name":"types",
-                "items": [
-                    {
-                        "name":"types.BackupInfo",
-                        "uid":"google.cloud.spanner.types.BackupInfo"
-                    }
-                ]
-            }
-        ]
-
-        check_name_with_uid(toc_yaml)
-        self.assertCountEqual(toc_yaml, toc_yaml_want)
 
 
 if __name__ == '__main__':

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -538,6 +538,5 @@ Simple test for docstring.
         self.assertCountEqual(toc_yaml_got, toc_yaml_want)
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -548,11 +548,11 @@ Simple test for docstring.
                 "uid":"google.cloud.spanner.types"
             },
             {
-                "name":"types",
-                "uid":"google.cloud.spanner.types"
+                "name":"Types",
+                "uid":"google.cloud.spanner_v1.Types"
             },
             {
-                "name":"types",
+                "name":"Overview",
                 "items": [
                     {
                         "name":"BackupInfo",

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -7,6 +7,7 @@ from docfx_yaml.extension import _extract_docstring_info
 from docfx_yaml.extension import find_package_group
 from docfx_yaml.extension import pretty_package_name
 from docfx_yaml.extension import group_by_package
+from docfx_yaml.extension import check_name_with_uid
 
 import unittest
 
@@ -16,7 +17,7 @@ class TestGenerate(unittest.TestCase):
     def test_find_unique_name(self):
 
         entries = {}
-        
+
         # Disambiguate with unique entries.
         entry1 = "google.cloud.aiplatform.v1.schema.predict.instance_v1.types"
         entry2 = "google.cloud.aiplatform.v1beta2.schema.predict.instance_v1.types"
@@ -536,6 +537,83 @@ Simple test for docstring.
         toc_yaml_got = group_by_package(toc_yaml)
 
         self.assertCountEqual(toc_yaml_got, toc_yaml_want)
+
+
+
+    def test_check_name_with_uid(self):
+        # Test that none of these entries change.
+        toc_yaml_want = [
+            {
+                "name":"Overview",
+                "uid":"google.cloud.spanner.types"
+            },
+            {
+                "name":"types",
+                "uid":"google.cloud.spanner.types"
+            },
+            {
+                "name":"types",
+                "items": [
+                    {
+                        "name":"BackupInfo",
+                        "uid":"google.cloud.spanner.types.BackupInfo"
+                    }
+                ]
+            }
+        ]
+
+        # Grab a shallow copy of the wanted toc_yaml.
+        toc_yaml = toc_yaml_want.copy()
+
+        check_name_with_uid(toc_yaml)
+        # Check that nothing changes with this given data.
+        self.assertCountEqual(toc_yaml, toc_yaml_want)
+
+
+    def test_check_name_with_uid_diff(self):
+        # Test that most of these entries change.
+        toc_yaml_want = [
+            {
+                "name":"types",
+                "uid":"google.cloud.spanner.types"
+            },
+            {
+                "name":"Types",
+                "uid":"google.cloud.spanner.Types"
+            },
+            {
+                "name":"types",
+                "items": [
+                    {
+                        "name":"BackupInfo",
+                        "uid":"google.cloud.spanner.types.BackupInfo"
+                    }
+                ]
+            }
+        ]
+
+        toc_yaml = [
+            {
+                "name":"overview",
+                "uid":"google.cloud.spanner.types"
+            },
+            {
+                "name":"types",
+                "uid":"google.cloud.spanner.Types"
+            },
+            {
+                "name":"types",
+                "items": [
+                    {
+                        "name":"types.BackupInfo",
+                        "uid":"google.cloud.spanner.types.BackupInfo"
+                    }
+                ]
+            }
+        ]
+
+        check_name_with_uid(toc_yaml)
+        self.assertCountEqual(toc_yaml, toc_yaml_want)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#100 was submitted where we failed to retrieve the file name. However, if the file name exists and we have entries entered into the TOC before its proper parent entry as shown in the example in #103, then the entry names get mixed up in the TOC.

I've retrieved the UID for the parent entries, so we can easily check against the existing UID. This should now cover almost every case unless there are very unique circumstances that I'm not aware of. With the given existing UID, we should be able to safely retrieve the names without doing much more work other than disambiguating if needed.

Fixes #103.