### PR TITLE
feat: format signature using black

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -23,6 +23,7 @@ import inspect
 import re
 import copy
 import shutil
+import black
 from pathlib import Path
 from functools import partial
 from itertools import zip_longest
@@ -712,11 +713,12 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
                     if arg in type_map:
                         arg_map['var_type'] = type_map[arg]
                         args.append(arg_map)
+
             if argspec.varargs:
                 args.append({'id': argspec.varargs})
             if argspec.varkw:
                 args.append({'id': argspec.varkw})
-            # Try to add default values. Currently does not work if there is * argument present.
+
             if argspec.defaults:
                 # Attempt to add default values to arguments.
                 try:
@@ -959,10 +961,19 @@ def process_docstring(app, _type, name, obj, options, lines):
     app.env.docfx_info_uid_types[datam['uid']] = _type
 
 
+# Uses black.format_str() to reformat code as if running black/linter
+# for better presnetation.
+def format_code(code):
+    # Signature code comes in raw text without formatting, to run black it
+    # requires the code to look like actual function declaration in code.
+    # Returns the original formatted code without the added bits.
+    return black.format_str("def " + code + ": pass", mode=black.FileMode())[4:-11]
+
+
 def process_signature(app, _type, name, obj, options, signature, return_annotation):
     if signature:
         short_name = name.split('.')[-1]
-        signature = short_name + signature
+        signature = format_code(short_name + signature)
         app.env.docfx_signature_funcs_methods[name] = signature
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+black==21.10.b0
 parameterized==0.8.1
 # google-resumable-media-python requires manual update as this repo isn't templated.
 # python-api-core also requires manual update as it is not templated.

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ name = 'gcp-sphinx-docfx-yaml'
 description = 'Sphinx Python Domain to DocFX YAML Generator'
 version = '1.2.0'
 dependencies = [
+    'black',
     'gcp-docuploader',
     'PyYAML',
     'sphinx',

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,6 +2,7 @@ from docfx_yaml.extension import extract_keyword
 from docfx_yaml.extension import indent_code_left
 from docfx_yaml.extension import convert_cross_references
 from docfx_yaml.extension import search_cross_references
+from docfx_yaml.extension import format_code
 
 import unittest
 from parameterized import parameterized
@@ -157,6 +158,16 @@ for i in range(10):
             yaml_post = load(want_file, Loader=Loader)
 
         self.assertEqual(yaml_pre, yaml_post)
+
+
+    def test_format_code(self):
+        # Test to ensure black formats strings properly.
+        code_want = 'batch_predict(\n    *,\n    gcs_source: Optional[Union[str, Sequence[str]]] = None,\n    instances_format: str = "jsonl",\n    gcs_destination_prefix: Optional[str] = None,\n    predictions_format: str = "jsonl",\n    model_parameters: Optional[Dict] = None,\n    machine_type: Optional[str] = None,\n    accelerator_type: Optional[str] = None,\n    explanation_parameters: Optional[\n        google.cloud.aiplatform_v1.types.explanation.ExplanationParameters\n    ] = None,\n    labels: Optional[Dict[str, str]] = None,\n    sync: bool = True,\n)'
+
+        code = 'batch_predict(*, gcs_source: Optional[Union[str, Sequence[str]]] = None, instances_format: str = "jsonl", gcs_destination_prefix: Optional[str] = None, predictions_format: str = "jsonl", model_parameters: Optional[Dict] = None, machine_type: Optional[str] = None, accelerator_type: Optional[str] = None, explanation_parameters: Optional[google.cloud.aiplatform_v1.types.explanation.ExplanationParameters] = None, labels: Optional[Dict[str, str]] = None, sync: bool = True,)'
+
+        code_got = format_code(code)
+        self.assertEqual(code_want, code_got)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Figured out that `black` could be called within Python using `format_str` function. Using this to better format function signatures for our docs.

Requires a bit of pre-processing the data to look like actual code, otherwise black will not be able to process the given code as it's meant to run in files. I also plan on using this to further format code for other types of code so I've created a standalone function. Will revisit with more types of code to format, for now it will only be formatting signatures.

Fixes b/199327840

- [x] Tests pass
