### PR TITLE
fix: disambiguate after grouping by packages and versions

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1487,10 +1487,10 @@ def build_finished(app, exception):
     if len(pkg_toc_yaml) == 0 and len(app.env.markdown_pages) == 0:
         raise RuntimeError("No documentation for this module.")
 
+    pkg_toc_yaml = group_by_package(pkg_toc_yaml)
+
     # Perform additional disambiguation of the name
     disambiguated_names = disambiguate_toc_name(pkg_toc_yaml)
-
-    pkg_toc_yaml = group_by_package(pkg_toc_yaml)
 
     # Keeping uidname field carrys over onto the toc.yaml files, we need to
     # be keep using them but don't need them in the actual file


### PR DESCRIPTION
If entries need to be disambiguated, it should be done after the entries are grouped into packages/versions to avoid having unique entries to specific version/packages not be disambiguated and left alone without a disambiguation prefix. 

New example TOC:

```
- items:
  - name: Overview
    uid: project-google-cloud-bigquery-storage
  - href: multiprocessing.md
    name: Multiprocessing
  - items:
    - items:
      - name: Overview
        uid: google.cloud.bigquery_storage_v1.client
      - name: BigQueryReadClient
        uid: google.cloud.bigquery_storage_v1.client.BigQueryReadClient
      name: client
      uid: google.cloud.bigquery_storage_v1.client
    - items:
      - name: Overview
        uid: google.cloud.bigquery_storage_v1.reader
      - name: ReadRowsIterable
        uid: google.cloud.bigquery_storage_v1.reader.ReadRowsIterable
      - name: ReadRowsPage
        uid: google.cloud.bigquery_storage_v1.reader.ReadRowsPage
      - name: ReadRowsStream
        uid: google.cloud.bigquery_storage_v1.reader.ReadRowsStream
      name: reader
      uid: google.cloud.bigquery_storage_v1.reader
    - items:
      - name: Overview
        uid: google.cloud.bigquery_storage_v1.services.big_query_read
      - name: BigQueryReadAsyncClient
        uid: google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient
      - name: BigQueryReadClient
        uid: google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient
      name: big_query_read
      uid: google.cloud.bigquery_storage_v1.services.big_query_read
```
All entries will be stripped off of the prefix unless disambiguation is required, to help shorten entries. Users will still see that they are grouped under specific packages/versions to help tell which packages/versions the entry falls under. From the above example, main difference would be that previously it would have `bigquery_storage_v1.client` and `reader`, but now it simply shows `client` and `reader`.

Fixes #131 

- [x] Tests pass
