### PR TITLE
fix: format code snippets properly

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -388,11 +388,8 @@ def extract_keyword(line):
 
 # Given lines of code, indent to left by 1 block, based on
 # amount of trailing white space of first line as 1 block.
-def indent_code_left(lines):
+def indent_code_left(lines, tab_space):
     parts = lines.split("\n")
-    # Count how much leading whitespaces there are based on first line.
-    # lstrip(" ") removes all trailing whitespace from the string.
-    tab_space = len(parts[0]) - len(parts[0].lstrip(" "))
     parts = [part[tab_space:] for part in parts]
     return "\n".join(parts)
 
@@ -417,6 +414,9 @@ def _parse_docstring_summary(summary):
         if keyword and keyword in [CODE, CODEBLOCK]:
             # If we reach the end of keyword, close up the code block.
             if not part.startswith(" "*tab_space) or part.startswith(".."):
+                if code_snippet:
+                    parts = [indent_code_left(part, tab_space) for part in code_snippet]
+                    summary_parts.append("\n\n".join(parts))
                 summary_parts.append("```\n")
                 keyword = ""
 
@@ -428,9 +428,12 @@ def _parse_docstring_summary(summary):
                         raise ValueError(f"Code in the code block should be indented. Please check the docstring: \n{summary}")
                 if not part.startswith(" "*tab_space):
                     # No longer looking at code-block, reset keyword.
+                    if code_snippet:
+                        parts = [indent_code_left(part, tab_space) for part in code_snippet]
+                        summary_parts.append("\n\n".join(parts))
                     keyword = ""
                     summary_parts.append("```\n")
-                summary_parts.append(indent_code_left(part))
+                code_snippet.append(part)
                 continue
 
         # Attributes come in 3 parts, parse the latter two here.
@@ -472,6 +475,7 @@ def _parse_docstring_summary(summary):
                 language = part.split("::")[1].strip()
                 summary_parts.append(f"```{language}")
 
+                code_snippet = []
                 tab_space = -1
 
             # Extract the name for attribute first.
@@ -490,6 +494,9 @@ def _parse_docstring_summary(summary):
     # Close up from the keyword if needed.
     if keyword and keyword in [CODE, CODEBLOCK]:
         # Check if it's already closed.
+        if code_snippet:
+            parts = [indent_code_left(part, tab_space) for part in code_snippet]
+            summary_parts.append("\n\n".join(parts))
         if summary_parts[-1] != "```\n":
             summary_parts.append("```\n")
 

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -386,9 +386,16 @@ def extract_keyword(line):
         return line
 
 
-# Given lines of code, indent to left by 1 block, based on
-# amount of trailing white space of first line as 1 block.
 def indent_code_left(lines, tab_space):
+    """Indents code lines left by tab_space.
+
+    Args:
+        lines: String lines of code.
+        tab_space: Number of spaces to indent to left by.
+
+    Returns:
+        String lines of left-indented code.
+    """
     parts = lines.split("\n")
     parts = [part[tab_space:] for part in parts]
     return "\n".join(parts)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -27,7 +27,9 @@ class TestGenerate(unittest.TestCase):
         print('test function for indent')
         return ('left-indented-code')
 """
-        code = indent_code_left(code)
+        parts = code.split("\n")
+        tab_space = len(parts[0]) - len(parts[0].lstrip(" "))
+        code = indent_code_left(code, tab_space)
         self.assertEqual(code, code_want)
 
         # Check that if there's no whitespace, it does not indent
@@ -41,8 +43,10 @@ for i in range(10):
     else:
         continue
 """
+        parts = code_want.split("\n")
+        tab_space = len(parts[0]) - len(parts[0].lstrip(" "))
 
-        code_got = indent_code_left(code_want)
+        code_got = indent_code_left(code_want, tab_space)
         # Confirm that nothing changes.
         self.assertEqual(code_got, code_want)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -45,9 +45,29 @@ for i in range(10):
 """
         parts = code_want.split("\n")
         tab_space = len(parts[0]) - len(parts[0].lstrip(" "))
-
         code_got = indent_code_left(code_want, tab_space)
         # Confirm that nothing changes.
+        self.assertEqual(code_got, code_want)
+
+
+    def test_indent_code_blocks_left(self):
+        # Check code blocks are indented properly.
+        code_want = \
+"""def foo():
+
+    print('test function for indent')
+
+    return ('left-indented-blocks')
+"""
+
+        # Test with how blocks would appear in the code block
+        code = [
+            "    def foo():",
+            "        print('test function for indent')",
+            "        return ('left-indented-blocks')\n"
+        ]
+        tab_space = len(code[0]) - len(code[0].lstrip(" "))
+        code_got = "\n\n".join([indent_code_left(part, tab_space) for part in code])
         self.assertEqual(code_got, code_want)
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -14,26 +14,33 @@ from yaml import load, Loader
 import tempfile
 
 class TestGenerate(unittest.TestCase):
-    def test_indent_code_left(self):
+    code_testdata = [
         # Check that the code indents to left based on first line.
-        code_want = \
+        [
+            \
+"""    def foo():
+        print('test function for indent')
+        return ('left-indented-code')
+""",
+            \
 """def foo():
     print('test function for indent')
     return ('left-indented-code')
 """
-
-        code = \
-"""    def foo():
-        print('test function for indent')
-        return ('left-indented-code')
-"""
-        parts = code.split("\n")
-        tab_space = len(parts[0]) - len(parts[0].lstrip(" "))
-        code = indent_code_left(code, tab_space)
-        self.assertEqual(code, code_want)
-
+        ],
         # Check that if there's no whitespace, it does not indent
-        code_want = \
+        [
+            \
+"""
+print('test function for no impact indent')
+for i in range(10):
+    print(i)
+    if i%5 == 0:
+        i += 1
+    else:
+        continue
+""",
+            \
 """
 print('test function for no impact indent')
 for i in range(10):
@@ -43,10 +50,13 @@ for i in range(10):
     else:
         continue
 """
-        parts = code_want.split("\n")
+        ],
+    ]
+    @parameterized.expand(code_testdata)
+    def test_indent_code_left(self, code, code_want):
+        parts = code.split("\n")
         tab_space = len(parts[0]) - len(parts[0].lstrip(" "))
-        code_got = indent_code_left(code_want, tab_space)
-        # Confirm that nothing changes.
+        code_got = indent_code_left(code, tab_space)
         self.assertEqual(code_got, code_want)
 
 


### PR DESCRIPTION
Code snippets that are separated by new blocks were not treated with the same `tab_space`, resulting in inconsistent formatting between the blocks. To make this consistent, the parser will now collect all of the code snippet first, then process all of them at once with a uniform `tab_space` value that was calculated when the code block is encountered at first.

Modified the unit test to grab the `tab_space` like how the parser will compute it. Also added an additional unit test for testing code snippet with blocks and refactored the existing unit test to use parameterized style instead.

Fixes b/219067629.

- [x] Tests pass
