### PR TITLE
chore: suppress blib2to3.pgen2.driver output to log

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -24,10 +24,7 @@ import re
 import copy
 import shutil
 import black
-
 import logging
-# Disable blib2to3 output that clutters debugging log.
-logging.getLogger("blib2to3").setLevel(logging.ERROR)
 
 from pathlib import Path
 from functools import partial
@@ -104,6 +101,8 @@ CODEBLOCK = "code-block"
 CODE = "code"
 PACKAGE = "package"
 
+# Disable blib2to3 output that clutters debugging log.
+logging.getLogger("blib2to3").setLevel(logging.ERROR)
 
 # Run sphinx-build with Markdown builder in the plugin.
 def run_sphinx_markdown():

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -24,6 +24,11 @@ import re
 import copy
 import shutil
 import black
+
+import logging
+# Disable blib2to3 output that clutters debugging log.
+logging.getLogger("blib2to3").setLevel(logging.ERROR)
+
 from pathlib import Path
 from functools import partial
 from itertools import zip_longest


### PR DESCRIPTION
Verified that the outputs are indeed suppressed in local test.

Fixes #149.

- [x] Tests pass
