### PR TITLE
fix: resolve square bracketed references

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -83,6 +83,8 @@ INITPY = '__init__.py'
 REF_PATTERN = ':(py:)?(func|class|meth|mod|ref|attr|exc):`~?[a-zA-Z0-9_\.<> ]*(\(\))?`'
 # Regex expression for checking references of pattern like "~package_v1.subpackage.module"
 REF_PATTERN_LAST = '~([a-zA-Z0-9_<>]*\.)*[a-zA-Z0-9_<>]*(\(\))?'
+# Regex expression for checking references of pattern like
+# "[module][google.cloud.cloudkms_v1.module]"
 REF_PATTERN_BRACKETS = '\[[a-zA-Z0-9\_\<\>\-\. ]+\]\[[a-zA-Z0-9\_\<\>\-\. ]+\]'
 
 PROPERTY = 'property'
@@ -239,6 +241,7 @@ def _resolve_reference_in_module_summary(pattern, lines):
             start = matched_obj.start()
             end = matched_obj.end()
             matched_str = line[start:end]
+            # TODO: separate this portion into a function per pattern.
             if pattern == REF_PATTERN:
                 if '<' in matched_str and '>' in matched_str:
                     # match string like ':func:`***<***>`'
@@ -260,10 +263,13 @@ def _resolve_reference_in_module_summary(pattern, lines):
                     index = 1
                 ref_name = matched_str[index:]
 
-            else: #pattern == REF_PATTERN_BRACKETS:
+            elif pattern == REF_PATTERN_BRACKETS:
                 lbracket = matched_str.find('[')+1
                 rbracket = matched_str.find(']')
                 ref_name = matched_str[lbracket:rbracket]
+
+            else:
+                raise ValueError('Encountered wrong ref pattern.')
 
             # Find the uid to add for xref
             index = matched_str.find("google.cloud")
@@ -831,7 +837,8 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
             REF_PATTERN,
             # REF_PATTERN_LAST checks for patterns like "~package.module"
             REF_PATTERN_LAST,
-            # REF_PATTERN_BRACKETS checks for patterns like "~package.module"
+            # REF_PATTERN_BRACKETS checks for patterns like
+            # "[module][google.cloud.cloudkms_v1.module]"
             REF_PATTERN_BRACKETS,
         ]
 

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -87,6 +87,12 @@ REF_PATTERN_LAST = '~([a-zA-Z0-9_<>]*\.)*[a-zA-Z0-9_<>]*(\(\))?'
 # "[module][google.cloud.cloudkms_v1.module]"
 REF_PATTERN_BRACKETS = '\[[a-zA-Z0-9\_\<\>\-\. ]+\]\[[a-zA-Z0-9\_\<\>\-\. ]+\]'
 
+REF_PATTERNS = [
+    REF_PATTERN,
+    REF_PATTERN_LAST,
+    REF_PATTERN_BRACKETS,
+]
+
 PROPERTY = 'property'
 CODEBLOCK = "code-block"
 CODE = "code"
@@ -269,7 +275,7 @@ def _resolve_reference_in_module_summary(pattern, lines):
                 ref_name = matched_str[lbracket:rbracket]
 
             else:
-                raise ValueError('Encountered wrong ref pattern.')
+                raise ValueError(f'Encountered wrong ref pattern: \n{pattern}')
 
             # Find the uid to add for xref
             index = matched_str.find("google.cloud")
@@ -831,18 +837,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
 
     # Add extracted summary
     if lines != []:
-        # Resolve references for xrefs in two different formats.
-        ref_patterns = [
-            # REF_PATTERN checks for patterns like ":class:`~google.package.module`"
-            REF_PATTERN,
-            # REF_PATTERN_LAST checks for patterns like "~package.module"
-            REF_PATTERN_LAST,
-            # REF_PATTERN_BRACKETS checks for patterns like
-            # "[module][google.cloud.cloudkms_v1.module]"
-            REF_PATTERN_BRACKETS,
-        ]
-
-        for ref_pattern in ref_patterns:
+        for ref_pattern in REF_PATTERNS:
             lines, xrefs = _resolve_reference_in_module_summary(ref_pattern, lines)
             for xref in xrefs:
                 if xref not in app.env.docfx_xrefs:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -250,19 +250,22 @@ The <xref uid="google.cloud.kms.v1.KeyRing.name">name</xref> of the <xref uid="g
 """
         summary_want = summary_want.split("\n")
 
-        xrefs_got = []
         summary = """Required.
 
 The [name][google.cloud.kms.v1.KeyRing.name] of the [KeyRing][google.cloud.kms.v1.KeyRing] associated with the [ImportJobs][google.cloud.kms.v1.ImportJob].
 """
         summary = summary.split("\n")
 
-        summary_got, xrefs = _resolve_reference_in_module_summary(REF_PATTERN_BRACKETS, summary)
-        for xref in xrefs:
-            xrefs_got.append(xref)
+        summary_got, xrefs_got = _resolve_reference_in_module_summary(REF_PATTERN_BRACKETS, summary)
 
         self.assertEqual(summary_got, summary_want)
         self.assertCountEqual(xrefs_got, xrefs_want)
+
+
+    # Check that other patterns throws an exception.
+    def test_reference_check_error(self):
+        with self.assertRaises(ValueError):
+            _resolve_reference_in_module_summary('.*', 'not a valid ref line'.split('\n'))
 
 
     def test_extract_docstring_info_normal_input(self):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -3,6 +3,7 @@ from docfx_yaml.extension import disambiguate_toc_name
 from docfx_yaml.extension import _resolve_reference_in_module_summary
 from docfx_yaml.extension import REF_PATTERN
 from docfx_yaml.extension import REF_PATTERN_LAST
+from docfx_yaml.extension import REF_PATTERN_BRACKETS
 from docfx_yaml.extension import _extract_docstring_info
 from docfx_yaml.extension import find_package_group
 from docfx_yaml.extension import pretty_package_name
@@ -234,7 +235,35 @@ Args:
             }
         ]
     }
-    
+
+
+    # Test for resolving square bracketed references.
+    def test_reference_square_brackets(self):
+        xrefs_want = [
+            'google.cloud.kms.v1.KeyRing.name',
+            'google.cloud.kms.v1.KeyRing',
+            'google.cloud.kms.v1.ImportJob',
+        ]
+        summary_want = """Required.
+
+The <xref uid="google.cloud.kms.v1.KeyRing.name">name</xref> of the <xref uid="google.cloud.kms.v1.KeyRing">KeyRing</xref> associated with the <xref uid="google.cloud.kms.v1.ImportJob">ImportJobs</xref>.
+"""
+        summary_want = summary_want.split("\n")
+
+        xrefs_got = []
+        summary = """Required.
+
+The [name][google.cloud.kms.v1.KeyRing.name] of the [KeyRing][google.cloud.kms.v1.KeyRing] associated with the [ImportJobs][google.cloud.kms.v1.ImportJob].
+"""
+        summary = summary.split("\n")
+
+        summary_got, xrefs = _resolve_reference_in_module_summary(REF_PATTERN_BRACKETS, summary)
+        for xref in xrefs:
+            xrefs_got.append(xref)
+
+        self.assertEqual(summary_got, summary_want)
+        self.assertCountEqual(xrefs_got, xrefs_want)
+
 
     def test_extract_docstring_info_normal_input(self):
 


### PR DESCRIPTION
Square bracketed references of the form `[name][link]` will now properly be handled accommodating its regex format.

Towards b/195685296.
Fixes #145.

- [x] Tests pass
