### PR TITLE
test: update generate-docs for multi-version

### DIFF
--- a/.kokoro/docs/common.cfg
+++ b/.kokoro/docs/common.cfg
@@ -1,5 +1,9 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
+# Timeout set to 120 hours to support for all tags for each library being
+# generated.
+timeout_mins: 7200
+
 # Build logs will be here
 action {
   define_artifacts {

--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -72,6 +72,8 @@ for bucket_item in $(gsutil ls 'gs://docs-staging-v2/docfx-python*' | sort -u -t
   fi
 
   for tag in ${GITHUB_TAGS}; do
+    # Ensure noxfile.py is reverted so merge conflicts do not occur.
+    git restore "noxfile.py"
     git checkout ${tag}
 
     # Use the latest noxfile for all tags.


### PR DESCRIPTION
To ensure that using the latest `noxfile.py` does not cause merge conflicts, restore the overwritten file before checking out to the new tag. As well, increasing the build timeout as it's taking quite a long time to refresh all the YAMLs for all releases.

Confirmed that if there are no changes to `noxfile.py`, there are no errors on running the restore command.

Fixes #183 

- [x] Tests pass
