### PR TITLE
feat: find more items to cross reference

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1261,22 +1261,29 @@ def find_markdown_pages(app, outdir):
             })
 
 
-# Looks for cross references to look for in given content, except for
-# current_name.
+# Finds and replaces occurrences which should be a cross reference in the given
+# content, except for the current name.
 def find_cross_references(content, current_name, keyword_map):
     words = content.split(" ")
+    new_words = []
+    sorted_map = sorted(keyword_map.keys(), reverse=True)
     # Using counter to check if the entry is already a cross reference.
-    for i in range(0, len(words)):
-        for keyword in sorted(keyword_map.keys(), reverse=True):
-            if keyword != current_name and keyword not in current_name and keyword in words[i]:
+    for index, word in enumerate(words):
+        cross_reference = ""
+        for keyword in sorted_map:
+            if keyword != current_name and keyword not in current_name and keyword in word:
                 # If it is already processed as cross reference, skip over it.
-                if "<xref" in words[i-1]:
+                if "<xref" in words[index-1] or (new_words and f"<xref uid=\"{keyword}" in new_words[-1]):
                     continue
                 cross_reference = f"<xref uid=\"{keyword}\">{keyword}</xref>"
-                words[i] = words[i].replace(keyword, cross_reference)
+                new_words.append(word.replace(keyword, cross_reference))
                 print(f"Converted {keyword} into cross reference in: \n{content}")
 
-    return " ".join(words)
+        # If cross reference has not been found, add current unchanged content.
+        if not cross_reference:
+            new_words.append(word)
+
+    return " ".join(new_words)
 
 
 def build_finished(app, exception):

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1263,13 +1263,13 @@ def find_markdown_pages(app, outdir):
 
 # Finds and replaces occurrences which should be a cross reference in the given
 # content, except for the current name.
-def convert_cross_references(content, current_name, sorted_map):
+def convert_cross_references(content, current_name, list_of_entry_names):
     words = content.split(" ")
     new_words = []
     # Using counter to check if the entry is already a cross reference.
     for index, word in enumerate(words):
         cross_reference = ""
-        for keyword in sorted_map:
+        for keyword in list_of_entry_names:
             if keyword != current_name and keyword not in current_name and keyword in word:
                 # If it is already processed as cross reference, skip over it.
                 if "<xref" in words[index-1] or (new_words and f"<xref uid=\"{keyword}" in new_words[-1]):
@@ -1287,9 +1287,9 @@ def convert_cross_references(content, current_name, sorted_map):
 
 # Used to look for cross references in the obj's data where applicable.
 # For now, we inspect summary, syntax and attributes.
-def search_cross_references(obj, current_name, sorted_map):
+def search_cross_references(obj, current_name, list_of_entry_names):
     if obj.get("summary"):
-        obj["summary"] = convert_cross_references(obj["summary"], current_name, sorted_map)
+        obj["summary"] = convert_cross_references(obj["summary"], current_name, list_of_entry_names)
 
     if obj.get("syntax"):
         if obj["syntax"].get("parameters"):
@@ -1298,21 +1298,21 @@ def search_cross_references(obj, current_name, sorted_map):
                     param["description"] = convert_cross_references(
                         param["description"],
                         current_name,
-                        sorted_map
+                        list_of_entry_names
                     )
 
                 if param.get("id"):
                     param["id"] = convert_cross_references(
                         param["id"],
                         current_name,
-                        sorted_map
+                        list_of_entry_names
                     )
 
                 if param.get("var_type"):
                     param["var_type"] = convert_cross_references(
                         param["var_type"],
                         current_name,
-                        sorted_map
+                        list_of_entry_names
                     )
 
         if obj["syntax"].get("exceptions"):
