### PR TITLE
fix: update markdown header parser

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1234,7 +1234,7 @@ def parse_markdown_header(header_line, prev_line):
         if not header_line[header_line.index(h1_header_prefix)+2].isspace() and \
             len(header_line) > 2:
 
-            return header_line.strip("#").strip()
+            return header_line[header_line.index(h1_header_prefix):].strip("#").strip()
 
     elif "=" in header_line:
         # Check if we're inspecting an empty or undefined lines.

--- a/tests/markdown_example_header.md
+++ b/tests/markdown_example_header.md
@@ -9,10 +9,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
--->
-
-
-# Test header for a simple markdown file.
+--> # Test header for a simple markdown file.
 
 ##Content header
 This is a simple line followed by an h2 header.


### PR DESCRIPTION
There is an issue on some markdown pages that contain the license header. Unfortunately the markdown plugin did not seem to handle this well and appended the title to the end of the markdown comment, making it harder to parse the header.

Updating the parser to simply look for the start of the header, strip everything afterwards to try and retrieve the header better.

Fixes b/218150724.

- [x] Tests pass
