### PR TITLE
fix: enable upgrading docs

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1327,9 +1327,6 @@ def find_markdown_pages(app, outdir):
 
         "readme.md",    # README does not seem to work in cloud site
                         # See https://github.com/googleapis/sphinx-docfx-yaml/issues/107.
-
-        "upgrading.md", # Currently the formatting breaks, will need to come back to it.
-                        # See https://github.com/googleapis/sphinx-docfx-yaml/issues/108.
     ]
 
     markdown_dir = Path(app.builder.outdir).parent / "markdown"


### PR DESCRIPTION
Upgrading docs have been left out as there were formatting issues before. The formatting issues seemed to have been cleared out, enabling them back into production. They're also important pieces of documentation required for users for breaking changes.

Fixes b/212403496. Towards #108.

- [x] Tests pass