@@ -1321,14 +1321,14 @@ def search_cross_references(obj, current_name, sorted_map):
                     exception["description"] = convert_cross_references(
                         exception["description"],
                         current_name,
-                        sorted_map
+                        list_of_entry_names
                     )
 
                 if exception.get("var_type"):
                     exception["var_type"] = convert_cross_references(
                         exception["var_type"],
                         current_name,
-                        sorted_map
+                        list_of_entry_names
                     )
 
         if obj["syntax"].get("returns"):
@@ -1337,14 +1337,14 @@ def search_cross_references(obj, current_name, sorted_map):
                     ret["description"] = convert_cross_references(
                         ret["description"],
                         current_name,
-                        sorted_map
+                        list_of_entry_names
                     )
 
                 if ret.get("var_type"):
                     ret["var_type"] = convert_cross_references(
                         ret["var_type"],
                         current_name,
-                        sorted_map
+                        list_of_entry_names
                     )
 
 
@@ -1354,21 +1354,21 @@ def search_cross_references(obj, current_name, sorted_map):
                 attribute["description"] = convert_cross_references(
                     attribute["description"],
                     current_name,
-                    sorted_map
+                    list_of_entry_names
                 )
 
             if attribute.get("name"):
                 attribute["name"] = convert_cross_references(
                     attribute["name"],
                     current_name,
-                    sorted_map
+                    list_of_entry_names
                 )
 
             if attribute.get("var_type"):
                 attribute["var_type"] = convert_cross_references(
                     attribute["var_type"],
                     current_name,
-                    sorted_map
+                    list_of_entry_names
                 )
 
 
@@ -1571,10 +1571,10 @@ def build_finished(app, exception):
                 #   google.cloud.aiplatform.AutoMLForecastingTrainingJob
 
                 current_name = obj["fullName"]
-                sorted_map = sorted(app.env.docfx_uid_names.keys(), reverse=True)
+                list_of_entry_names = sorted(app.env.docfx_uid_names.keys(), reverse=True)
                 # Currently we only need to look in summary, syntax and
                 # attributes for cross references.
-                search_cross_references(obj, current_name, sorted_map)
+                search_cross_references(obj, current_name, list_of_entry_names)
 
             yaml_map[uid] = [yaml_data, references]
 

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1263,13 +1263,13 @@ def find_markdown_pages(app, outdir):
 
 # Finds and replaces occurrences which should be a cross reference in the given
 # content, except for the current name.
-def convert_cross_references(content, current_name, list_of_entry_names):
+def convert_cross_references(content: str, current_name: str, entry_names: list[str]):
     words = content.split(" ")
     new_words = []
     # Using counter to check if the entry is already a cross reference.
     for index, word in enumerate(words):
         cross_reference = ""
-        for keyword in list_of_entry_names:
+        for keyword in entry_names:
             if keyword != current_name and keyword not in current_name and keyword in word:
                 # If it is already processed as cross reference, skip over it.
                 if "<xref" in words[index-1] or (new_words and f"<xref uid=\"{keyword}" in new_words[-1]):
@@ -1287,9 +1287,9 @@ def convert_cross_references(content, current_name, list_of_entry_names):
 
 # Used to look for cross references in the obj's data where applicable.
 # For now, we inspect summary, syntax and attributes.
-def search_cross_references(obj, current_name, list_of_entry_names):
+def search_cross_references(obj, current_name: str, entry_names: list[str]):
     if obj.get("summary"):
-        obj["summary"] = convert_cross_references(obj["summary"], current_name, list_of_entry_names)
+        obj["summary"] = convert_cross_references(obj["summary"], current_name, entry_names)
 
     if obj.get("syntax"):
         if obj["syntax"].get("parameters"):
@@ -1298,21 +1298,21 @@ def search_cross_references(obj, current_name, list_of_entry_names):
                     param["description"] = convert_cross_references(
                         param["description"],
                         current_name,
-                        list_of_entry_names
+                        entry_names
                     )
 
                 if param.get("id"):
                     param["id"] = convert_cross_references(
                         param["id"],
                         current_name,
-                        list_of_entry_names
+                        entry_names
                     )
 
                 if param.get("var_type"):
                     param["var_type"] = convert_cross_references(
                         param["var_type"],
                         current_name,
-                        list_of_entry_names
+                        entry_names
                     )
 
         if obj["syntax"].get("exceptions"):
