### PR TITLE
ci: handle duplicate names for renamed packages

### DIFF
--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -115,8 +115,20 @@ for package in $(echo "${python_bucket_items}" | cut -d "-" -f 5- | rev | cut -d
     # Build YAML tarballs for Cloud-RAD.
     nox -s docfx
 
+    # Update specific names to be up to date.
+    name=$(jq --raw-output '.name // empty' .repo-metadata.json)
+    if [[ "${name}" == "translation" ]]; then
+      name="translate"
+    fi
+    if [[ "${name}" == "clouderroreporting" ]]; then
+      name="clouderrorreporting"
+    fi
+    if [[ "${name}" == "iam" ]]; then
+      name="iamcredentials"
+    fi
+
     python3 -m docuploader create-metadata \
-      --name=$(jq --raw-output '.name // empty' .repo-metadata.json) \
+      --name=${name} \
       --version=$(python3 setup.py --version) \
       --language=$(jq --raw-output '.language // empty' .repo-metadata.json) \
       --distribution-name=$(python3 setup.py --name) \


### PR DESCRIPTION
There are three packages that's been renamed that are producing different names based on the version they were released from:

```
iamcredentials
iam

translate
translation

clouderrorreporting
clouderroreporting
```

To avoid confusion, we should stay consistent throughout the version to stick with the renamed ones. This only affects how the tarballs are named, `docs.metadata` files and the path in which the files are stored (i.e. `python/docs/reference/translate/latest` instead of `python/docs/reference/translation/latest`). The content will still continue to remain the same.

I've manually verified that this fixes the names by generating the script with the following:

```
./generate-docs-old.sh > ~/workspace/tmp/log.txt
./generate-docs.sh > ~/workspace/tmp/log2.txt

cat ~/workspace/tmp/log.txt | sort -u  > ~/workspace/tmp/log_uniq.txt
cat ~/workspace/tmp/log2.txt | sort -u  > ~/workspace/tmp/log_uniq2.txt
diff ~/workspace/tmp/log.txt ~/workspace/tmp/log2.txt

31d30
< clouderroreporting
78d76
< iam
131d128
< translation
```
which took the two scripts with modifications to suppress output and compare before/after this change, modified the output and then ensured that the problematic package names were filtered out.

Fixes #191.

- [x] Tests pass
