### PR TITLE
chore: Revert "chore(deps): update dependency ubuntu to v22"

### DIFF
--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ubuntu:22.04
+from ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Reverts googleapis/sphinx-docfx-yaml#205.

This update somehow seemed to have stopped Python3.8 interpreter showing up on the machines. Verified that the older version reverted to, still has Py3.8 interpreter available.