### PR TITLE
test: include dependency for librarytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands =
 [testenv:librarytest]
 deps =
     sphinx_rtd_theme
+    {[testenv]deps}
 changedir = {toxinidir}/docs
 commands =
     sphinx-build -D extensions=sphinx.ext.autodoc,sphinx.ext.autosummary,docfx_yaml.extension,sphinx.ext.intersphinx,sphinx.ext.coverage,sphinx.ext.napoleon,sphinx.ext.todo,sphinx.ext.viewcode -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html


### PR DESCRIPTION
Without pinning the dependency, the test runs the latest Sphinx version which currently is incompatible at the moment. This should be pinned regardless to test with consistent Sphinx version.

Fixes #214.

- [x] Tests pass
