### PR TITLE
fix: support parsing summary docstring that is not well formed

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -469,9 +469,13 @@ def _parse_docstring_summary(summary):
                 continue
 
         # Parse keywords if found.
-        if part.startswith(".."):
+        # lstrip is added to parse code blocks that are not formatted well.
+        # TODO: remove the lstrip if
+        # https://github.com/googleapis/gapic-generator-python/issues/1244 is
+        # resolved.
+        if part.lstrip('\n').startswith('..'):
             try:
-                keyword = extract_keyword(part)
+                keyword = extract_keyword(part.lstrip('\n'))
             except ValueError:
                 raise ValueError(f"Please check the docstring: \n{summary}")
             # Works for both code-block and code

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -470,9 +470,6 @@ def _parse_docstring_summary(summary):
 
         # Parse keywords if found.
         # lstrip is added to parse code blocks that are not formatted well.
-        # TODO: remove the lstrip if
-        # https://github.com/googleapis/gapic-generator-python/issues/1244 is
-        # resolved.
         if part.lstrip('\n').startswith('..'):
             try:
                 keyword = extract_keyword(part.lstrip('\n'))

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -736,6 +736,7 @@ Raises:
 
         self.assertEqual(header_line_want, header_line_got)
 
+
     def test_parse_docstring_summary(self):
         # Check that the summary gets parsed correctly.
         attributes_want = []
@@ -794,7 +795,7 @@ client = ImageAnnotatorClient(
 You can also pass a mapping object.
 
 
-.. code-block:: ruby
+\n.. code-block:: ruby
 
 \n    from google.cloud.vision_v1 import ImageAnnotatorClient
 \n    client = ImageAnnotatorClient(


### PR DESCRIPTION
Currently, there are `.. code-block` docstrings that could appear with extra newlines if the summary before the docstring is longer than one line (80 characters). This causes the parser to not correctly find the docstring element. The parser however should be able to correctly locate the docstring despite the summary not being properly formatted, so the users do not see extra items in the documentation.

Fixing this by stripping any existence of newlines that come before the docstring; any other characters will still not be tolerated. 

Modified the unit test for a code block that contains an extra newline; without the fix in this code, the unit test will fail.

Fixes b/219067629.

- [x] Tests pass