@@ -1321,14 +1321,14 @@ def search_cross_references(obj, current_name, list_of_entry_names):
                     exception["description"] = convert_cross_references(
                         exception["description"],
                         current_name,
-                        list_of_entry_names
+                        entry_names
                     )
 
                 if exception.get("var_type"):
                     exception["var_type"] = convert_cross_references(
                         exception["var_type"],
                         current_name,
-                        list_of_entry_names
+                        entry_names
                     )
 
         if obj["syntax"].get("returns"):
@@ -1337,14 +1337,14 @@ def search_cross_references(obj, current_name, list_of_entry_names):
                     ret["description"] = convert_cross_references(
                         ret["description"],
                         current_name,
-                        list_of_entry_names
+                        entry_names
                     )
 
                 if ret.get("var_type"):
                     ret["var_type"] = convert_cross_references(
                         ret["var_type"],
                         current_name,
-                        list_of_entry_names
+                        entry_names
                     )
 
 
@@ -1354,21 +1354,21 @@ def search_cross_references(obj, current_name, list_of_entry_names):
                 attribute["description"] = convert_cross_references(
                     attribute["description"],
                     current_name,
-                    list_of_entry_names
+                    entry_names
                 )
 
             if attribute.get("name"):
                 attribute["name"] = convert_cross_references(
                     attribute["name"],
                     current_name,
-                    list_of_entry_names
+                    entry_names
                 )
 
             if attribute.get("var_type"):
                 attribute["var_type"] = convert_cross_references(
                     attribute["var_type"],
                     current_name,
-                    list_of_entry_names
+                    entry_names
                 )
 
 
@@ -1571,10 +1571,10 @@ def build_finished(app, exception):
                 #   google.cloud.aiplatform.AutoMLForecastingTrainingJob
 
                 current_name = obj["fullName"]
-                list_of_entry_names = sorted(app.env.docfx_uid_names.keys(), reverse=True)
+                entry_names = sorted(app.env.docfx_uid_names.keys(), reverse=True)
                 # Currently we only need to look in summary, syntax and
                 # attributes for cross references.
-                search_cross_references(obj, current_name, list_of_entry_names)
+                search_cross_references(obj, current_name, entry_names)
 
             yaml_map[uid] = [yaml_data, references]
 

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -26,6 +26,7 @@ import shutil
 from pathlib import Path
 from functools import partial
 from itertools import zip_longest
+from typing import List
 
 try:
     from subprocess import getoutput
@@ -1263,7 +1264,7 @@ def find_markdown_pages(app, outdir):
 
 # Finds and replaces occurrences which should be a cross reference in the given
 # content, except for the current name.
-def convert_cross_references(content: str, current_name: str, entry_names: list[str]):
+def convert_cross_references(content: str, current_name: str, entry_names: List[str]):
     words = content.split(" ")
     new_words = []
     # Using counter to check if the entry is already a cross reference.
