### PR TITLE
fix: add markdown header if it is missing

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1351,12 +1351,12 @@ def highlight_md_codeblocks(mdfile):
 
 
 def prepend_markdown_header(filename, mdfile_iterator):
-    """Prepends the name as a Markdown header.
+    """Prepends the filename as a Markdown header.
 
     Args:
         filename: the name of the markdown file to prepend.
         mdfile_iterator: iterator to the markdown file that is both readable
-        and writable.
+          and writable.
     """
     file_content = f'# {filename}\n\n' + mdfile_iterator.read()
     # Reset file position to the beginning to write

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1350,8 +1350,8 @@ def highlight_md_codeblocks(mdfile):
         mdfile_iterator.write(new_content)
 
 
-def prepend_markdown_title(filename, mdfile_iterator):
-    """Prepends the name as a Markdown title.
+def prepend_markdown_header(filename, mdfile_iterator):
+    """Prepends the name as a Markdown header.
 
     Args:
         filename: the name of the markdown file to prepend.
@@ -1401,7 +1401,7 @@ def find_markdown_pages(app, outdir):
                     print(f"Could not find a title for {mdfile_iterator.name}. Using {mdfile_name} as the title instead.")
                     name = mdfile_name
 
-                    prepend_markdown_title(name, mdfile_iterator)
+                    prepend_markdown_header(name, mdfile_iterator)
 
             shutil.copy(mdfile, f"{outdir}/{mdfile.name.lower()}")
 

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1286,7 +1286,7 @@ def parse_markdown_header(header_line, prev_line):
     return ""
 
 
-def extract_header_from_markdown(mdfile: Iterable) -> str:
+def extract_header_from_markdown(mdfile: Iterable[str]) -> str:
     """For a given markdown file, extract its header line.
 
     Args:
@@ -1356,7 +1356,7 @@ def highlight_md_codeblocks(mdfile):
         mdfile_iterator.write(new_content)
 
 
-def prepend_markdown_header(filename: str, mdfile: Iterable):
+def prepend_markdown_header(filename: str, mdfile: Iterable[str]):
     """Prepends the filename as a Markdown header.
 
     Args:

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -29,7 +29,7 @@ import logging
 from pathlib import Path
 from functools import partial
 from itertools import zip_longest
-from typing import List
+from typing import List, Iterable
 from black import InvalidInput
 
 try:
@@ -1286,12 +1286,18 @@ def parse_markdown_header(header_line, prev_line):
     return ""
 
 
-# For a given markdown file, extract its header line.
-# Returns empty string if a Markdown heading level 1 does not exist.
-def extract_header_from_markdown(mdfile_iterator):
+def extract_header_from_markdown(mdfile: Iterable) -> str:
+    """For a given markdown file, extract its header line.
+
+    Args:
+        mdfile: iterator to the markdown file.
+
+    Returns:
+        A string for header or empty string if header is not found.
+    """
     prev_line = ""
 
-    for header_line in mdfile_iterator:
+    for header_line in mdfile:
 
         # Ignore licenses and other non-headers prior to the header.
         header = parse_markdown_header(header_line, prev_line)
@@ -1350,18 +1356,18 @@ def highlight_md_codeblocks(mdfile):
         mdfile_iterator.write(new_content)
 
 
-def prepend_markdown_header(filename, mdfile_iterator):
+def prepend_markdown_header(filename: str, mdfile: Iterable):
     """Prepends the filename as a Markdown header.
 
     Args:
         filename: the name of the markdown file to prepend.
