### PR TITLE
fix: use `id` field for Attributes instead of `name`

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -448,7 +448,7 @@ def _parse_docstring_summary(summary):
                 keyword = ""
                 if name and description and var_type:
                     attributes.append({
-                        "name": name,
+                        "id": name,
                         "description": description,
                         "var_type": var_type
                     })
@@ -1447,9 +1447,9 @@ def search_cross_references(obj, current_name: str, entry_names: List[str]):
                     entry_names
                 )
 
-            if attribute.get("name"):
-                attribute["name"] = convert_cross_references(
-                    attribute["name"],
+            if attribute.get("id"):
+                attribute["id"] = convert_cross_references(
+                    attribute["id"],
                     current_name,
                     entry_names
                 )

--- a/tests/cross_references_post.yaml
+++ b/tests/cross_references_post.yaml
@@ -7,10 +7,10 @@ items:
       \ \"date_field = CAST('2014-9-27' as\n   DATE)\" \"nullable_field is not NULL\"\
       \ \"st_equals(geo_field,\n   st_geofromtext(\"POINT(2, 2)\"))\" \"numeric_field\
       \ BETWEEN 1.0\n   AND 5.0\"\n   \n   Restricted to a maximum length for 1 MB."
-    name: <xref uid="google.cloud.bigquery_storage_v1.types.StreamStats">google.cloud.bigquery_storage_v1.types.StreamStats</xref>
+    id: <xref uid="google.cloud.bigquery_storage_v1.types.StreamStats">google.cloud.bigquery_storage_v1.types.StreamStats</xref>
     var_type: str
   - description: "Optional. Options specific to the Apache\n   Arrow output format."
-    name: arrow_serialization_options
+    id: arrow_serialization_options
     var_type: <xref uid="google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions">google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions</xref>
   children: []
   class: google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions

--- a/tests/cross_references_pre.yaml
+++ b/tests/cross_references_pre.yaml
@@ -7,10 +7,10 @@ items:
       \ \"date_field = CAST('2014-9-27' as\n   DATE)\" \"nullable_field is not NULL\"\
       \ \"st_equals(geo_field,\n   st_geofromtext(\"POINT(2, 2)\"))\" \"numeric_field\
       \ BETWEEN 1.0\n   AND 5.0\"\n   \n   Restricted to a maximum length for 1 MB."
-    name: google.cloud.bigquery_storage_v1.types.StreamStats
+    id: google.cloud.bigquery_storage_v1.types.StreamStats
     var_type: str
   - description: "Optional. Options specific to the Apache\n   Arrow output format."
-    name: arrow_serialization_options
+    id: arrow_serialization_options
     var_type: <xref uid="google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions">google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions</xref>
   children: []
   class: google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -815,7 +815,7 @@ And any other documentation that the source code would have could go here.
         # Test parsing docstring with attributes.
         attributes_want = [
             {
-                "name": "simple name",
+                "id": "simple name",
                 "description": "simple description",
                 "var_type": 'str'
             }
@@ -837,12 +837,12 @@ And any other documentation that the source code would have could go here.
         # Check multiple attributes are parsed.
         attributes_want = [
             {
-                "name": "simple name",
+                "id": "simple name",
                 "description": "simple description",
                 "var_type": "str"
             },
             {
-                "name": "table_insert_request",
+                "id": "table_insert_request",
                 "description": "Table insert request.",
                 "var_type": "google.cloud.bigquery_logging_v1.types.TableInsertRequest"
             }
@@ -874,7 +874,7 @@ And any other documentation that the source code would have could go here.
         # Check only attributes in valid format gets parsed.
         attributes_want = [
             {
-                "name": "proper name",
+                "id": "proper name",
                 "description": "proper description.",
                 "var_type": "str"
             }


### PR DESCRIPTION
To stay consistent on how YAMLs are formed, updating for Attributes to use `id` instead of `name`. Parameters and other fields use `id` as well.

Fixes b/218725782.

- [x] Tests pass