@@ -1287,7 +1288,7 @@ def convert_cross_references(content: str, current_name: str, entry_names: list[
 
 # Used to look for cross references in the obj's data where applicable.
 # For now, we inspect summary, syntax and attributes.
-def search_cross_references(obj, current_name: str, entry_names: list[str]):
+def search_cross_references(obj, current_name: str, entry_names: List[str]):
     if obj.get("summary"):
         obj["summary"] = convert_cross_references(obj["summary"], current_name, entry_names)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+parameterized==0.8.1
 # google-resumable-media-python requires manual update as this repo isn't templated.
 # python-api-core also requires manual update as it is not templated.
 sphinx==4.1.2

--- a/tests/cross_references_post.yaml
+++ b/tests/cross_references_post.yaml
@@ -1,0 +1,52 @@
+## YamlMime:UniversalReference
+api_name: []
+items:
+- attributes:
+  - description: "SQL text filtering statement, similar to a WHERE clause in a\n \
+      \  query. Aggregates are not supported.\n   \n   Examples: \"int_field > 5\"\
+      \ \"date_field = CAST('2014-9-27' as\n   DATE)\" \"nullable_field is not NULL\"\
+      \ \"st_equals(geo_field,\n   st_geofromtext(\"POINT(2, 2)\"))\" \"numeric_field\
+      \ BETWEEN 1.0\n   AND 5.0\"\n   \n   Restricted to a maximum length for 1 MB."
+    name: <xref uid="google.cloud.bigquery_storage_v1.types.StreamStats">google.cloud.bigquery_storage_v1.types.StreamStats</xref>
+    var_type: str
+  - description: "Optional. Options specific to the Apache\n   Arrow output format."
+    name: arrow_serialization_options
+    var_type: <xref uid="google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions">google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions</xref>
+  children: []
+  class: google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions
+  fullName: google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions
+  inheritance:
+  - inheritance:
+    - type: builtins.object
+    type: proto.message.Message
+  langs:
+  - python
+  module: google.cloud.bigquery_storage_v1.types.ReadSession
+  name: TableReadOptions
+  source:
+    id: TableReadOptions
+    path: google/cloud/bigquery_storage_v1/types/stream.py
+    remote:
+      branch: main
+      path: google/cloud/bigquery_storage_v1/types/stream.py
+      repo: git@github.com:googleapis/python-bigquery-storage.git
+    startLine: 85
+  summary: "Options dictating how we read a table.\n\
+    \nNames of the fields in the table that should be read in google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions."
+  syntax:
+    content: TableReadOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)
+    exceptions:
+    - description: If the request failed for any reason.
+      var_type: google.api_core.exceptions.GoogleAPICallError
+    parameters:
+    - description: Required. Name of the stream to start reading from, of the form
+        `projects/{project_id}/locations/{location}/sessions/{session_id}/streams/{stream_id}`
+        with <xref uid="google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>
+      id: row
+      var_type: <xref uid="google.cloud.bigquery_storage_v1.types.AvroRows">google.cloud.bigquery_storage_v1.types.AvroRows</xref>
+    returns:
+    - description: An iterable of <xref uid="google.cloud.bigquery_storage_v1.types.ReadRowsResponse">ReadRowsResponse</xref>.
+      var_type: <xref uid="google.cloud.bigquery_storage_v1.reader.ReadRowsStream">ReadRowsStream</xref>
+  type: class
+  uid: google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions
+references: []

--- a/tests/cross_references_pre.yaml
+++ b/tests/cross_references_pre.yaml
@@ -1,0 +1,52 @@
+## YamlMime:UniversalReference
+api_name: []
+items:
+- attributes:
+  - description: "SQL text filtering statement, similar to a WHERE clause in a\n \
+      \  query. Aggregates are not supported.\n   \n   Examples: \"int_field > 5\"\
+      \ \"date_field = CAST('2014-9-27' as\n   DATE)\" \"nullable_field is not NULL\"\
+      \ \"st_equals(geo_field,\n   st_geofromtext(\"POINT(2, 2)\"))\" \"numeric_field\
+      \ BETWEEN 1.0\n   AND 5.0\"\n   \n   Restricted to a maximum length for 1 MB."
+    name: google.cloud.bigquery_storage_v1.types.StreamStats
+    var_type: str
+  - description: "Optional. Options specific to the Apache\n   Arrow output format."
+    name: arrow_serialization_options
+    var_type: <xref uid="google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions">google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions</xref>
+  children: []
+  class: google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions
+  fullName: google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions
+  inheritance:
+  - inheritance:
+    - type: builtins.object
+    type: proto.message.Message
+  langs:
+  - python
+  module: google.cloud.bigquery_storage_v1.types.ReadSession
+  name: TableReadOptions
+  source:
+    id: TableReadOptions
+    path: google/cloud/bigquery_storage_v1/types/stream.py
+    remote:
+      branch: main
+      path: google/cloud/bigquery_storage_v1/types/stream.py
+      repo: git@github.com:googleapis/python-bigquery-storage.git
+    startLine: 85
+  summary: "Options dictating how we read a table.\n\
+    \nNames of the fields in the table that should be read in google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions."
+  syntax:
+    content: TableReadOptions(mapping=None, *, ignore_unknown_fields=False, **kwargs)
+    exceptions:
+    - description: If the request failed for any reason.
+      var_type: google.api_core.exceptions.GoogleAPICallError
+    parameters:
+    - description: Required. Name of the stream to start reading from, of the form
+        `projects/{project_id}/locations/{location}/sessions/{session_id}/streams/{stream_id}`
+        with google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse
+      id: row
+      var_type: google.cloud.bigquery_storage_v1.types.AvroRows
+    returns:
+    - description: An iterable of <xref uid="google.cloud.bigquery_storage_v1.types.ReadRowsResponse">ReadRowsResponse</xref>.
+      var_type: <xref uid="google.cloud.bigquery_storage_v1.reader.ReadRowsStream">ReadRowsStream</xref>
+  type: class
+  uid: google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions
+references: []

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -62,8 +62,8 @@ for i in range(10):
     cross_references_testdata = [
         # Testing for normal input.
         [
-            "<xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>",
-            "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse"
+            "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse",
+            "<xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>"
         ],
         # Testing for no cross references to convert.
         [
@@ -72,12 +72,12 @@ for i in range(10):
         ],
         # Testing for cross references to convert within longer content.
         [
-            "Response message for <xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>.",
-            "Response message for google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse."
+            "Response message for google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse.",
+            "Response message for <xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>."
         ],
     ]
     @parameterized.expand(cross_references_testdata)
-    def test_convert_cross_references(self, content_want, content):
+    def test_convert_cross_references(self, content, content_want):
         # Check that entries correctly turns into cross references.
         keyword_map = [
             "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse"
@@ -91,12 +91,12 @@ for i in range(10):
     # Test data used to test for processing already-processed cross references.
     cross_references_short_testdata = [
         [
-            "Response message for <xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>.",
-            "Response message for google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse."
+            "Response message for google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse.",
+            "Response message for <xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>."
         ],
     ]
     @parameterized.expand(cross_references_short_testdata)
-    def test_convert_cross_references_twice(self, content_want, content):
+    def test_convert_cross_references_twice(self, content, content_want):
         keyword_map = [
             "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse"
         ]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
 from docfx_yaml.extension import extract_keyword
 from docfx_yaml.extension import indent_code_left
-from docfx_yaml.extension import find_cross_references
+from docfx_yaml.extension import convert_cross_references
+from docfx_yaml.extension import search_cross_references
 
 import unittest
 
@@ -57,8 +58,8 @@ for i in range(10):
             keyword_got = extract_keyword(keyword_line)
 
 
-    def test_find_cross_references(self):
-        #Check that entries correctly turns into cross references.
+    def test_convert_cross_references(self):
+        # Check that entries correctly turns into cross references.
         keyword_map = {
             "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse": "",
         }
@@ -66,35 +67,35 @@ for i in range(10):
         long_name_want = "<xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>"
 
         long_name = "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse"
-        long_name_got = find_cross_references(long_name, current_name, keyword_map)
+        long_name_got = convert_cross_references(long_name, current_name, keyword_map)
         self.assertEqual(long_name_got, long_name_want)
 
         # This should not get processed.
         short_content = "Response message for SplitReadStreamResponse."
-        short_content_got = find_cross_references(short_content, current_name, keyword_map)
+        short_content_got = convert_cross_references(short_content, current_name, keyword_map)
         self.assertEqual(short_content_got, short_content)
 
         long_content_want = "Response message for <xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>."
         long_content = "Response message for google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse."
-        long_content_got = find_cross_references(long_content, current_name, keyword_map)
+        long_content_got = convert_cross_references(long_content, current_name, keyword_map)
         self.assertEqual(long_content_got, long_content_want)
 
         # Make sure that same entries are not processed twice.
         # The output should not be different.
         current_want = long_content_want
         current = long_content_got
-        current_got = find_cross_references(current, long_name, keyword_map)
+        current_got = convert_cross_references(current, long_name, keyword_map)
         self.assertEqual(current_want, current_got)
 
         # If shorter version of the current name exists, it should not interfere
         # unless strictly necessary.
         keyword_map["google.cloud.bigquery_storage_v1.types"] = ""
-        long_name_got = find_cross_references(long_name, current_name, keyword_map)
+        long_name_got = convert_cross_references(long_name, current_name, keyword_map)
         self.assertEqual(long_name_got, long_name_want)
 
         shorter_name_want = "<xref uid=\"google.cloud.bigquery_storage_v1.types\">google.cloud.bigquery_storage_v1.types</xref>"
         shorter_name = "google.cloud.bigquery_storage_v1.types"
-        shorter_name_got = find_cross_references(shorter_name, current_name, keyword_map)
+        shorter_name_got = convert_cross_references(shorter_name, current_name, keyword_map)
         self.assertEqual(shorter_name_got, shorter_name_want)
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -79,9 +79,9 @@ for i in range(10):
     @parameterized.expand(cross_references_testdata)
     def test_convert_cross_references(self, content_want, content):
         # Check that entries correctly turns into cross references.
-        keyword_map = {
-            "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse": "",
-        }
+        keyword_map = [
+            "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse"
+        ]
         current_name = "SplitRepsonse"
 
         content_got = convert_cross_references(content, current_name, keyword_map)
@@ -97,9 +97,9 @@ for i in range(10):
     ]
     @parameterized.expand(cross_references_short_testdata)
     def test_convert_cross_references_twice(self, content_want, content):
-        keyword_map = {
-            "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse": "",
-        }
+        keyword_map = [
+            "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse"
+        ]
         current_name = "SplitRepsonse"
 
         content_got = convert_cross_references(content, current_name, keyword_map)
@@ -112,7 +112,7 @@ for i in range(10):
 
         # If shorter version of the current name exists, it should not interfere
         # unless strictly necessary.
-        keyword_map["google.cloud.bigquery_storage_v1.types"] = ""
+        keyword_map.append("google.cloud.bigquery_storage_v1.types")
         long_name_got = convert_cross_references(content, current_name, keyword_map)
         self.assertEqual(long_name_got, content_want)
 
@@ -121,6 +121,42 @@ for i in range(10):
         shorter_name_got = convert_cross_references(shorter_name, current_name, keyword_map)
         self.assertEqual(shorter_name_got, shorter_name_want)
 
+
+    def test_search_cross_references(self):
+        # Test for a given YAML file.
+        keyword_map = [
+               "google.cloud.bigquery_storage_v1.types.ThrottleState",
+               "google.cloud.bigquery_storage_v1.types.StreamStats.Progress",
+               "google.cloud.bigquery_storage_v1.types.StreamStats",
+               "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse",
+               "google.cloud.bigquery_storage_v1.types.SplitReadStreamRequest",
+               "google.cloud.bigquery_storage_v1.types.ReadStream",
+               "google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions",
+               "google.cloud.bigquery_storage_v1.types.ReadSession.TableModifiers",
+               "google.cloud.bigquery_storage_v1.types.ReadSession",
+               "google.cloud.bigquery_storage_v1.types.ReadRowsResponse",
+               "google.cloud.bigquery_storage_v1.types.ReadRowsRequest",
+               "google.cloud.bigquery_storage_v1.types.DataFormat",
+               "google.cloud.bigquery_storage_v1.types.CreateReadSessionRequest",
+               "google.cloud.bigquery_storage_v1.types.AvroSchema",
+               "google.cloud.bigquery_storage_v1.types.AvroRows",
+               "google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions.CompressionCodec",
+               "google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions",
+               "google.cloud.bigquery_storage_v1.types.ArrowSchema",
+               "google.cloud.bigquery_storage_v1.types.ArrowRecordBatch",
+               "google.cloud.bigquery_storage_v1.types",
+        ]
+        current_name = "google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions"
+        with open('tests/cross_references_pre.yaml', 'r') as test_file:
+            yaml_pre = load(test_file, Loader=Loader)
+
+        for obj in yaml_pre['items']:
+            search_cross_references(obj, current_name, keyword_map)
+
+        with open('tests/cross_references_post.yaml', 'r') as want_file:
+            yaml_post = load(want_file, Loader=Loader)
+
+        self.assertEqual(yaml_pre, yaml_post)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 from docfx_yaml.extension import extract_keyword
 from docfx_yaml.extension import indent_code_left
-
+from docfx_yaml.extension import find_cross_references
 
 import unittest
 
@@ -55,6 +55,47 @@ for i in range(10):
         # Should raise an exception..
         with self.assertRaises(ValueError):
             keyword_got = extract_keyword(keyword_line)
+
+
+    def test_find_cross_references(self):
+        #Check that entries correctly turns into cross references.
+        keyword_map = {
+            "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse": "",
+        }
+        current_name = "SplitRepsonse"
+        long_name_want = "<xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>"
+
+        long_name = "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse"
+        long_name_got = find_cross_references(long_name, current_name, keyword_map)
+        self.assertEqual(long_name_got, long_name_want)
+
+        # This should not get processed.
+        short_content = "Response message for SplitReadStreamResponse."
+        short_content_got = find_cross_references(short_content, current_name, keyword_map)
+        self.assertEqual(short_content_got, short_content)
+
+        long_content_want = "Response message for <xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>."
+        long_content = "Response message for google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse."
+        long_content_got = find_cross_references(long_content, current_name, keyword_map)
+        self.assertEqual(long_content_got, long_content_want)
+
+        # Make sure that same entries are not processed twice.
+        # The output should not be different.
+        current_want = long_content_want
+        current = long_content_got
+        current_got = find_cross_references(current, long_name, keyword_map)
+        self.assertEqual(current_want, current_got)
+
+        # If shorter version of the current name exists, it should not interfere
+        # unless strictly necessary.
+        keyword_map["google.cloud.bigquery_storage_v1.types"] = ""
+        long_name_got = find_cross_references(long_name, current_name, keyword_map)
+        self.assertEqual(long_name_got, long_name_want)
+
+        shorter_name_want = "<xref uid=\"google.cloud.bigquery_storage_v1.types\">google.cloud.bigquery_storage_v1.types</xref>"
+        shorter_name = "google.cloud.bigquery_storage_v1.types"
+        shorter_name_got = find_cross_references(shorter_name, current_name, keyword_map)
+        self.assertEqual(shorter_name_got, shorter_name_want)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Given the full UIDs found within syntax, attributes, parameters, returns and exception info, tries to parse through the content and find entries to cross reference to.

After collecting a list of UIDs, we check in specific parts of the YAML that's applicable. I've decided to look for the expanded full UID (i.e. `google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse`) rather than looking for the short version as well (i.e. `SplitReadStreamResponse`) because some of the shorter names shorten to common words like `open` and `type` and there is just not an easy way to determine correct parsing of those. The words don't always just appear as broken by whitespace, but could be contained in non-alphanumeric characters like `[google.cloud.bigquery_storage_v1.types]` and `` `google.cloud.bigquery_storage_v1.types` ``, hence using `keyword in content` approach.

This will fully cover for missing cross references for expanded UIDs and those who can be linked to within the package. For Googlers, see example through `bigquery_storage` on internal site.

Towards #82 for cross reference within the same package.

Fixes b/195685296.

- [x] Tests pass