-        mdfile_iterator: iterator to the markdown file that is both readable
+        mdfile: iterator to the markdown file that is both readable
           and writable.
     """
-    file_content = f'# {filename}\n\n' + mdfile_iterator.read()
+    file_content = f'# {filename}\n\n' + mdfile.read()
     # Reset file position to the beginning to write
-    mdfile_iterator.seek(0)
-    mdfile_iterator.write(file_content)
+    mdfile.seek(0)
+    mdfile.write(file_content)
 
 
 # Given generated markdown files, incorporate them into the docfx_yaml output.

--- a/tests/markdown_example_alternate_bad_want.md
+++ b/tests/markdown_example_alternate_bad_want.md
@@ -1,0 +1,8 @@
+# Markdown_example_alternate_bad
+
+==============
+
+There should be a header line before the divider.
+
+##Content header
+This is a simple line followed by an h2 header.

--- a/tests/markdown_example_bad_header_want.md
+++ b/tests/markdown_example_bad_header_want.md
@@ -1,0 +1,6 @@
+# Markdown_example_bad_header
+
+ #Test header for a bad formatted markdown file.  
+
+##Content header
+This is a simple line followed by an h2 header.

--- a/tests/markdown_example_h2_want.md
+++ b/tests/markdown_example_h2_want.md
@@ -1,0 +1,6 @@
+# Markdown_example_h2
+
+## Test header for a simple markdown file.  
+
+##Content header
+This is a simple line followed by an h2 header.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,7 @@ from docfx_yaml.extension import search_cross_references
 from docfx_yaml.extension import format_code
 from docfx_yaml.extension import extract_product_name
 from docfx_yaml.extension import highlight_md_codeblocks
-from docfx_yaml.extension import prepend_markdown_title
+from docfx_yaml.extension import prepend_markdown_header
 
 import unittest
 from parameterized import parameterized
@@ -277,7 +277,7 @@ for i in range(10):
         ],
     ]
     @parameterized.expand(test_markdown_filenames)
-    def test_prepend_markdown_title(self, base_filename, want_filename):
+    def test_prepend_markdown_header(self, base_filename, want_filename):
         # Test to ensure markdown titles are correctly prepended.
 
         # Copy the base file we'll need to test.
@@ -289,7 +289,7 @@ for i in range(10):
                 test_file.flush()
                 test_file.seek(0)
 
-            prepend_markdown_title(file_name, test_file)
+            prepend_markdown_header(file_name, test_file)
             test_file.seek(0)
 
             with open(want_filename) as mdfile_want:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,6 +5,7 @@ from docfx_yaml.extension import search_cross_references
 from docfx_yaml.extension import format_code
 from docfx_yaml.extension import extract_product_name
 from docfx_yaml.extension import highlight_md_codeblocks
+from docfx_yaml.extension import prepend_markdown_title
 
 import unittest
 from parameterized import parameterized
@@ -254,6 +255,41 @@ for i in range(10):
                 test_file.flush()
 
             highlight_md_codeblocks(test_file.name)
+            test_file.seek(0)
+
+            with open(want_filename) as mdfile_want:
+                self.assertEqual(test_file.read(), mdfile_want.read())
+
+
+    # Filenames to test prepending Markdown title..
+    test_markdown_filenames = [
+        [
+            "tests/markdown_example_bad_header.md",
+            "tests/markdown_example_bad_header_want.md"
+        ],
+        [
+            "tests/markdown_example_h2.md",
+            "tests/markdown_example_h2_want.md"
+        ],
+        [
+            "tests/markdown_example_alternate_bad.md",
+            "tests/markdown_example_alternate_bad_want.md"
+        ],
+    ]
+    @parameterized.expand(test_markdown_filenames)
+    def test_prepend_markdown_title(self, base_filename, want_filename):
+        # Test to ensure markdown titles are correctly prepended.
+
+        # Copy the base file we'll need to test.
+        with tempfile.NamedTemporaryFile(mode='r+', delete=False) as test_file:
+            with open(base_filename) as base_file:
+                # Use same file name extraction as original code.
+                file_name = base_file.name.split("/")[-1].split(".")[0].capitalize()
+                test_file.write(base_file.read())
+                test_file.flush()
+                test_file.seek(0)
+
+            prepend_markdown_title(file_name, test_file)
             test_file.seek(0)
 
             with open(want_filename) as mdfile_want:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -278,7 +278,7 @@ for i in range(10):
     ]
     @parameterized.expand(test_markdown_filenames)
     def test_prepend_markdown_header(self, base_filename, want_filename):
-        # Test to ensure markdown titles are correctly prepended.
+        # Ensure markdown titles are correctly prepended.
 
         # Copy the base file we'll need to test.
         with tempfile.NamedTemporaryFile(mode='r+', delete=False) as test_file:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -13,6 +13,7 @@ from docfx_yaml.extension import _parse_docstring_summary
 from docfx_yaml.extension import parse_markdown_header
 
 import unittest
+from parameterized import parameterized
 
 from yaml import load, Loader
 
@@ -667,67 +668,69 @@ Raises:
         self.assertEqual(header_line_got, header_line_want)
 
 
-    def test_extract_header_from_markdown(self):
-        # Check the header for a normal markdown file.
+    test_markdown_filenames = [
+        [
+            # Check the header for a normal markdown file.
+            "tests/markdown_example.md"
+        ],
+        [
+            # The header should be the same even with the license header.
+            "tests/markdown_example_header.md"
+        ],
+    ]
+    @parameterized.expand(test_markdown_filenames)
+    def test_extract_header_from_markdown(self, markdown_filename):
+        # Check the header for markdown files.
         header_line_want = "Test header for a simple markdown file."
 
-        with open('tests/markdown_example.md', 'r') as mdfile:
+        with open(markdown_filename, 'r') as mdfile:
             header_line_got = extract_header_from_markdown(mdfile)
 
         self.assertEqual(header_line_got, header_line_want)
 
-        # The header should be the same even with the license header.
-        header_line_with_license_want = header_line_want
 
-        with open('tests/markdown_example_header.md', 'r') as mdfile_license:
-            header_line_with_license_got = extract_header_from_markdown(mdfile_license)
-
-        self.assertEqual(header_line_with_license_got, header_line_with_license_want)
-
-
-    def test_extract_header_from_markdown_alternate_header(self):
-        # Check the header for an alternate header style.
+    test_markdown_filenames = [
+        [
+            # Check the header for an alternate header style.
+            "tests/markdown_example_alternate.md"
+        ],
+        [
+            # The header should be the same even with the license header.
+            "tests/markdown_example_alternate_header.md"
+        ],
+        [
+            # Check the header for an alternate header style.
+            "tests/markdown_example_alternate_less.md"
+        ],
+    ]
+    @parameterized.expand(test_markdown_filenames)
+    def test_extract_header_from_markdown_alternate_header(self, markdown_filename):
+        # Check the header for different accepted styles.
         header_line_want = "This is a simple alternate header"
 
-        with open('tests/markdown_example_alternate.md', 'r') as mdfile:
-            header_line_got = extract_header_from_markdown(mdfile)
-
-        self.assertEqual(header_line_got, header_line_want)
-
-        # The header should be the same even with the license header.
-        header_line_with_license_want = header_line_want
-
-        with open('tests/markdown_example_alternate_header.md', 'r') as mdfile:
-            header_line_with_license_got = extract_header_from_markdown(mdfile)
-
-        self.assertEqual(header_line_with_license_got, header_line_with_license_want)
-
-        # Check the header for an alternate header style.
-        header_line_want = "This is a simple alternate header"
-
-        with open('tests/markdown_example_alternate_less.md', 'r') as mdfile:
+        with open(markdown_filename, 'r') as mdfile:
             header_line_got = extract_header_from_markdown(mdfile)
 
         self.assertEqual(header_line_got, header_line_want)
 
 
-    def test_extract_header_from_markdown_bad_headers(self):
-        # Check that the filename is used as header if no valid header is found.
+    test_markdown_filenames = [
+        [
+            "tests/markdown_example_bad_header.md"
+        ],
+        [
+            "tests/markdown_example_h2.md"
+        ],
+        [
+            "tests/markdown_example_alternate_bad.md"
+        ],
+    ]
+    @parameterized.expand(test_markdown_filenames)
+    def test_extract_header_from_markdown_bad_headers(self, markdown_filename):
+        # Check that empty string is returned if no valid header is found.
         header_line_want = ""
 
-        with open('tests/markdown_example_bad_header.md', 'r') as mdfile:
-            header_line_got = extract_header_from_markdown(mdfile)
-
-        self.assertEqual(header_line_want, header_line_got)
-
-        # Check that only h1 headers are parsed.
-        with open('tests/markdown_example_h2.md', 'r') as mdfile:
-            header_line_got = extract_header_from_markdown(mdfile)
-
-        self.assertEqual(header_line_want, header_line_got)
-
-        # Check that there must be a line before the h1 header breaker.
-        with open('tests/markdown_example_alternate_bad.md', 'r') as mdfile:
+        with open(markdown_filename, 'r') as mdfile:
             header_line_got = extract_header_from_markdown(mdfile)
 
         self.assertEqual(header_line_want, header_line_got)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -713,7 +713,7 @@ Raises:
 
     def test_extract_header_from_markdown_bad_headers(self):
         # Check that the filename is used as header if no valid header is found.
-        header_line_want = "Markdown_example_bad_header"
+        header_line_want = ""
 
         with open('tests/markdown_example_bad_header.md', 'r') as mdfile:
             header_line_got = extract_header_from_markdown(mdfile)
@@ -721,16 +721,12 @@ Raises:
         self.assertEqual(header_line_want, header_line_got)
 
         # Check that only h1 headers are parsed.
-        header_line_want = "Markdown_example_h2"
-
         with open('tests/markdown_example_h2.md', 'r') as mdfile:
             header_line_got = extract_header_from_markdown(mdfile)
 
         self.assertEqual(header_line_want, header_line_got)
 
         # Check that there must be a line before the h1 header breaker.
-        header_line_want = "Markdown_example_alternate_bad"
-
         with open('tests/markdown_example_alternate_bad.md', 'r') as mdfile:
             header_line_got = extract_header_from_markdown(mdfile)
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -728,12 +728,10 @@ Raises:
     @parameterized.expand(test_markdown_filenames)
     def test_extract_header_from_markdown_bad_headers(self, markdown_filename):
         # Check that empty string is returned if no valid header is found.
-        header_line_want = ""
-
         with open(markdown_filename, 'r') as mdfile:
             header_line_got = extract_header_from_markdown(mdfile)
 
-        self.assertEqual(header_line_want, header_line_got)
+        self.assertFalse(header_line_got)
 
 
     def test_parse_docstring_summary(self):


### PR DESCRIPTION
A markdown file may come without a title. Ideally, this could get fixed from the source, but the plugin should try and render content that is still readable rather than not making the rest of the content unreadable and giving the user poorer experience.

This means that if a title exists but do not conform to the Markdown's style, there would be duplicated content. However, I think that is much better rather than a completely non-readable title and body content. For example, I'd prefer

```
<h1> Markdown_title </h1>
 #Markdown_title

This is the body content of the markdown page with a malformed title.
```

rather than
```
<h1> #Markdown_title This is the body content of the markdown page with a malformed title. </h1>
```

If the owner of the documentation page does not like seeing the former, they can simply update the source to have a proper title and the plugin will use the correct title as the header.

Adding unit test and updating existing tests as `extract_header_from_markdown` now returns an empty string instead of a proposed title. 

Fixes #135 and b/208866831.

- [x] Tests pass
