### PR TITLE
chore: use templated renovate.json

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -45,7 +45,6 @@ s.move(
         ".github/CONTRIBUTING.md",
         ".github/PULL_REQUEST_TEMPLATE.md",
         ".gitignore",
-        "renovate.json",
         ".github/workflows", # exclude templated gh actions
 	"README.rst",
     ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "config:base",
+    "group:all",
+    ":preserveSemverRanges",
+    ":disableDependencyDashboard"
+  ],
+  "ignorePaths": [".pre-commit-config.yaml", ".kokoro/requirements.txt"],
+  "pip_requirements": {
+    "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
+  }
+}


### PR DESCRIPTION
This will prevent renovate bot from opening PRs such as https://github.com/googleapis/sphinx-docfx-yaml/pull/232 for templated files