### PR TITLE
fix: do not omit arguments retrieved from docstring

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -546,6 +546,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
         lines = []
     short_name = name.split('.')[-1]
     args = []
+    # Check how many arguments are present in the function.
     arg_count = 0
     try:
         if _type in [METHOD, FUNCTION]:
@@ -569,6 +570,8 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
                             print(f"Could not parse argument information for {annotation}.")
                             continue
 
+            # Add up the number of arguments. `argspec.args` contains a list of
+            # all the arguments from the function.
             arg_count += len(argspec.args)
             for arg in argspec.args:
                 arg_map = {}
@@ -710,6 +713,8 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
     if args or sig or summary_info:
         datam['syntax'] = {}
 
+    # If there are well-formatted arguments or a lot of arguments we should look
+    # into, loop through what we got from the docstring.
     if args or arg_count > 0:
         variables = summary_info['variables']
         arg_id = []

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -546,6 +546,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
         lines = []
     short_name = name.split('.')[-1]
     args = []
+    arg_count = 0
     try:
         if _type in [METHOD, FUNCTION]:
             argspec = inspect.getfullargspec(obj) # noqa
@@ -568,6 +569,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
                             print(f"Could not parse argument information for {annotation}.")
                             continue
 
+            arg_count += len(argspec.args)
             for arg in argspec.args:
                 arg_map = {}
                 # Ignore adding in entry for "self"
@@ -708,7 +710,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
     if args or sig or summary_info:
         datam['syntax'] = {}
 
-    if args:
+    if args or arg_count > 0:
         variables = summary_info['variables']
         arg_id = []
         for arg in args:


### PR DESCRIPTION
After #93, I've omitted arguments that didn't have docstring entries or didn't have types specified as part of the feedback for cloud site documents. However this had a side effect of leaving out more arguments than we needed.

Fixing this by keeping a track of number of arguments the function comes with. If `args` list is not empty, it'll loop through all the variables we extract from the docstring. If the function didn't have well formatted arguments, we should still loop through what we retrieved from the docstring to see if we have any info that we've retrieved through `summary_info['variables']` that we can add to.

Fixes #113.

Not having goldens is really biting me, but at least now I have a good idea what I need to base the golden data off of. I'll work on it the first thing after we launch.