### PR TITLE
feat: use GitHub's default README as index page

### DIFF
--- a/tests/markdown_example_bad_image_links.md
+++ b/tests/markdown_example_bad_image_links.md
@@ -1,0 +1,23 @@
+# Python Client for Google Cloud Storage API
+
+[
+
+![image](https://img.shields.io/badge/support-stable-gold.svg)
+
+](https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels) [
+
+![image](https://img.shields.io/pypi/v/google-cloud-storage.svg)
+
+](https://pypi.org/project/google-cloud-storage/) [
+
+![image](https://img.shields.io/pypi/pyversions/google-cloud-storage.svg)
+
+](https://pypi.org/project/google-cloud-storage/)
+
+[Google Cloud Storage API](https://cloud.google.com/storage): is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.
+
+
+* [Client Library Documentation](https://cloud.google.com/python/docs/reference/storage/latest)
+
+
+* [Product Documentation](https://cloud.google.com/storage)

--- a/tests/markdown_example_bad_image_links_want.md
+++ b/tests/markdown_example_bad_image_links_want.md
@@ -1,0 +1,11 @@
+# Python Client for Google Cloud Storage API
+
+[![image](https://img.shields.io/badge/support-stable-gold.svg)](https://github.com/googleapis/google-cloud-python/blob/main/README.rst#stability-levels) [![image](https://img.shields.io/pypi/v/google-cloud-storage.svg)](https://pypi.org/project/google-cloud-storage/) [![image](https://img.shields.io/pypi/pyversions/google-cloud-storage.svg)](https://pypi.org/project/google-cloud-storage/)
+
+[Google Cloud Storage API](https://cloud.google.com/storage): is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.
+
+
+* [Client Library Documentation](https://cloud.google.com/python/docs/reference/storage/latest)
+
+
+* [Product Documentation](https://cloud.google.com/storage)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -7,6 +7,7 @@ from docfx_yaml.extension import format_code
 from docfx_yaml.extension import extract_product_name
 from docfx_yaml.extension import highlight_md_codeblocks
 from docfx_yaml.extension import prepend_markdown_header
+from docfx_yaml.extension import clean_image_links
 
 import unittest
 from parameterized import parameterized
@@ -304,6 +305,33 @@ for i in range(10):
                 test_file.seek(0)
 
             prepend_markdown_header(file_name, test_file)
+            test_file.seek(0)
+
+            with open(want_filename) as mdfile_want:
+                self.assertEqual(test_file.read(), mdfile_want.read())
+
+
+    # Filenames to test cleaning up markdown image links.
+    test_markdown_filenames = [
+        [
+            "tests/markdown_example_bad_image_links.md",
+            "tests/markdown_example_bad_image_links_want.md"
+        ],
+    ]
+    @parameterized.expand(test_markdown_filenames)
+    def test_clean_image_links(self, base_filename, want_filename):
+        # Ensure image links are well formed in markdown files.
+
+        # Copy the base file we'll need to test.
+        with tempfile.NamedTemporaryFile(mode='r+', delete=False) as test_file:
+            with open(base_filename) as base_file:
+                # Use same file name extraction as original code.
+                file_name = base_file.name.split("/")[-1].split(".")[0].capitalize()
+                test_file.write(base_file.read())
+                test_file.flush()
+                test_file.seek(0)
+
+            clean_image_links(test_file.name)
             test_file.seek(0)
 
             with open(want_filename) as mdfile_want:


### PR DESCRIPTION
Instead of using a custom index page that provided little to no benefit, this PR is incorporating the existing README as the main index page. This was asked by a lot of DPEs for their client libraries' landing page.

The markdown generator unfortunately messed around with the spacing for image links (see tests/markdown_example_bad_image_links.md file for reference), but all other parts I've verified is looking good. (See staged version of the doc for https://cloud.google.com/python/docs/reference/storage/latest). Adding a small parser to help fix that for the index file.

Fixes #105.
Fixes #107.

- [x] Tests pass
