### PR TITLE
fix: add hardcoded IAM references temporarily

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1444,7 +1444,7 @@ def check_existing_references(
     """
     cross_reference = ""
     if keyword != current_name and keyword not in current_name and keyword in word:
-        if keyword in hard_coded_references:
+        if hard_coded_references and keyword in hard_coded_references:
             if "<a" not in words[index-1] and \
                 not (converted_words and f"<a href=\"{hard_coded_references[keyword]}" in converted_words[-1]):
                 cross_reference = f"<a href=\"{hard_coded_references[keyword]}\">{keyword}</a>"

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1421,42 +1421,42 @@ def resolve_cross_reference(
     current_word: str,
     words: List[str],
     index: int,
-    keyword: str,
+    uid: str,
     processed_words: List[str],
     hard_coded_references: Dict[str, str] = None
 ) -> Optional[str]:
-    """Given `current_word`, returns the resolved cross reference for `keyword` if found.
+    """Given `current_word`, returns the resolved cross reference for `uid` if found.
 
     Args:
         current_word: current word being looked at
         words: list of words used to check and compare content before and after `current_word`
         index: index position of `current_word` within words
-        keyword: reference keyword to check against
+        uid: reference uid to check against
         processed_words: list of words containing words that's been processed so far
         hard_coded_references: Optional list containing a list of hard coded reference
 
     Returns:
-        None if current word does not contain a reference keyword, or a string
+        None if current word does not contain a reference uid, or a string
           that contains the converted reference.
     """
-    if keyword in current_word:
-        if hard_coded_references and keyword in hard_coded_references:
+    if uid in current_word:
+        if hard_coded_references and uid in hard_coded_references:
             # If the cross reference has been processed already, "<a" will
             # appear as the previous word. Also check against the words that
             # have been converted. For hard coded references, we use
             # "<a href" links.
             if "<a" not in words[index-1] and \
-                not (processed_words and f"<a href=\"{hard_coded_references[keyword]}" in processed_words[-1]):
-                return f"<a href=\"{hard_coded_references[keyword]}\">{keyword}</a>"
+                not (processed_words and f"<a href=\"{hard_coded_references[uid]}" in processed_words[-1]):
+                return f"<a href=\"{hard_coded_references[uid]}\">{uid}</a>"
 
         else:
-            # Check to see if the keyword has always been identified as a cross
+            # Check to see if the uid has always been identified as a cross
             # reference. If so, the original text will contain "<xref" as the
             # previous word, i.e. "<xref uid="storage">storage</xref>". Check
             # against the words that have been converted so far as well.
             if "<xref" not in words[index-1] and \
-                not (processed_words and f"<xref uid=\"{keyword}" in processed_words[-1]):
-                return f"<xref uid=\"{keyword}\">{keyword}</xref>"
+                not (processed_words and f"<xref uid=\"{uid}" in processed_words[-1]):
+                return f"<xref uid=\"{uid}\">{uid}</xref>"
 
     return None
 
@@ -1472,7 +1472,7 @@ def convert_cross_references(content: str, current_object_name: str, entry_names
     Args:
         content: given body of content to parse and look for references
         current_object_name: the name of the current Python object being looked at
-        entry_names: list of keyword references to look for
+        entry_names: list of uid references to look for
 
     Returns:
         content that has been modified with proper cross references if found.
@@ -1497,22 +1497,22 @@ def convert_cross_references(content: str, current_object_name: str, entry_names
     # Using counter to check if the entry is already a cross reference.
     for index, word in enumerate(words):
         cross_reference = None
-        for keyword in entry_names:
+        for uid in entry_names:
             # Do not convert references to itself or containing partial
             # references. This could result in `storage.types.ReadSession` being
             # prematurely converted to
             # `<xref uid="storage.types">storage.types</xref>ReadSession`
             # instead of
             # `<xref uid="storage.types.ReadSession">storage.types.ReadSession</xref>`
-            if keyword in current_object_name:
+            if uid in current_object_name:
                 continue
 
             cross_reference = resolve_cross_reference(
-                word, words, index, keyword, processed_words, hard_coded_references
+                word, words, index, uid, processed_words, hard_coded_references
             )
             if cross_reference:
-                processed_words.append(word.replace(keyword, cross_reference))
-                print(f"Converted {keyword} into cross reference in: \n{content}")
+                processed_words.append(word.replace(uid, cross_reference))
+                print(f"Converted {uid} into cross reference in: \n{content}")
                 break
 
         # If cross reference has not been found, add current unchanged content.

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1426,19 +1426,19 @@ def find_uid_to_convert(
     processed_words: List[str],
     hard_coded_references: Dict[str, str] = None
 ) -> Optional[str]:
-    """Given `current_word`, returns the resolved cross reference for `uid` if found.
+    """Given `current_word`, returns the `uid` to convert to cross reference if found.
 
     Args:
         current_word: current word being looked at
         words: list of words used to check and compare content before and after `current_word`
         index: index position of `current_word` within words
         known_uids: list of uid references to look for
-        current_object_name: the name of the current Python object being looked at
+        current_object_name: the name of the current Python object being processed
         processed_words: list of words containing words that's been processed so far
         hard_coded_references: Optional list containing a list of hard coded reference
 
     Returns:
-        None if current word does not contain a reference uid, or the uid
+        None if current word does not contain any reference `uid`, or the `uid`
           that should be converted.
     """
     for uid in known_uids:
@@ -1452,11 +1452,11 @@ def find_uid_to_convert(
             continue
 
         if uid in current_word:
-            # If the cross reference has been processed already, "<a" or
-            # "<xref"will appear as the previous word. Also check against
-            # the words that have been converted. For hard coded
-            # references, we use "<a href" links.
-            if "<a" not in words[index-1] and "<xref" not in words[index-1]:
+            # If the cross reference has been processed already, "<xref" or
+            # "<a" will appear as the previous word.
+            # For hard coded references, we use "<a href" style.
+            if "<xref" not in words[index-1] and "<a" not in words[index-1]:
+                # Check to see if the reference has been converted already.
                 if not (processed_words and ( \
                     f"<xref uid=\"{uid}" in processed_words[-1] or \
                     (hard_coded_references and f"<a href=\"{hard_coded_references.get(uid)}" in processed_words[-1]))):
@@ -1474,8 +1474,8 @@ def convert_cross_references(content: str, current_object_name: str, known_uids:
     to references.
 
     Args:
-        content: given body of content to parse and look for references
-        current_object_name: the name of the current Python object being looked at
+        content: body of content to parse and look for references in
+        current_object_name: the name of the current Python object being processed
         known_uids: list of uid references to look for
 
     Returns:
@@ -1498,7 +1498,6 @@ def convert_cross_references(content: str, current_object_name: str, known_uids:
     }
     known_uids.extend(hard_coded_references.keys())
 
-    # Using counter to check if the entry is already a cross reference.
     for index, word in enumerate(words):
         uid = find_uid_to_convert(
             word, words, index, known_uids, current_object_name, processed_words, hard_coded_references

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1454,7 +1454,7 @@ def resolve_cross_reference(
     return None
 
 
-def convert_cross_references(content: str, current_object_name: str, entry_names: List[str]):
+def convert_cross_references(content: str, current_object_name: str, entry_names: List[str]) -> str:
     """Finds and replaces references that should be a cross reference in given content.
 
     This should not convert any references that contain `current_object_name`,

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1440,7 +1440,7 @@ def convert_cross_references(content: str, current_name: str, entry_names: List[
         cross_reference = ""
         for keyword in entry_names:
             if keyword != current_name and keyword not in current_name and keyword in word:
-                if keyword in hard_coded_references:
+                if keyword, reference in hard_coded_references.items():
                     if "<a" in words[index-1] or \
                         (new_words and f"<a href=\"{hard_coded_references[keyword]}" in new_words[-1]):
                         continue

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -115,6 +115,13 @@ for i in range(10):
             "Response message for google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse.",
             "Response message for <xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>."
         ],
+        # TODO(https://github.com/googleapis/sphinx-docfx-yaml/issues/208):
+        # remove this when it is not needed anymore.
+        # Testing for hardcoded reference.
+        [
+            "google.iam.v1.iam_policy_pb2.GetIamPolicyRequest",
+            "<a href=\"http://github.com/googleapis/python-grpc-google-iam-v1/blob/main/google/iam/v1/iam_policy_pb2_grpc.py#L111-L118\">google.iam.v1.iam_policy_pb2.GetIamPolicyRequest</a>"
+        ]
     ]
     @parameterized.expand(cross_references_testdata)
     def test_convert_cross_references(self, content, content_want):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -335,7 +335,7 @@ for i in range(10):
         ],
     ]
     @parameterized.expand(test_reference_params)
-    def test_resolve_cross_reference(self, current_word, keyword, visited_words, cross_reference_want):
+    def test_resolve_cross_reference(self, current_word, uid, visited_words, cross_reference_want):
         content ="""Sets the IAM access control policy for the specified project.
 
 The following constraints apply when using google.cloud.resourcemanager_v3.ProjectsClient
@@ -350,7 +350,7 @@ Take a look at <xref uid="google.cloud.resourcemanager_v3.set_iam_policy">docume
         index = words.index(current_word)
 
         cross_reference_got = resolve_cross_reference(
-            current_word, words, index, keyword, visited_words
+            current_word, words, index, uid, visited_words
         )
         self.assertEqual(cross_reference_got, cross_reference_want)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 from docfx_yaml.extension import extract_keyword
 from docfx_yaml.extension import indent_code_left
-from docfx_yaml.extension import check_existing_references
+from docfx_yaml.extension import resolve_cross_reference
 from docfx_yaml.extension import convert_cross_references
 from docfx_yaml.extension import search_cross_references
 from docfx_yaml.extension import format_code
@@ -116,23 +116,29 @@ for i in range(10):
             "Response message for google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse.",
             "Response message for <xref uid=\"google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse\">google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse</xref>."
         ],
+        # Testing for cross reference to not be converted for its own object.
+        [
+            "Response message for google.cloud.bigquery_storage_v1.types.SplitResponse.",
+            "Response message for google.cloud.bigquery_storage_v1.types.SplitResponse."
+        ],
         # TODO(https://github.com/googleapis/sphinx-docfx-yaml/issues/208):
         # remove this when it is not needed anymore.
         # Testing for hardcoded reference.
         [
             "google.iam.v1.iam_policy_pb2.GetIamPolicyRequest",
-            "<a href=\"http://github.com/googleapis/python-grpc-google-iam-v1/blob/main/google/iam/v1/iam_policy_pb2_grpc.py#L111-L118\">google.iam.v1.iam_policy_pb2.GetIamPolicyRequest</a>"
+            "<a href=\"http://github.com/googleapis/python-grpc-google-iam-v1/blob/8e73b45993f030f521c0169b380d0fbafe66630b/google/iam/v1/iam_policy_pb2_grpc.py#L111-L118\">google.iam.v1.iam_policy_pb2.GetIamPolicyRequest</a>"
         ]
     ]
     @parameterized.expand(cross_references_testdata)
     def test_convert_cross_references(self, content, content_want):
         # Check that entries correctly turns into cross references.
         keyword_map = [
-            "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse"
+            "google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse",
+            "google.cloud.bigquery_storage_v1.types.SplitResponse"
         ]
-        current_name = "SplitRepsonse"
+        current_object_name = "google.cloud.bigquery_storage_v1.types.SplitResponse"
 
-        content_got = convert_cross_references(content, current_name, keyword_map)
+        content_got = convert_cross_references(content, current_object_name, keyword_map)
         self.assertEqual(content_got, content_want)
 
 
@@ -306,27 +312,30 @@ for i in range(10):
 
     test_reference_params = [
         [
+            # If no reference keyword is found, check for None
             "google.cloud.resourcemanager_v3.ProjectsClient",
-            "google.cloud.resourcemanager_v3.ProjectsClient",
+            "google.cloud.resourcemanager_v1.ProjectsClient",
             ["The", "following", "constraints", "apply", "when", "using"],
-            ""
+            None
         ],
         [
+            # If keyword reference is found, validate proper cross reference
             "google.cloud.resourcemanager_v3.set_iam_policy",
             "google.cloud.resourcemanager_v3.set_iam_policy",
             ["A", "Policy", "is", "a", "collection", "of", "bindings", "from"],
             "<xref uid=\"google.cloud.resourcemanager_v3.set_iam_policy\">google.cloud.resourcemanager_v3.set_iam_policy</xref>"
         ],
         [
+            # If keyword reference has already been converted, do not convert
+            # again.
             "uid=\"google.cloud.resourcemanager_v3.set_iam_policy\">documentation</xref>",
             "google.cloud.resourcemanager_v3.set_iam_policy",
             ["Take", "a", "look", "at", "<xref"],
-            ""
+            None
         ],
     ]
     @parameterized.expand(test_reference_params)
-    def test_check_existing_references(self, word, keyword, converted_words, cross_reference_want):
-        current_name = "google.cloud.resourcemanager_v3.ProjectsClient"
+    def test_resolve_cross_reference(self, current_word, keyword, visited_words, cross_reference_want):
         content ="""Sets the IAM access control policy for the specified project.
 
 The following constraints apply when using google.cloud.resourcemanager_v3.ProjectsClient
@@ -338,10 +347,10 @@ Take a look at <xref uid="google.cloud.resourcemanager_v3.set_iam_policy">docume
         # Break up the paragraph into sanitized list of words as shown in Sphinx.
         words = " ".join(content.split("\n")).split(" ")
 
-        index = words.index(word)
+        index = words.index(current_word)
 
-        cross_reference_got = check_existing_references(
-            current_name, words, index, word, keyword, converted_words
+        cross_reference_got = resolve_cross_reference(
+            words, index, current_word, keyword, visited_words
         )
         self.assertEqual(cross_reference_got, cross_reference_want)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,6 @@
 from docfx_yaml.extension import extract_keyword
 from docfx_yaml.extension import indent_code_left
-from docfx_yaml.extension import resolve_cross_reference
+from docfx_yaml.extension import find_uid_to_convert
 from docfx_yaml.extension import convert_cross_references
 from docfx_yaml.extension import search_cross_references
 from docfx_yaml.extension import format_code
@@ -314,28 +314,36 @@ for i in range(10):
         [
             # If no reference keyword is found, check for None
             "google.cloud.resourcemanager_v3.ProjectsClient",
-            "google.cloud.resourcemanager_v1.ProjectsClient",
+            ["google.cloud.resourcemanager_v1.ProjectsClient"],
             ["The", "following", "constraints", "apply", "when", "using"],
             None
         ],
         [
             # If keyword reference is found, validate proper cross reference
             "google.cloud.resourcemanager_v3.set_iam_policy",
-            "google.cloud.resourcemanager_v3.set_iam_policy",
+            ["google.cloud.resourcemanager_v3.set_iam_policy"],
             ["A", "Policy", "is", "a", "collection", "of", "bindings", "from"],
-            "<xref uid=\"google.cloud.resourcemanager_v3.set_iam_policy\">google.cloud.resourcemanager_v3.set_iam_policy</xref>"
+            "google.cloud.resourcemanager_v3.set_iam_policy"
         ],
         [
             # If keyword reference has already been converted, do not convert
             # again.
             "uid=\"google.cloud.resourcemanager_v3.set_iam_policy\">documentation</xref>",
-            "google.cloud.resourcemanager_v3.set_iam_policy",
+            ["google.cloud.resourcemanager_v3.set_iam_policy"],
             ["Take", "a", "look", "at", "<xref"],
+            None
+        ],
+        [
+            # If no reference keyword is found, check for None
+            "google.cloud.resourcemanager_v3.ProjectsClient",
+            ["google.cloud.resourcemanager_v3.ProjectsClient"],
+            ["The", "following", "constraints", "apply", "when", "using"],
             None
         ],
     ]
     @parameterized.expand(test_reference_params)
-    def test_resolve_cross_reference(self, current_word, uid, visited_words, cross_reference_want):
+    def test_find_uid_to_convert(self, current_word, uids, visited_words, cross_reference_want):
+        current_object_name = "google.cloud.resourcemanager_v3.ProjectsClient"
         content ="""Sets the IAM access control policy for the specified project.
 
 The following constraints apply when using google.cloud.resourcemanager_v3.ProjectsClient
@@ -349,8 +357,8 @@ Take a look at <xref uid="google.cloud.resourcemanager_v3.set_iam_policy">docume
 
         index = words.index(current_word)
 
-        cross_reference_got = resolve_cross_reference(
-            current_word, words, index, uid, visited_words
+        cross_reference_got = find_uid_to_convert(
+            current_word, words, index, uids, current_object_name, visited_words
         )
         self.assertEqual(cross_reference_got, cross_reference_want)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,6 @@
 from docfx_yaml.extension import extract_keyword
 from docfx_yaml.extension import indent_code_left
+from docfx_yaml.extension import check_existing_references
 from docfx_yaml.extension import convert_cross_references
 from docfx_yaml.extension import search_cross_references
 from docfx_yaml.extension import format_code
@@ -301,6 +302,48 @@ for i in range(10):
 
             with open(want_filename) as mdfile_want:
                 self.assertEqual(test_file.read(), mdfile_want.read())
+
+
+    test_reference_params = [
+        [
+            "google.cloud.resourcemanager_v3.ProjectsClient",
+            "google.cloud.resourcemanager_v3.ProjectsClient",
+            ["The", "following", "constraints", "apply", "when", "using"],
+            ""
+        ],
+        [
+            "google.cloud.resourcemanager_v3.set_iam_policy",
+            "google.cloud.resourcemanager_v3.set_iam_policy",
+            ["A", "Policy", "is", "a", "collection", "of", "bindings", "from"],
+            "<xref uid=\"google.cloud.resourcemanager_v3.set_iam_policy\">google.cloud.resourcemanager_v3.set_iam_policy</xref>"
+        ],
+        [
+            "uid=\"google.cloud.resourcemanager_v3.set_iam_policy\">documentation</xref>",
+            "google.cloud.resourcemanager_v3.set_iam_policy",
+            ["Take", "a", "look", "at", "<xref"],
+            ""
+        ],
+    ]
+    @parameterized.expand(test_reference_params)
+    def test_check_existing_references(self, word, keyword, converted_words, cross_reference_want):
+        current_name = "google.cloud.resourcemanager_v3.ProjectsClient"
+        content ="""Sets the IAM access control policy for the specified project.
+
+The following constraints apply when using google.cloud.resourcemanager_v3.ProjectsClient
+
+A Policy is a collection of bindings from google.cloud.resourcemanager_v3.set_iam_policy
+
+Take a look at <xref uid="google.cloud.resourcemanager_v3.set_iam_policy">documentation</xref> for more information.
+"""
+        # Break up the paragraph into sanitized list of words as shown in Sphinx.
+        words = " ".join(content.split("\n")).split(" ")
+
+        index = words.index(word)
+
+        cross_reference_got = check_existing_references(
+            current_name, words, index, word, keyword, converted_words
+        )
+        self.assertEqual(cross_reference_got, cross_reference_want)
 
 
 if __name__ == '__main__':

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -350,7 +350,7 @@ Take a look at <xref uid="google.cloud.resourcemanager_v3.set_iam_policy">docume
         index = words.index(current_word)
 
         cross_reference_got = resolve_cross_reference(
-            words, index, current_word, keyword, visited_words
+            current_word, words, index, keyword, visited_words
         )
         self.assertEqual(cross_reference_got, cross_reference_want)
 


### PR DESCRIPTION
At the moment, there are 4 IAM libraries and it is very unclear to users which IAM library is referenced in the documentation. To make this worse, some of them don't have documentation that is generated to point to. The IAM team is reviewing combining all the libraries under `python-iam`, but until then it will remain unclear.

To temporarily address this, pointing the IAM references to the GitHub repository where the source code is located. This hard coded reference list can also be used for other common libraries that the documentation is missing references to, until we can figure out Intersphinx and hosting that on c.g.c.

Filed https://github.com/googleapis/sphinx-docfx-yaml/issues/208 to track removing the hard coded references in the future.

Fixes b/232773389.

- [x] Tests pass
