### PR TITLE
ci: skip empty packages

### DIFF
--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -119,7 +119,7 @@ for package in $(echo "${python_bucket_items}" | cut -d "-" -f 5- | rev | cut -d
 
     # Check that documentation is produced. If not, log and continue.
     file_num=$(ls docs/_build/html/docfx_yaml/ | wc -l)
-    if [ ${file_num} -eq 0]; then
+    if [ ${file_num} -eq 0 ]; then
       empty_packages="${repo}-${tag} ${empty_packages}"
       continue
     fi

--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -118,8 +118,7 @@ for package in $(echo "${python_bucket_items}" | cut -d "-" -f 5- | rev | cut -d
     nox -s docfx
 
     # Check that documentation is produced. If not, log and continue.
-    file_num=$(ls docs/_build/html/docfx_yaml/ | wc -l)
-    if [ ${file_num} -eq 0 ]; then
+    if [ ! "$(ls docs/_build/html/docfx_yaml/)" ]; then
       empty_packages="${repo}-${tag} ${empty_packages}"
       continue
     fi

--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -38,6 +38,8 @@ python3 -m pip install --user django==2.2 ipython
 
 # Store the contents of bucket log in a variable to reuse.
 python_bucket_items=$(gsutil ls "gs://docs-staging-v2/docfx-python*")
+# Store empty tarballs that did not produce any content to check later.
+empty_packages=""
 # Retrieve unique repositories to regenerate the YAML with.
 for package in $(echo "${python_bucket_items}" | cut -d "-" -f 5- | rev | cut -d "-" -f 2- | rev | uniq); do
 
@@ -115,6 +117,13 @@ for package in $(echo "${python_bucket_items}" | cut -d "-" -f 5- | rev | cut -d
     # Build YAML tarballs for Cloud-RAD.
     nox -s docfx
 
+    # Check that documentation is produced. If not, log and continue.
+    file_num=$(ls docs/_build/html/docfx_yaml/ | wc -l)
+    if [ ${file_num} -eq 0]; then
+      empty_packages="${repo}-${tag} ${empty_packages}"
+      continue
+    fi
+
     # Update specific names to be up to date.
     name=$(jq --raw-output '.name // empty' .repo-metadata.json)
     if [[ "${name}" == "translation" ]]; then
@@ -146,4 +155,13 @@ for package in $(echo "${python_bucket_items}" | cut -d "-" -f 5- | rev | cut -d
   cd ../
   rm -rf ${repo}
   rm "noxfile.py"
+done
+
+if [ ! ${empty_packages} ]; then
+  exit
+fi
+
+echo "The following packages did not produce any content:"
+for empty_package in $(echo ${empty_packages}); do
+  echo ${empty_package}
 done


### PR DESCRIPTION
After running sphinx to build documentation, there wasn't any check to ensure that there is content produced. This caused issues like empty tarballs being passed and failing to build in the pipeline.

Adding in a check to see if any documentation has been produced by checking the contents of `docs/_build/html/docfx_yaml`, which is the output directory (In the near future I'll refactor this to make it a variable as `output_directory`). Simple check for `ls | wc -l` will suffice to check whether there's content in the directory or not.

Also adding in `empty_packages` to log the packages that did not produce any documentation; maybe this is expected or unexpected, but having this logged at the very end should help track things after running the script.

Fixes #225.
Fixes https://github.com/googleapis/doc-pipeline/issues/250.

- [x] Tests pass
