### PR TITLE
fix: parse docstring that come without summaries

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -582,8 +582,8 @@ def _extract_docstring_info(summary_info, summary, name):
     # if we found empty array for indexes, stop processing further.
     index = min(indexes) if indexes else 0
 
-    # Store the top summary separately.
-    if index == 0:
+    # Store the top summary separately. Ensure that the docstring is not empty.
+    if index == 0 and not indexes:
         return summary
 
     top_summary = parsed_text[:index]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -431,6 +431,31 @@ Simple test for docstring.
         self.assertDictEqual(summary_info_got, summary_info_want)
 
 
+    def test_extract_docstring_info_no_summary(self):
+        ## Test parsing docstring with no summary.
+        summary =(
+"""Args:
+    arg1(int): simple description.
+    arg2(str): simple description for `arg2`.
+
+Returns:
+    str: simple description for return value.
+
+Raises:
+    AttributeError: if `condition x`.
+"""
+        )
+        summary_info_got = {
+            'variables': {},
+            'returns': [],
+            'exceptions': []
+        }
+
+        top_summary_got = _extract_docstring_info(summary_info_got, summary, "")
+        self.assertEqual(top_summary_got, "")
+        self.assertDictEqual(summary_info_got, self.summary_info1_want)
+
+
     def test_find_package_group(self):
         package_group_want = "google.cloud.spanner_v1beta2"
         uid = "google.cloud.spanner_v1beta2.services.admin_database_v1.types"


### PR DESCRIPTION
The docstring format usually comes with a descriptive one comment, followed by more descriptive info, followed by other special sections like arguments, exceptions and return info. However when there is a docstring with just the special sections without summaries, for example:


```
"""
Args:
            project (Optional[str]): the project which the client acts on behalf of.
                If not passed, falls back to the default inferred
                from the environment.
            credentials (Optional[google.auth.credentials.Credentials]):
                Thehe OAuth2 Credentials to use for this
                client. If not passed (and if no ``_http`` object is
                passed), falls back to the default inferred from the
                environment.
"""
```
This breaks in the parser, but technically this is a proper GoogleDocstring. While this is not an encouraged docstring format, the parser should not break and should still render items properly.

Fixing this by ensuring that if there is no summary, we check to see if there are other items present in the `indexes` list that checks for special keywords.

Fixes b/222493613.

- [x] Tests pass
