### PR TITLE
chore: exclude and remove renovate on OwlBot

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -44,6 +44,7 @@ s.move(
         "CONTRIBUTING.rst",  # repo has a CONTRIBUTING.md
         ".github/CONTRIBUTING.md",
         ".github/PULL_REQUEST_TEMPLATE.md",
-        ".gitignore"
+        ".gitignore",
+        "renovate.json"
     ],
 )

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,0 @@
-{
-  "extends": [
-    "config:base",  ":preserveSemverRanges"
-  ],
-  "ignorePaths": [".pre-commit-config.yaml"],
-  "pip_requirements": {
-    "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
-  }
-}


### PR DESCRIPTION
OwlBot reverted the previous PR, removing the file and excluding it on OwlBot.