### PR TITLE
fix: remove unused YAML fields to fix presubmit

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -935,11 +935,6 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
         'name': short_name,
         'fullName': name,
         'source': {
-            'remote': {
-                'path': path,
-                'branch': app.env.docfx_branch,
-                'repo': app.env.docfx_remote,
-            },
             'id': short_name,
             'path': path,
             'startLine': start_line,
@@ -1734,11 +1729,6 @@ def build_finished(app, exception):
 
                 except NameError:
                     pass
-
-                if 'source' in obj and (not obj['source']['remote']['repo'] or \
-                    obj['source']['remote']['repo'] == 'https://apidrop.visualstudio.com/Content%20CI/_git/ReferenceAutomation'):
-                        del(obj['source'])
-
 
                 # Extract any missing cross references where applicable.
                 # Potential targets are instances of full uid shown, or

--- a/tests/test_goldens.py
+++ b/tests/test_goldens.py
@@ -97,19 +97,6 @@ def test_goldens(update_goldens, test_dir):
 
     if update_goldens:
         shutil.rmtree(golden_dir, ignore_errors=True)
-        files_to_move = out_dir.rglob("*")
-
-        # Overwrite incorrect repo data used compared to GH Action.
-        incorrect_repo = "git@github.com:googleapis/sphinx-docfx-yaml.git"
-        correct_repo = "https://github.com/googleapis/sphinx-docfx-yaml"
-
-        for yaml_file in files_to_move:
-            with open(yaml_file) as file:
-                lines = file.read()
-            lines = lines.replace(incorrect_repo, correct_repo)
-            with open(yaml_file, 'w') as file:
-                file.write(lines)
-
         shutil.copytree(out_dir, golden_dir, dirs_exist_ok=True)
         pytest.skip(
             "Updated goldens! Re-run the test without the --update-goldens flag."

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.yml
@@ -35,10 +35,6 @@ items:
   source:
     id: TextToSpeechAsyncClient
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 41
   summary: 'Service that implements Google Cloud Text-to-Speech API.
 
@@ -65,10 +61,6 @@ items:
   source:
     id: TextToSpeechAsyncClient
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 41
   summary: 'Instantiates the text to speech client.
 
@@ -117,10 +109,6 @@ items:
   source:
     id: common_billing_account_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 185
   summary: 'Returns a fully-qualified billing_account string.
 
@@ -141,10 +129,6 @@ items:
   source:
     id: common_folder_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 200
   summary: 'Returns a fully-qualified folder string.
 
@@ -165,10 +149,6 @@ items:
   source:
     id: common_location_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 245
   summary: 'Returns a fully-qualified location string.
 
@@ -189,10 +169,6 @@ items:
   source:
     id: common_organization_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 215
   summary: 'Returns a fully-qualified organization string.
 
@@ -213,10 +189,6 @@ items:
   source:
     id: common_project_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 230
   summary: 'Returns a fully-qualified project string.
 
@@ -237,10 +209,6 @@ items:
   source:
     id: from_service_account_file
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 87
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  file.\n"
@@ -265,10 +233,6 @@ items:
   source:
     id: from_service_account_info
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 72
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  info.\n"
@@ -293,10 +257,6 @@ items:
   source:
     id: from_service_account_json
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 87
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  file.\n"
@@ -321,10 +281,6 @@ items:
   source:
     id: get_mtls_endpoint_and_cert_source
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 105
   summary: 'Return the API endpoint and client cert source for mutual TLS.
 
@@ -390,10 +346,6 @@ items:
   source:
     id: get_transport_class
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Returns an appropriate transport class.
 
@@ -413,10 +365,6 @@ items:
   source:
     id: list_voices
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 201
   summary: "Returns a list of Voice supported for synthesis.\n\n```python\n# This\
     \ snippet has been automatically generated and should be regarded as a\n# code\
@@ -477,10 +425,6 @@ items:
   source:
     id: model_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 163
   summary: 'Returns a fully-qualified model string.
 
@@ -501,10 +445,6 @@ items:
   source:
     id: parse_common_billing_account_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 194
   summary: 'Parse a billing_account path into its component segments.
 
@@ -525,10 +465,6 @@ items:
   source:
     id: parse_common_folder_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 209
   summary: 'Parse a folder path into its component segments.
 
@@ -549,10 +485,6 @@ items:
   source:
     id: parse_common_location_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 256
   summary: 'Parse a location path into its component segments.
 
@@ -573,10 +505,6 @@ items:
   source:
     id: parse_common_organization_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 224
   summary: 'Parse a organization path into its component segments.
 
@@ -597,10 +525,6 @@ items:
   source:
     id: parse_common_project_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 239
   summary: 'Parse a project path into its component segments.
 
@@ -621,10 +545,6 @@ items:
   source:
     id: parse_model_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 176
   summary: 'Parses a model path into its component segments.
 
@@ -645,10 +565,6 @@ items:
   source:
     id: synthesize_speech
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 303
   summary: "Synthesizes speech synchronously: receive results\nafter all text input\
     \ has been processed.\n\n```python\n# This snippet has been automatically generated\
@@ -723,10 +639,6 @@ items:
   source:
     id: transport
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Returns the transport used by the client instance.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.yml
@@ -35,10 +35,6 @@ items:
   source:
     id: TextToSpeechClient
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 78
   summary: 'Service that implements Google Cloud Text-to-Speech API.
 
@@ -65,10 +61,6 @@ items:
   source:
     id: TextToSpeechClient
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 78
   summary: 'Instantiates the text to speech client.
 
@@ -122,10 +114,6 @@ items:
   source:
     id: __exit__
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 661
   summary: 'Releases underlying transport''s resources.
 
@@ -156,10 +144,6 @@ items:
   source:
     id: common_billing_account_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 185
   summary: 'Returns a fully-qualified billing_account string.
 
@@ -180,10 +164,6 @@ items:
   source:
     id: common_folder_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 200
   summary: 'Returns a fully-qualified folder string.
 
@@ -204,10 +184,6 @@ items:
   source:
     id: common_location_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 245
   summary: 'Returns a fully-qualified location string.
 
@@ -228,10 +204,6 @@ items:
   source:
     id: common_organization_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 215
   summary: 'Returns a fully-qualified organization string.
 
@@ -252,10 +224,6 @@ items:
   source:
     id: common_project_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 230
   summary: 'Returns a fully-qualified project string.
 
@@ -276,10 +244,6 @@ items:
   source:
     id: from_service_account_file
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 133
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  file.\n"
@@ -304,10 +268,6 @@ items:
   source:
     id: from_service_account_info
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 116
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  info.\n"
@@ -332,10 +292,6 @@ items:
   source:
     id: from_service_account_json
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 133
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  file.\n"
@@ -360,10 +316,6 @@ items:
   source:
     id: get_mtls_endpoint_and_cert_source
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 262
   summary: 'Return the API endpoint and client cert source for mutual TLS.
 
@@ -429,10 +381,6 @@ items:
   source:
     id: list_voices
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 428
   summary: "Returns a list of Voice supported for synthesis.\n\n```python\n# This\
     \ snippet has been automatically generated and should be regarded as a\n# code\
@@ -493,10 +441,6 @@ items:
   source:
     id: model_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 163
   summary: 'Returns a fully-qualified model string.
 
@@ -517,10 +461,6 @@ items:
   source:
     id: parse_common_billing_account_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 194
   summary: 'Parse a billing_account path into its component segments.
 
@@ -541,10 +481,6 @@ items:
   source:
     id: parse_common_folder_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 209
   summary: 'Parse a folder path into its component segments.
 
@@ -565,10 +501,6 @@ items:
   source:
     id: parse_common_location_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 256
   summary: 'Parse a location path into its component segments.
 
@@ -589,10 +521,6 @@ items:
   source:
     id: parse_common_organization_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 224
   summary: 'Parse a organization path into its component segments.
 
@@ -613,10 +541,6 @@ items:
   source:
     id: parse_common_project_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 239
   summary: 'Parse a project path into its component segments.
 
@@ -637,10 +561,6 @@ items:
   source:
     id: parse_model_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 176
   summary: 'Parses a model path into its component segments.
 
@@ -661,10 +581,6 @@ items:
   source:
     id: synthesize_speech
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 530
   summary: "Synthesizes speech synchronously: receive results\nafter all text input\
     \ has been processed.\n\n```python\n# This snippet has been automatically generated\
@@ -739,10 +655,6 @@ items:
   source:
     id: transport
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Returns the transport used by the client instance.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.yml
@@ -12,10 +12,6 @@ items:
   source:
     id: text_to_speech
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/__init__.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/services/text_to_speech/__init__.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `texttospeech_v1.services.text_to_speech` package.
   syntax: {}

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.AudioConfig.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.AudioConfig.yml
@@ -57,10 +57,6 @@ items:
   source:
     id: AudioConfig
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 262
   summary: 'Description of audio data to be synthesized.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.AudioEncoding.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.AudioEncoding.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: AudioEncoding
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 46
   summary: 'Configuration to set up audio encoder. The encoding
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.CustomVoiceParams.ReportedUsage.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.CustomVoiceParams.ReportedUsage.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: ReportedUsage
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 348
   summary: 'The usage of the synthesized audio. You must report your
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.CustomVoiceParams.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.CustomVoiceParams.yml
@@ -24,10 +24,6 @@ items:
   source:
     id: CustomVoiceParams
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 336
   summary: 'Description of the custom voice to be synthesized.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.ListVoicesRequest.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.ListVoicesRequest.yml
@@ -25,10 +25,6 @@ items:
   source:
     id: ListVoicesRequest
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 58
   summary: 'The top-level message sent by the client for the `ListVoices`
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.ListVoicesResponse.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.ListVoicesResponse.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: ListVoicesResponse
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 81
   summary: 'The message returned to the client by the `ListVoices` method.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SsmlVoiceGender.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SsmlVoiceGender.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: SsmlVoiceGender
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 36
   summary: 'Gender of the voice as described in `SSML voice
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesisInput.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesisInput.yml
@@ -26,10 +26,6 @@ items:
   source:
     id: SynthesisInput
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 166
   summary: 'Contains text input to be synthesized. Either `text` or `ssml`
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesizeSpeechRequest.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesizeSpeechRequest.yml
@@ -26,10 +26,6 @@ items:
   source:
     id: SynthesizeSpeechRequest
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 133
   summary: 'The top-level message sent by the client for the
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesizeSpeechResponse.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesizeSpeechResponse.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: SynthesizeSpeechResponse
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 368
   summary: 'The message returned to the client by the `SynthesizeSpeech`
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.Voice.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.Voice.yml
@@ -30,10 +30,6 @@ items:
   source:
     id: Voice
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 96
   summary: 'Description of a voice supported by the TTS service.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.VoiceSelectionParams.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.VoiceSelectionParams.yml
@@ -45,10 +45,6 @@ items:
   source:
     id: VoiceSelectionParams
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 206
   summary: 'Description of which voice to use for a synthesis request.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.yml
@@ -21,10 +21,6 @@ items:
   source:
     id: types
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/__init__.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1/types/__init__.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `texttospeech_v1.types` package.
   syntax: {}

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.yml
@@ -35,10 +35,6 @@ items:
   source:
     id: TextToSpeechAsyncClient
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 41
   summary: 'Service that implements Google Cloud Text-to-Speech API.
 
@@ -65,10 +61,6 @@ items:
   source:
     id: TextToSpeechAsyncClient
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 41
   summary: 'Instantiates the text to speech client.
 
@@ -117,10 +109,6 @@ items:
   source:
     id: common_billing_account_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 185
   summary: 'Returns a fully-qualified billing_account string.
 
@@ -141,10 +129,6 @@ items:
   source:
     id: common_folder_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 200
   summary: 'Returns a fully-qualified folder string.
 
@@ -165,10 +149,6 @@ items:
   source:
     id: common_location_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 245
   summary: 'Returns a fully-qualified location string.
 
@@ -189,10 +169,6 @@ items:
   source:
     id: common_organization_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 215
   summary: 'Returns a fully-qualified organization string.
 
@@ -213,10 +189,6 @@ items:
   source:
     id: common_project_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 230
   summary: 'Returns a fully-qualified project string.
 
@@ -237,10 +209,6 @@ items:
   source:
     id: from_service_account_file
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 87
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  file.\n"
@@ -265,10 +233,6 @@ items:
   source:
     id: from_service_account_info
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 72
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  info.\n"
@@ -293,10 +257,6 @@ items:
   source:
     id: from_service_account_json
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 87
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  file.\n"
@@ -321,10 +281,6 @@ items:
   source:
     id: get_mtls_endpoint_and_cert_source
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 105
   summary: 'Return the API endpoint and client cert source for mutual TLS.
 
@@ -390,10 +346,6 @@ items:
   source:
     id: get_transport_class
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Returns an appropriate transport class.
 
@@ -413,10 +365,6 @@ items:
   source:
     id: list_voices
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 201
   summary: "Returns a list of Voice supported for synthesis.\n\n```python\n# This\
     \ snippet has been automatically generated and should be regarded as a\n# code\
@@ -477,10 +425,6 @@ items:
   source:
     id: model_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 163
   summary: 'Returns a fully-qualified model string.
 
@@ -501,10 +445,6 @@ items:
   source:
     id: parse_common_billing_account_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 194
   summary: 'Parse a billing_account path into its component segments.
 
@@ -525,10 +465,6 @@ items:
   source:
     id: parse_common_folder_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 209
   summary: 'Parse a folder path into its component segments.
 
@@ -549,10 +485,6 @@ items:
   source:
     id: parse_common_location_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 256
   summary: 'Parse a location path into its component segments.
 
@@ -573,10 +505,6 @@ items:
   source:
     id: parse_common_organization_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 224
   summary: 'Parse a organization path into its component segments.
 
@@ -597,10 +525,6 @@ items:
   source:
     id: parse_common_project_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 239
   summary: 'Parse a project path into its component segments.
 
@@ -621,10 +545,6 @@ items:
   source:
     id: parse_model_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 176
   summary: 'Parses a model path into its component segments.
 
@@ -645,10 +565,6 @@ items:
   source:
     id: synthesize_speech
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 303
   summary: "Synthesizes speech synchronously: receive results\nafter all text input\
     \ has been processed.\n\n```python\n# This snippet has been automatically generated\
@@ -723,10 +639,6 @@ items:
   source:
     id: transport
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Returns the transport used by the client instance.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.yml
@@ -35,10 +35,6 @@ items:
   source:
     id: TextToSpeechClient
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 78
   summary: 'Service that implements Google Cloud Text-to-Speech API.
 
@@ -65,10 +61,6 @@ items:
   source:
     id: TextToSpeechClient
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 78
   summary: 'Instantiates the text to speech client.
 
@@ -122,10 +114,6 @@ items:
   source:
     id: __exit__
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 661
   summary: 'Releases underlying transport''s resources.
 
@@ -156,10 +144,6 @@ items:
   source:
     id: common_billing_account_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 185
   summary: 'Returns a fully-qualified billing_account string.
 
@@ -180,10 +164,6 @@ items:
   source:
     id: common_folder_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 200
   summary: 'Returns a fully-qualified folder string.
 
@@ -204,10 +184,6 @@ items:
   source:
     id: common_location_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 245
   summary: 'Returns a fully-qualified location string.
 
@@ -228,10 +204,6 @@ items:
   source:
     id: common_organization_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 215
   summary: 'Returns a fully-qualified organization string.
 
@@ -252,10 +224,6 @@ items:
   source:
     id: common_project_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 230
   summary: 'Returns a fully-qualified project string.
 
@@ -276,10 +244,6 @@ items:
   source:
     id: from_service_account_file
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 133
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  file.\n"
@@ -304,10 +268,6 @@ items:
   source:
     id: from_service_account_info
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 116
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  info.\n"
@@ -332,10 +292,6 @@ items:
   source:
     id: from_service_account_json
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 133
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  file.\n"
@@ -360,10 +316,6 @@ items:
   source:
     id: get_mtls_endpoint_and_cert_source
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 262
   summary: 'Return the API endpoint and client cert source for mutual TLS.
 
@@ -429,10 +381,6 @@ items:
   source:
     id: list_voices
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 428
   summary: "Returns a list of Voice supported for synthesis.\n\n```python\n# This\
     \ snippet has been automatically generated and should be regarded as a\n# code\
@@ -493,10 +441,6 @@ items:
   source:
     id: model_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 163
   summary: 'Returns a fully-qualified model string.
 
@@ -517,10 +461,6 @@ items:
   source:
     id: parse_common_billing_account_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 194
   summary: 'Parse a billing_account path into its component segments.
 
@@ -541,10 +481,6 @@ items:
   source:
     id: parse_common_folder_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 209
   summary: 'Parse a folder path into its component segments.
 
@@ -565,10 +501,6 @@ items:
   source:
     id: parse_common_location_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 256
   summary: 'Parse a location path into its component segments.
 
@@ -589,10 +521,6 @@ items:
   source:
     id: parse_common_organization_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 224
   summary: 'Parse a organization path into its component segments.
 
@@ -613,10 +541,6 @@ items:
   source:
     id: parse_common_project_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 239
   summary: 'Parse a project path into its component segments.
 
@@ -637,10 +561,6 @@ items:
   source:
     id: parse_model_path
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 176
   summary: 'Parses a model path into its component segments.
 
@@ -661,10 +581,6 @@ items:
   source:
     id: synthesize_speech
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 530
   summary: "Synthesizes speech synchronously: receive results\nafter all text input\
     \ has been processed.\n\n```python\n# This snippet has been automatically generated\
@@ -739,10 +655,6 @@ items:
   source:
     id: transport
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Returns the transport used by the client instance.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.yml
@@ -12,10 +12,6 @@ items:
   source:
     id: text_to_speech
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/__init__.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/services/text_to_speech/__init__.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `texttospeech_v1beta1.services.text_to_speech` package.
   syntax: {}

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.AudioConfig.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.AudioConfig.yml
@@ -57,10 +57,6 @@ items:
   source:
     id: AudioConfig
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 279
   summary: 'Description of audio data to be synthesized.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.AudioEncoding.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.AudioEncoding.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: AudioEncoding
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 47
   summary: 'Configuration to set up audio encoder. The encoding
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.ReportedUsage.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.ReportedUsage.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: ReportedUsage
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 365
   summary: 'The usage of the synthesized audio. You must report your
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.yml
@@ -24,10 +24,6 @@ items:
   source:
     id: CustomVoiceParams
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 353
   summary: 'Description of the custom voice to be synthesized.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.ListVoicesRequest.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.ListVoicesRequest.yml
@@ -25,10 +25,6 @@ items:
   source:
     id: ListVoicesRequest
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 60
   summary: 'The top-level message sent by the client for the `ListVoices`
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.ListVoicesResponse.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.ListVoicesResponse.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: ListVoicesResponse
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 83
   summary: 'The message returned to the client by the `ListVoices` method.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SsmlVoiceGender.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SsmlVoiceGender.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: SsmlVoiceGender
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 37
   summary: 'Gender of the voice as described in `SSML voice
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesisInput.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesisInput.yml
@@ -26,10 +26,6 @@ items:
   source:
     id: SynthesisInput
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 183
   summary: 'Contains text input to be synthesized. Either `text` or `ssml`
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: TimepointType
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 154
   summary: 'The type of timepoint information that is returned in the
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.yml
@@ -30,10 +30,6 @@ items:
   source:
     id: SynthesizeSpeechRequest
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 135
   summary: 'The top-level message sent by the client for the
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechResponse.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechResponse.yml
@@ -31,10 +31,6 @@ items:
   source:
     id: SynthesizeSpeechResponse
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 385
   summary: 'The message returned to the client by the `SynthesizeSpeech`
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.Timepoint.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.Timepoint.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: Timepoint
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 421
   summary: 'This contains a mapping between a certain point in the input
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.Voice.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.Voice.yml
@@ -30,10 +30,6 @@ items:
   source:
     id: Voice
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 98
   summary: 'Description of a voice supported by the TTS service.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.VoiceSelectionParams.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.VoiceSelectionParams.yml
@@ -45,10 +45,6 @@ items:
   source:
     id: VoiceSelectionParams
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 223
   summary: 'Description of which voice to use for a synthesis request.
 

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.yml
@@ -22,10 +22,6 @@ items:
   source:
     id: types
     path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/__init__.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-auto/google/cloud/texttospeech_v1beta1/types/__init__.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `texttospeech_v1beta1.types` package.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.client.Client.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.client.Client.yml
@@ -56,10 +56,6 @@ items:
   source:
     id: Client
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 65
   summary: 'A publisher client for Google Cloud Pub/Sub.
 
@@ -93,10 +89,6 @@ items:
   source:
     id: Client
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 65
   summary: 'Instantiates the publisher client.
 
@@ -149,10 +141,6 @@ items:
   source:
     id: __exit__
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1430
   summary: 'Releases underlying transport''s resources.
 
@@ -184,10 +172,6 @@ items:
   source:
     id: api
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: "The underlying gapic API client.\n\n.. versionchanged:: 2.10.0\n    Instead\
     \ of a GAPIC `PublisherClient` client instance, this property is a\n    proxy\
@@ -208,10 +192,6 @@ items:
   source:
     id: common_billing_account_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 236
   summary: 'Returns a fully-qualified billing_account string.
 
@@ -232,10 +212,6 @@ items:
   source:
     id: common_folder_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 251
   summary: 'Returns a fully-qualified folder string.
 
@@ -256,10 +232,6 @@ items:
   source:
     id: common_location_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 296
   summary: 'Returns a fully-qualified location string.
 
@@ -280,10 +252,6 @@ items:
   source:
     id: common_organization_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 266
   summary: 'Returns a fully-qualified organization string.
 
@@ -304,10 +272,6 @@ items:
   source:
     id: common_project_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 281
   summary: 'Returns a fully-qualified project string.
 
@@ -328,10 +292,6 @@ items:
   source:
     id: create_topic
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 488
   summary: "Creates the given topic with the given name. See the [resource\nname rules]\n\
     (https://cloud.google.com/pubsub/docs/admin#resource_names).\n\n```python\n# This\
@@ -391,10 +351,6 @@ items:
   source:
     id: delete_topic
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1243
   summary: "Deletes the topic with the given name. Returns `NOT_FOUND` if\nthe topic\
     \ does not exist. After a topic is deleted, a new topic\nmay be created with the\
@@ -448,10 +404,6 @@ items:
   source:
     id: detach_subscription
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1339
   summary: "Detaches a subscription from this topic. All messages retained\nin the\
     \ subscription are dropped. Subsequent `Pull` and\n`StreamingPull` requests will\
@@ -503,10 +455,6 @@ items:
   source:
     id: ensure_cleanup_and_commit_timer_runs
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 421
   summary: 'Ensure a cleanup/commit timer thread is running.
 
@@ -530,10 +478,6 @@ items:
   source:
     id: from_service_account_file
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 161
   summary: 'Creates an instance of this client using the provided credentials
 
@@ -557,10 +501,6 @@ items:
   source:
     id: from_service_account_info
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 136
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  info.\n"
@@ -585,10 +525,6 @@ items:
   source:
     id: from_service_account_json
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 161
   summary: 'Creates an instance of this client using the provided credentials
 
@@ -612,10 +548,6 @@ items:
   source:
     id: get_iam_policy
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1561
   summary: 'Gets the IAM access control policy for a function.
 
@@ -683,10 +615,6 @@ items:
   source:
     id: get_mtls_endpoint_and_cert_source
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 313
   summary: 'Return the API endpoint and client cert source for mutual TLS.
 
@@ -752,10 +680,6 @@ items:
   source:
     id: get_topic
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 791
   summary: "Gets the configuration of a topic.\n\n```python\n# This snippet has been\
     \ automatically generated and should be regarded as a\n# code template only.\n\
@@ -809,10 +733,6 @@ items:
   source:
     id: list_topic_snapshots
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1122
   summary: "Lists the names of the snapshots on this topic. Snapshots are\nused in\n\
     `Seek <https://cloud.google.com/pubsub/docs/replay-overview>`__\noperations, which\
@@ -874,10 +794,6 @@ items:
   source:
     id: list_topic_subscriptions
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1005
   summary: "Lists the names of the attached subscriptions on this\ntopic.\n\n```python\n\
     # This snippet has been automatically generated and should be regarded as a\n\
@@ -935,10 +851,6 @@ items:
   source:
     id: list_topics
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 891
   summary: "Lists matching topics.\n\n```python\n# This snippet has been automatically\
     \ generated and should be regarded as a\n# code template only.\n# It will require\
@@ -995,10 +907,6 @@ items:
   source:
     id: parse_common_billing_account_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 245
   summary: 'Parse a billing_account path into its component segments.
 
@@ -1019,10 +927,6 @@ items:
   source:
     id: parse_common_folder_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 260
   summary: 'Parse a folder path into its component segments.
 
@@ -1043,10 +947,6 @@ items:
   source:
     id: parse_common_location_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 307
   summary: 'Parse a location path into its component segments.
 
@@ -1067,10 +967,6 @@ items:
   source:
     id: parse_common_organization_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 275
   summary: 'Parse a organization path into its component segments.
 
@@ -1091,10 +987,6 @@ items:
   source:
     id: parse_common_project_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 290
   summary: 'Parse a project path into its component segments.
 
@@ -1115,10 +1007,6 @@ items:
   source:
     id: parse_schema_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 194
   summary: 'Parses a schema path into its component segments.
 
@@ -1139,10 +1027,6 @@ items:
   source:
     id: parse_subscription_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 211
   summary: 'Parses a subscription path into its component segments.
 
@@ -1163,10 +1047,6 @@ items:
   source:
     id: parse_topic_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 230
   summary: 'Parses a topic path into its component segments.
 
@@ -1187,10 +1067,6 @@ items:
   source:
     id: publish
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 274
   summary: "Publish a single message.\n\n<aside class=\"note\">\n<b>Note:</b>\nMessages\
     \ in Pub/Sub are blobs of bytes. They are *binary* data,\nnot text. You must send\
@@ -1232,10 +1108,6 @@ items:
   source:
     id: resume_publish
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 234
   summary: 'Resume publish on an ordering key that has had unrecoverable errors.
 
@@ -1262,10 +1134,6 @@ items:
   source:
     id: schema_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 183
   summary: 'Returns a fully-qualified schema string.
 
@@ -1286,10 +1154,6 @@ items:
   source:
     id: set_iam_policy
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1440
   summary: 'Sets the IAM access control policy on the specified function.
 
@@ -1355,10 +1219,6 @@ items:
   source:
     id: stop
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 475
   summary: 'Immediately publish all outstanding messages.
 
@@ -1402,10 +1262,6 @@ items:
   source:
     id: subscription_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 200
   summary: 'Returns a fully-qualified subscription string.
 
@@ -1427,10 +1283,6 @@ items:
   source:
     id: target
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the target (where the API is).
 
@@ -1449,10 +1301,6 @@ items:
   source:
     id: test_iam_permissions
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1683
   summary: "Tests the specified IAM permissions against the IAM access control\n \
     \   policy for a function.\n\nIf the function does not exist, this will return\
@@ -1494,10 +1342,6 @@ items:
   source:
     id: topic_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 219
   summary: 'Returns a fully-qualified topic string.
 
@@ -1519,10 +1363,6 @@ items:
   source:
     id: transport
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Returns the transport used by the client instance.
 
@@ -1544,10 +1384,6 @@ items:
   source:
     id: update_topic
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 596
   summary: "Updates an existing topic. Note that certain\nproperties of a topic are\
     \ not modifiable.\n\n```python\n# This snippet has been automatically generated\

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.client.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.client.yml
@@ -11,10 +11,6 @@ items:
   source:
     id: client
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `pubsub_v1.publisher.client` module.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.futures.Future.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.futures.Future.yml
@@ -32,10 +32,6 @@ items:
   source:
     id: Future
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 26
   summary: 'This future object is returned from asychronous Pub/Sub publishing
 
@@ -72,10 +68,6 @@ items:
   source:
     id: Future
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 26
   summary: 'Initializes the future. Should not be called by clients.
 
@@ -96,10 +88,6 @@ items:
   source:
     id: add_done_callback
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 69
   summary: 'Attach a callable that will be called when the future finishes.
 
@@ -120,10 +108,6 @@ items:
   source:
     id: cancel
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 34
   summary: 'Actions in Pub/Sub generally may not be canceled.
 
@@ -147,10 +131,6 @@ items:
   source:
     id: cancelled
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 41
   summary: 'Actions in Pub/Sub generally may not be canceled.
 
@@ -174,10 +154,6 @@ items:
   source:
     id: done
     path: concurrent/futures/_base.py
-    remote:
-      branch: add_goldens
-      path: concurrent/futures/_base.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 383
   summary: 'Return True if the future was cancelled or finished executing.
 
@@ -198,10 +174,6 @@ items:
   source:
     id: exception
     path: concurrent/futures/_base.py
-    remote:
-      branch: add_goldens
-      path: concurrent/futures/_base.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 453
   summary: 'Return the exception raised by the call that the future represents.
 
@@ -226,10 +198,6 @@ items:
   source:
     id: result
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 48
   summary: 'Return the message ID or raise an exception.
 
@@ -259,10 +227,6 @@ items:
   source:
     id: running
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 33
   summary: 'Return `True` if the associated Pub/Sub action has not yet completed.
 
@@ -283,10 +247,6 @@ items:
   source:
     id: set_exception
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 50
   summary: 'Set the result of the future as being the given exception.
 
@@ -312,10 +272,6 @@ items:
   source:
     id: set_result
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 42
   summary: 'Set the return value of work associated with the future.
 
@@ -341,10 +297,6 @@ items:
   source:
     id: set_running_or_notify_cancel
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 37
   summary: 'Mark the future as running or process any cancel notifications.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.futures.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.futures.yml
@@ -11,10 +11,6 @@ items:
   source:
     id: futures
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/publisher/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `pubsub_v1.publisher.futures` module.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.client.Client.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.client.Client.yml
@@ -62,10 +62,6 @@ items:
   source:
     id: Client
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 46
   summary: 'A subscriber client for Google Cloud Pub/Sub.
 
@@ -96,10 +92,6 @@ items:
   source:
     id: Client
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 46
   summary: 'Instantiates the subscriber client.
 
@@ -149,10 +141,6 @@ items:
   source:
     id: acknowledge
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1203
   summary: "Acknowledges the messages associated with the `ack_ids` in the\n`AcknowledgeRequest`.\
     \ The Pub/Sub system can remove the\nrelevant messages from the subscription.\n\
@@ -215,10 +203,6 @@ items:
   source:
     id: api
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: "The underlying gapic API client.\n\n.. versionchanged:: 2.10.0\n    Instead\
     \ of a GAPIC `SubscriberClient` client instance, this property is a\n    proxy\
@@ -239,10 +223,6 @@ items:
   source:
     id: close
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 271
   summary: 'Close the underlying channel to release socket resources.
 
@@ -272,10 +252,6 @@ items:
   source:
     id: closed
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return whether the client has been closed and cannot be used anymore.
 
@@ -298,10 +274,6 @@ items:
   source:
     id: common_billing_account_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 248
   summary: 'Returns a fully-qualified billing_account string.
 
@@ -322,10 +294,6 @@ items:
   source:
     id: common_folder_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 263
   summary: 'Returns a fully-qualified folder string.
 
@@ -346,10 +314,6 @@ items:
   source:
     id: common_location_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 308
   summary: 'Returns a fully-qualified location string.
 
@@ -370,10 +334,6 @@ items:
   source:
     id: common_organization_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 278
   summary: 'Returns a fully-qualified organization string.
 
@@ -394,10 +354,6 @@ items:
   source:
     id: common_project_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 293
   summary: 'Returns a fully-qualified project string.
 
@@ -418,10 +374,6 @@ items:
   source:
     id: create_snapshot
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1892
   summary: "Creates a snapshot from the requested subscription. Snapshots\nare used\
     \ in\n`Seek <https://cloud.google.com/pubsub/docs/replay-overview>`__\noperations,\
@@ -505,10 +457,6 @@ items:
   source:
     id: create_subscription
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 500
   summary: "Creates a subscription to a given topic. See the [resource name\nrules]\n\
     (https://cloud.google.com/pubsub/docs/admin#resource_names). If\nthe subscription\
@@ -611,10 +559,6 @@ items:
   source:
     id: delete_snapshot
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2133
   summary: "Removes an existing snapshot. Snapshots are used in [Seek]\n(https://cloud.google.com/pubsub/docs/replay-overview)\n\
     operations, which allow you to manage message acknowledgments in\nbulk. That is,\
@@ -671,10 +615,6 @@ items:
   source:
     id: delete_subscription
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 980
   summary: "Deletes an existing subscription. All messages retained in the\nsubscription\
     \ are immediately dropped. Calls to `Pull` after\ndeletion will return `NOT_FOUND`.\
@@ -727,10 +667,6 @@ items:
   source:
     id: from_service_account_file
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 91
   summary: 'Creates an instance of this client using the provided credentials
 
@@ -752,10 +688,6 @@ items:
   source:
     id: from_service_account_info
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 148
   summary: "Creates an instance of this client using the provided credentials\n  \
     \  info.\n"
@@ -780,10 +712,6 @@ items:
   source:
     id: from_service_account_json
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 91
   summary: 'Creates an instance of this client using the provided credentials
 
@@ -805,10 +733,6 @@ items:
   source:
     id: get_iam_policy
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2453
   summary: 'Gets the IAM access control policy for a function.
 
@@ -875,10 +799,6 @@ items:
   source:
     id: get_mtls_endpoint_and_cert_source
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 325
   summary: 'Return the API endpoint and client cert source for mutual TLS.
 
@@ -944,10 +864,6 @@ items:
   source:
     id: get_snapshot
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1663
   summary: "Gets the configuration details of a snapshot.\nSnapshots are used in <a\n\
     href=\"https://cloud.google.com/pubsub/docs/replay-overview\">Seek</a>\noperations,\
@@ -1006,10 +922,6 @@ items:
   source:
     id: get_subscription
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 677
   summary: "Gets the configuration details of a subscription.\n\n```python\n# This\
     \ snippet has been automatically generated and should be regarded as a\n# code\
@@ -1061,10 +973,6 @@ items:
   source:
     id: list_snapshots
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1774
   summary: "Lists the existing snapshots. Snapshots are used in\n`Seek <https://cloud.google.com/pubsub/docs/replay-overview>`__\n\
     operations, which allow you to manage message acknowledgments in\nbulk. That is,\
@@ -1123,10 +1031,6 @@ items:
   source:
     id: list_subscriptions
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 866
   summary: "Lists matching subscriptions.\n\n```python\n# This snippet has been automatically\
     \ generated and should be regarded as a\n# code template only.\n# It will require\
@@ -1182,10 +1086,6 @@ items:
   source:
     id: modify_ack_deadline
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1077
   summary: "Modifies the ack deadline for a specific message. This method is\nuseful\
     \ to indicate that more time is needed to process a message\nby the subscriber,\
@@ -1258,10 +1158,6 @@ items:
   source:
     id: modify_push_config
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1550
   summary: "Modifies the `PushConfig` for a specified subscription.\n\nThis may be\
     \ used to change a push subscription to a pull one\n(signified by an empty `PushConfig`)\
@@ -1324,10 +1220,6 @@ items:
   source:
     id: parse_common_billing_account_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 257
   summary: 'Parse a billing_account path into its component segments.
 
@@ -1348,10 +1240,6 @@ items:
   source:
     id: parse_common_folder_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 272
   summary: 'Parse a folder path into its component segments.
 
@@ -1372,10 +1260,6 @@ items:
   source:
     id: parse_common_location_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 319
   summary: 'Parse a location path into its component segments.
 
@@ -1396,10 +1280,6 @@ items:
   source:
     id: parse_common_organization_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 287
   summary: 'Parse a organization path into its component segments.
 
@@ -1420,10 +1300,6 @@ items:
   source:
     id: parse_common_project_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 302
   summary: 'Parse a project path into its component segments.
 
@@ -1444,10 +1320,6 @@ items:
   source:
     id: parse_snapshot_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 206
   summary: 'Parses a snapshot path into its component segments.
 
@@ -1468,10 +1340,6 @@ items:
   source:
     id: parse_subscription_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 223
   summary: 'Parses a subscription path into its component segments.
 
@@ -1492,10 +1360,6 @@ items:
   source:
     id: parse_topic_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 242
   summary: 'Parses a topic path into its component segments.
 
@@ -1516,10 +1380,6 @@ items:
   source:
     id: pull
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1314
   summary: "Pulls messages from the server. The server may return\n`UNAVAILABLE` if\
     \ there are too many concurrent pull requests\npending for the given subscription.\n\
@@ -1594,10 +1454,6 @@ items:
   source:
     id: seek
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2232
   summary: "Seeks an existing subscription to a point in time or to a given\nsnapshot,\
     \ whichever is provided in the request. Snapshots are\nused in [Seek]\n(https://cloud.google.com/pubsub/docs/replay-overview)\n\
@@ -1649,10 +1505,6 @@ items:
   source:
     id: set_iam_policy
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2333
   summary: 'Sets the IAM access control policy on the specified function.
 
@@ -1717,10 +1569,6 @@ items:
   source:
     id: snapshot_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 195
   summary: 'Returns a fully-qualified snapshot string.
 
@@ -1741,10 +1589,6 @@ items:
   source:
     id: streaming_pull
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1455
   summary: "Establishes a stream with the server, which sends messages down\nto the\
     \ client. The client streams acknowledgements and ack\ndeadline modifications\
@@ -1806,10 +1650,6 @@ items:
   source:
     id: subscribe
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 149
   summary: "Asynchronously start receiving messages on a given subscription.\n\nThis\
     \ method starts a background thread to begin pulling messages from\na Pub/Sub\
@@ -1866,10 +1706,6 @@ items:
   source:
     id: subscription_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 212
   summary: 'Returns a fully-qualified subscription string.
 
@@ -1891,10 +1727,6 @@ items:
   source:
     id: target
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the target (where the API is).
 
@@ -1913,10 +1745,6 @@ items:
   source:
     id: test_iam_permissions
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2574
   summary: "Tests the specified IAM permissions against the IAM access control\n \
     \   policy for a function.\n\nIf the function does not exist, this will return\
@@ -1957,10 +1785,6 @@ items:
   source:
     id: topic_path
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 231
   summary: 'Returns a fully-qualified topic string.
 
@@ -1982,10 +1806,6 @@ items:
   source:
     id: transport
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Returns the transport used by the client instance.
 
@@ -2007,10 +1827,6 @@ items:
   source:
     id: update_snapshot
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2040
   summary: "Updates an existing snapshot. Snapshots are used in\n<a\nhref=\"https://cloud.google.com/pubsub/docs/replay-overview\"\
     >Seek</a>\noperations, which allow\nyou to manage message acknowledgments in bulk.\
@@ -2063,10 +1879,6 @@ items:
   source:
     id: update_subscription
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 779
   summary: "Updates an existing subscription. Note that certain\nproperties of a subscription,\
     \ such as its topic, are not\nmodifiable.\n\n```python\n# This snippet has been\

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.client.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.client.yml
@@ -11,10 +11,6 @@ items:
   source:
     id: client
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `pubsub_v1.subscriber.client` module.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.Future.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.Future.yml
@@ -32,10 +32,6 @@ items:
   source:
     id: Future
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 86
   summary: 'This future object is for subscribe-side calls.
 
@@ -70,10 +66,6 @@ items:
   source:
     id: Future
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 86
   summary: 'Initializes the future. Should not be called by clients.
 
@@ -94,10 +86,6 @@ items:
   source:
     id: add_done_callback
     path: concurrent/futures/_base.py
-    remote:
-      branch: add_goldens
-      path: concurrent/futures/_base.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 398
   summary: 'Attaches a callable that will be called when the future finishes.
 
@@ -117,10 +105,6 @@ items:
   source:
     id: cancel
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 93
   summary: 'Actions in Pub/Sub generally may not be canceled.
 
@@ -144,10 +128,6 @@ items:
   source:
     id: cancelled
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 100
   summary: 'Actions in Pub/Sub generally may not be canceled.
 
@@ -171,10 +151,6 @@ items:
   source:
     id: done
     path: concurrent/futures/_base.py
-    remote:
-      branch: add_goldens
-      path: concurrent/futures/_base.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 383
   summary: 'Return True if the future was cancelled or finished executing.
 
@@ -195,10 +171,6 @@ items:
   source:
     id: exception
     path: concurrent/futures/_base.py
-    remote:
-      branch: add_goldens
-      path: concurrent/futures/_base.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 453
   summary: 'Return the exception raised by the call that the future represents.
 
@@ -223,10 +195,6 @@ items:
   source:
     id: result
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 107
   summary: 'Return a success code or raise an exception.
 
@@ -256,10 +224,6 @@ items:
   source:
     id: running
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 33
   summary: 'Return `True` if the associated Pub/Sub action has not yet completed.
 
@@ -280,10 +244,6 @@ items:
   source:
     id: set_exception
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 50
   summary: 'Set the result of the future as being the given exception.
 
@@ -309,10 +269,6 @@ items:
   source:
     id: set_result
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 42
   summary: 'Set the return value of work associated with the future.
 
@@ -338,10 +294,6 @@ items:
   source:
     id: set_running_or_notify_cancel
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 37
   summary: 'Mark the future as running or process any cancel notifications.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.yml
@@ -32,10 +32,6 @@ items:
   source:
     id: StreamingPullFuture
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 30
   summary: 'Represents a process that asynchronously performs streaming pull and
 
@@ -74,10 +70,6 @@ items:
   source:
     id: StreamingPullFuture
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 30
   summary: 'Initializes the future. Should not be called by clients.
 
@@ -98,10 +90,6 @@ items:
   source:
     id: add_done_callback
     path: concurrent/futures/_base.py
-    remote:
-      branch: add_goldens
-      path: concurrent/futures/_base.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 398
   summary: 'Attaches a callable that will be called when the future finishes.
 
@@ -121,10 +109,6 @@ items:
   source:
     id: cancel
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 56
   summary: "Stops pulling messages and shutdowns the background thread consuming\n\
     messages.\n\nThe method always returns `True`, as the shutdown is always initiated.\n\
@@ -149,10 +133,6 @@ items:
   source:
     id: cancelled
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 78
   summary: ''
   syntax:
@@ -170,10 +150,6 @@ items:
   source:
     id: done
     path: concurrent/futures/_base.py
-    remote:
-      branch: add_goldens
-      path: concurrent/futures/_base.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 383
   summary: 'Return True if the future was cancelled or finished executing.
 
@@ -194,10 +170,6 @@ items:
   source:
     id: exception
     path: concurrent/futures/_base.py
-    remote:
-      branch: add_goldens
-      path: concurrent/futures/_base.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 453
   summary: 'Return the exception raised by the call that the future represents.
 
@@ -222,10 +194,6 @@ items:
   source:
     id: result
     path: concurrent/futures/_base.py
-    remote:
-      branch: add_goldens
-      path: concurrent/futures/_base.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 418
   summary: 'Return the result of the call that the future represents.
 
@@ -252,10 +220,6 @@ items:
   source:
     id: running
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 33
   summary: 'Return `True` if the associated Pub/Sub action has not yet completed.
 
@@ -276,10 +240,6 @@ items:
   source:
     id: set_exception
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 50
   summary: 'Set the result of the future as being the given exception.
 
@@ -305,10 +265,6 @@ items:
   source:
     id: set_result
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 42
   summary: 'Set the return value of work associated with the future.
 
@@ -334,10 +290,6 @@ items:
   source:
     id: set_running_or_notify_cancel
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 37
   summary: 'Mark the future as running or process any cancel notifications.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.yml
@@ -12,10 +12,6 @@ items:
   source:
     id: futures
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/futures.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `pubsub_v1.subscriber.futures` module.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.message.Message.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.message.Message.yml
@@ -29,10 +29,6 @@ items:
   source:
     id: Message
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 67
   summary: "A representation of a single Pub/Sub message.\n\nThe common way to interact\
     \ with\n`.pubsub_v1.subscriber.message.Message` objects is to receive\nthem in\
@@ -60,10 +56,6 @@ items:
   source:
     id: Message
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 67
   summary: 'Construct the Message.
 
@@ -94,10 +86,6 @@ items:
   source:
     id: ack
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 234
   summary: 'Acknowledge the given message.
 
@@ -150,10 +138,6 @@ items:
   source:
     id: ack_id
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'the ID used to ack the message.
 
@@ -173,10 +157,6 @@ items:
   source:
     id: ack_with_response
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 265
   summary: 'Acknowledge the given message.
 
@@ -241,10 +221,6 @@ items:
   source:
     id: attributes
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the attributes of the underlying Pub/Sub Message.
 
@@ -281,10 +257,6 @@ items:
   source:
     id: data
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the data for the underlying Pub/Sub Message.
 
@@ -304,10 +276,6 @@ items:
   source:
     id: delivery_attempt
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The delivery attempt counter is 1 + (the sum of number of NACKs
 
@@ -346,10 +314,6 @@ items:
   source:
     id: drop
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 322
   summary: 'Release the message from lease management.
 
@@ -389,10 +353,6 @@ items:
   source:
     id: modify_ack_deadline
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 341
   summary: 'Resets the deadline for acknowledgement.
 
@@ -426,10 +386,6 @@ items:
   source:
     id: modify_ack_deadline_with_response
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 361
   summary: 'Resets the deadline for acknowledgement and returns the response
 
@@ -496,10 +452,6 @@ items:
   source:
     id: nack
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 422
   summary: 'Decline to acknowledge the given message.
 
@@ -527,10 +479,6 @@ items:
   source:
     id: nack_with_response
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/message.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 438
   summary: 'Decline to acknowledge the given message, returning the response status
     via
@@ -584,10 +532,6 @@ items:
   source:
     id: ordering_key
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The ordering key used to publish the message.
 
@@ -608,10 +552,6 @@ items:
   source:
     id: publish_time
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the time that the message was originally published.
 
@@ -631,10 +571,6 @@ items:
   source:
     id: size
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the size of the underlying message, in bytes.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.yml
@@ -17,10 +17,6 @@ items:
   source:
     id: Scheduler
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 32
   summary: 'Abstract base class for schedulers.
 
@@ -44,10 +40,6 @@ items:
   source:
     id: queue
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Queue: A concurrency-safe queue specific to the underlying
 
@@ -72,10 +64,6 @@ items:
   source:
     id: schedule
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 48
   summary: 'Schedule the callback to be called asynchronously.
 
@@ -95,10 +83,6 @@ items:
   source:
     id: shutdown
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 62
   summary: 'Shuts down the scheduler and immediately end all pending callbacks.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: ThreadScheduler
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 89
   summary: "A thread pool-based scheduler. It must not be shared across\n   SubscriberClients.\n\
     \nThis scheduler is useful in typical I/O-bound message processing.\n"
@@ -43,10 +39,6 @@ items:
   source:
     id: queue
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Queue: A thread-safe queue used for communication between callbacks
 
@@ -68,10 +60,6 @@ items:
   source:
     id: schedule
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 116
   summary: 'Schedule the callback to be called asynchronously in a thread pool.
 
@@ -91,10 +79,6 @@ items:
   source:
     id: shutdown
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 136
   summary: 'Shut down the scheduler and immediately end all pending callbacks.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.yml
@@ -13,10 +13,6 @@ items:
   source:
     id: scheduler
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/subscriber/scheduler.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Schedulers provide means to *schedule* callbacks asynchronously.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AcknowledgeRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AcknowledgeRequest.yml
@@ -25,10 +25,6 @@ items:
   source:
     id: AcknowledgeRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the Acknowledge method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditConfig.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditConfig.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: AuditConfig
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.AuditConfig` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditConfigDelta.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditConfigDelta.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: AuditConfigDelta
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.AuditConfigDelta` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditData.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditData.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: AuditData
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.AuditData` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditLogConfig.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditLogConfig.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: AuditLogConfig
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.AuditLogConfig` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BatchSettings.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BatchSettings.yml
@@ -20,10 +20,6 @@ items:
   source:
     id: BatchSettings
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 63
   summary: 'The settings for batch publishing the messages.
 
@@ -49,10 +45,6 @@ items:
   source:
     id: BatchSettings
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 63
   summary: 'Create new instance of BatchSettings(max_bytes, max_latency, max_messages)
 
@@ -74,10 +66,6 @@ items:
   source:
     id: max_bytes
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The maximum total size of the messages to collect before automatically
     publishing the batch, including any byte size overhead of the publish request
@@ -98,10 +86,6 @@ items:
   source:
     id: max_latency
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The maximum number of seconds to wait for additional messages before automatically
     publishing the batch.
@@ -121,10 +105,6 @@ items:
   source:
     id: max_messages
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The maximum number of messages to collect before automatically publishing
     the batch.

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BigQueryConfig.State.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BigQueryConfig.State.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: State
     path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1041
   summary: 'Possible states for a BigQuery subscription.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BigQueryConfig.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BigQueryConfig.yml
@@ -42,10 +42,6 @@ items:
   source:
     id: BigQueryConfig
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Configuration for a BigQuery subscription.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Binding.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Binding.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: Binding
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.Binding` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BindingDelta.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BindingDelta.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: BindingDelta
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.BindingDelta` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CreateSnapshotRequest.LabelsEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CreateSnapshotRequest.LabelsEntry.yml
@@ -16,10 +16,6 @@ items:
   source:
     id: LabelsEntry
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The abstract base class for a message.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CreateSnapshotRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CreateSnapshotRequest.yml
@@ -37,10 +37,6 @@ items:
   source:
     id: CreateSnapshotRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `CreateSnapshot` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CustomHttpPattern.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CustomHttpPattern.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: CustomHttpPattern
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.CustomHttpPattern` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeadLetterPolicy.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeadLetterPolicy.yml
@@ -36,10 +36,6 @@ items:
   source:
     id: DeadLetterPolicy
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Dead lettering is done on a best effort basis. The same
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteSnapshotRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteSnapshotRequest.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: DeleteSnapshotRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `DeleteSnapshot` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteSubscriptionRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteSubscriptionRequest.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: DeleteSubscriptionRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the DeleteSubscription method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteTopicRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteTopicRequest.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: DeleteTopicRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `DeleteTopic` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.ExtensionRange.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.ExtensionRange.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: ExtensionRange
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.DescriptorProto.ExtensionRange`
     class.

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.ReservedRange.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.ReservedRange.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: ReservedRange
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.DescriptorProto.ReservedRange` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.yml
@@ -20,10 +20,6 @@ items:
   source:
     id: DescriptorProto
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.DescriptorProto` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DetachSubscriptionRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DetachSubscriptionRequest.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: DetachSubscriptionRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the DetachSubscription method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DetachSubscriptionResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DetachSubscriptionResponse.yml
@@ -16,10 +16,6 @@ items:
   source:
     id: DetachSubscriptionResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Response for the DetachSubscription method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Duration.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Duration.yml
@@ -21,10 +21,6 @@ items:
   source:
     id: Duration
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.Duration` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Empty.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Empty.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: Empty
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.Empty` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumDescriptorProto.EnumReservedRange.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumDescriptorProto.EnumReservedRange.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: EnumReservedRange
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.EnumDescriptorProto.EnumReservedRange`
     class.

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumDescriptorProto.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: EnumDescriptorProto
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.EnumDescriptorProto` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumOptions.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: EnumOptions
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.EnumOptions` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumValueDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumValueDescriptorProto.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: EnumValueDescriptorProto
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.EnumValueDescriptorProto` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumValueOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumValueOptions.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: EnumValueOptions
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.EnumValueOptions` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ExpirationPolicy.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ExpirationPolicy.yml
@@ -24,10 +24,6 @@ items:
   source:
     id: ExpirationPolicy
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'A policy that specifies the conditions for resource
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ExtensionRangeOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ExtensionRangeOptions.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: ExtensionRangeOptions
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.ExtensionRangeOptions` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldDescriptorProto.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: FieldDescriptorProto
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.FieldDescriptorProto` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldMask.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldMask.yml
@@ -21,10 +21,6 @@ items:
   source:
     id: FieldMask
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.FieldMask` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldOptions.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: FieldOptions
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.FieldOptions` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileDescriptorProto.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: FileDescriptorProto
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.FileDescriptorProto` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileDescriptorSet.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileDescriptorSet.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: FileDescriptorSet
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.FileDescriptorSet` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileOptions.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: FileOptions
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.FileOptions` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FlowControl.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FlowControl.yml
@@ -22,10 +22,6 @@ items:
   source:
     id: FlowControl
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 142
   summary: 'The settings for controlling the rate at which messages are pulled
 
@@ -54,10 +50,6 @@ items:
   source:
     id: FlowControl
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 142
   summary: 'Create new instance of FlowControl(max_bytes, max_messages, max_lease_duration,
     min_duration_per_lease_extension, max_duration_per_lease_extension)
@@ -81,10 +73,6 @@ items:
   source:
     id: max_bytes
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The maximum total size of received - but not yet processed - messages
     before pausing the message stream.
@@ -104,10 +92,6 @@ items:
   source:
     id: max_duration_per_lease_extension
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The max amount of time in seconds for a single lease extension attempt.
     Bounds the delay before a message redelivery if the subscriber fails to extend
@@ -128,10 +112,6 @@ items:
   source:
     id: max_lease_duration
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The maximum amount of time in seconds to hold a lease on a message before
     dropping it from the lease management.
@@ -151,10 +131,6 @@ items:
   source:
     id: max_messages
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The maximum number of received - but not yet processed - messages before
     pausing the message stream.
@@ -174,10 +150,6 @@ items:
   source:
     id: min_duration_per_lease_extension
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The min amount of time in seconds for a single lease extension attempt.
     Must be between 10 and 600 (inclusive). Ignored by default, but set to 60 seconds

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GeneratedCodeInfo.Annotation.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GeneratedCodeInfo.Annotation.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: Annotation
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.GeneratedCodeInfo.Annotation` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GeneratedCodeInfo.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GeneratedCodeInfo.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: GeneratedCodeInfo
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.GeneratedCodeInfo` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetIamPolicyRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetIamPolicyRequest.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: GetIamPolicyRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.GetIamPolicyRequest` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetSnapshotRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetSnapshotRequest.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: GetSnapshotRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the GetSnapshot method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetSubscriptionRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetSubscriptionRequest.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: GetSubscriptionRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the GetSubscription method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetTopicRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetTopicRequest.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: GetTopicRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the GetTopic method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Http.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Http.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: Http
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.Http` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.HttpRule.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.HttpRule.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: HttpRule
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.HttpRule` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.LimitExceededBehavior.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.LimitExceededBehavior.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: LimitExceededBehavior
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 87
   summary: 'The possible actions when exceeding the publish flow control limits.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSnapshotsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSnapshotsRequest.yml
@@ -28,10 +28,6 @@ items:
   source:
     id: ListSnapshotsRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `ListSnapshots` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSnapshotsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSnapshotsResponse.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: ListSnapshotsResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Response for the `ListSnapshots` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSubscriptionsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSubscriptionsRequest.yml
@@ -28,10 +28,6 @@ items:
   source:
     id: ListSubscriptionsRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `ListSubscriptions` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSubscriptionsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSubscriptionsResponse.yml
@@ -24,10 +24,6 @@ items:
   source:
     id: ListSubscriptionsResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Response for the `ListSubscriptions` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSnapshotsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSnapshotsRequest.yml
@@ -28,10 +28,6 @@ items:
   source:
     id: ListTopicSnapshotsRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `ListTopicSnapshots` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSnapshotsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSnapshotsResponse.yml
@@ -24,10 +24,6 @@ items:
   source:
     id: ListTopicSnapshotsResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Response for the `ListTopicSnapshots` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSubscriptionsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSubscriptionsRequest.yml
@@ -28,10 +28,6 @@ items:
   source:
     id: ListTopicSubscriptionsRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `ListTopicSubscriptions` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSubscriptionsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSubscriptionsResponse.yml
@@ -25,10 +25,6 @@ items:
   source:
     id: ListTopicSubscriptionsResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Response for the `ListTopicSubscriptions` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicsRequest.yml
@@ -28,10 +28,6 @@ items:
   source:
     id: ListTopicsRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `ListTopics` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicsResponse.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: ListTopicsResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Response for the `ListTopics` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MessageOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MessageOptions.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: MessageOptions
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.MessageOptions` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MessageStoragePolicy.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MessageStoragePolicy.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: MessageStoragePolicy
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'A policy constraining the storage of messages published to
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MethodDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MethodDescriptorProto.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: MethodDescriptorProto
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.MethodDescriptorProto` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MethodOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MethodOptions.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: MethodOptions
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.MethodOptions` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ModifyAckDeadlineRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ModifyAckDeadlineRequest.yml
@@ -32,10 +32,6 @@ items:
   source:
     id: ModifyAckDeadlineRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the ModifyAckDeadline method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ModifyPushConfigRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ModifyPushConfigRequest.yml
@@ -26,10 +26,6 @@ items:
   source:
     id: ModifyPushConfigRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the ModifyPushConfig method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.OneofDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.OneofDescriptorProto.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: OneofDescriptorProto
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.OneofDescriptorProto` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.OneofOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.OneofOptions.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: OneofOptions
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.OneofOptions` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Policy.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Policy.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: Policy
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.Policy` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PolicyDelta.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PolicyDelta.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: PolicyDelta
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.PolicyDelta` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishFlowControl.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishFlowControl.yml
@@ -20,10 +20,6 @@ items:
   source:
     id: PublishFlowControl
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 95
   summary: 'The client flow control settings for message publishing.
 
@@ -50,10 +46,6 @@ items:
   source:
     id: PublishFlowControl
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 95
   summary: 'Create new instance of PublishFlowControl(message_limit, byte_limit, limit_exceeded_behavior)
 
@@ -76,10 +68,6 @@ items:
   source:
     id: byte_limit
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The maximum total size of messages awaiting to be published.
 
@@ -98,10 +86,6 @@ items:
   source:
     id: limit_exceeded_behavior
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The action to take when publish flow control limits are exceeded.
 
@@ -120,10 +104,6 @@ items:
   source:
     id: message_limit
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The maximum number of messages awaiting to be published.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishRequest.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: PublishRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the Publish method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishResponse.yml
@@ -21,10 +21,6 @@ items:
   source:
     id: PublishResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Response for the `Publish` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublisherOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublisherOptions.yml
@@ -21,10 +21,6 @@ items:
   source:
     id: PublisherOptions
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 112
   summary: 'The options for the publisher client.
 
@@ -53,10 +49,6 @@ items:
   source:
     id: PublisherOptions
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 112
   summary: 'Create new instance of PublisherOptions(enable_message_ordering, flow_control,
     retry, timeout)
@@ -82,10 +74,6 @@ items:
   source:
     id: enable_message_ordering
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Whether to order messages in a batch by a supplied ordering key.
 
@@ -104,10 +92,6 @@ items:
   source:
     id: flow_control
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Flow control settings for message publishing by the client. By default
     the publisher client does not do any throttling.
@@ -127,10 +111,6 @@ items:
   source:
     id: retry
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retry settings for message publishing by the client. This should be an
     instance of `google.api_core.retry.Retry`.
@@ -150,10 +130,6 @@ items:
   source:
     id: timeout
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Timeout settings for message publishing by the client. It should be compatible
     with `.pubsub_v1.types.TimeoutType`.

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PubsubMessage.AttributesEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PubsubMessage.AttributesEntry.yml
@@ -16,10 +16,6 @@ items:
   source:
     id: AttributesEntry
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The abstract base class for a message.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PubsubMessage.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PubsubMessage.yml
@@ -47,10 +47,6 @@ items:
   source:
     id: PubsubMessage
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'A message that is published by publishers and consumed by
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PullRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PullRequest.yml
@@ -34,10 +34,6 @@ items:
   source:
     id: PullRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `Pull` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PullResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PullResponse.yml
@@ -22,10 +22,6 @@ items:
   source:
     id: PullResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Response for the `Pull` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.AttributesEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.AttributesEntry.yml
@@ -16,10 +16,6 @@ items:
   source:
     id: AttributesEntry
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The abstract base class for a message.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.OidcToken.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.OidcToken.yml
@@ -30,10 +30,6 @@ items:
   source:
     id: OidcToken
     path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 960
   summary: 'Contains information needed for generating an `OpenID Connect
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.yml
@@ -45,10 +45,6 @@ items:
   source:
     id: PushConfig
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Configuration for a push delivery endpoint.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ReceivedMessage.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ReceivedMessage.yml
@@ -35,10 +35,6 @@ items:
   source:
     id: ReceivedMessage
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'A message and its corresponding acknowledgment ID.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.RetryPolicy.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.RetryPolicy.yml
@@ -26,10 +26,6 @@ items:
   source:
     id: RetryPolicy
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'A policy that specifies how Cloud Pub/Sub retries message delivery.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SchemaSettings.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SchemaSettings.yml
@@ -25,10 +25,6 @@ items:
   source:
     id: SchemaSettings
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Settings for validating messages published against a schema.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SeekRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SeekRequest.yml
@@ -37,10 +37,6 @@ items:
   source:
     id: SeekRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `Seek` method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SeekResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SeekResponse.yml
@@ -16,10 +16,6 @@ items:
   source:
     id: SeekResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Response for the `Seek` method (this response is empty).
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ServiceDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ServiceDescriptorProto.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: ServiceDescriptorProto
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.ServiceDescriptorProto` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ServiceOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ServiceOptions.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: ServiceOptions
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.ServiceOptions` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SetIamPolicyRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SetIamPolicyRequest.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: SetIamPolicyRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.SetIamPolicyRequest` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Snapshot.LabelsEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Snapshot.LabelsEntry.yml
@@ -16,10 +16,6 @@ items:
   source:
     id: LabelsEntry
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The abstract base class for a message.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Snapshot.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Snapshot.yml
@@ -39,10 +39,6 @@ items:
   source:
     id: Snapshot
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'A snapshot resource. Snapshots are used in
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SourceCodeInfo.Location.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SourceCodeInfo.Location.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: Location
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.SourceCodeInfo.Location` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SourceCodeInfo.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SourceCodeInfo.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: SourceCodeInfo
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.SourceCodeInfo` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullRequest.yml
@@ -85,10 +85,6 @@ items:
   source:
     id: StreamingPullRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the `StreamingPull` streaming RPC method. This request
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.AcknowledgeConfirmation.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.AcknowledgeConfirmation.yml
@@ -26,10 +26,6 @@ items:
   source:
     id: AcknowledgeConfirmation
     path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1509
   summary: 'Acknowledgement IDs sent in one or more previous requests to
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.ModifyAckDeadlineConfirmation.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.ModifyAckDeadlineConfirmation.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: ModifyAckDeadlineConfirmation
     path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1538
   summary: 'Acknowledgement IDs sent in one or more previous requests to
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.SubscriptionProperties.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.SubscriptionProperties.yml
@@ -22,10 +22,6 @@ items:
   source:
     id: SubscriptionProperties
     path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1560
   summary: 'Subscription properties sent as part of the response.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.yml
@@ -33,10 +33,6 @@ items:
   source:
     id: StreamingPullResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Response for the `StreamingPull` method. This response is used to
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.LabelsEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.LabelsEntry.yml
@@ -16,10 +16,6 @@ items:
   source:
     id: LabelsEntry
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The abstract base class for a message.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.State.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.State.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: State
     path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/types/pubsub.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 717
   summary: 'Possible states for a subscription.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.yml
@@ -148,10 +148,6 @@ items:
   source:
     id: Subscription
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'A subscription resource.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.TestIamPermissionsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.TestIamPermissionsRequest.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: TestIamPermissionsRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.TestIamPermissionsRequest` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.TestIamPermissionsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.TestIamPermissionsResponse.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: TestIamPermissionsResponse
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.TestIamPermissionsResponse` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Timestamp.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Timestamp.yml
@@ -21,10 +21,6 @@ items:
   source:
     id: Timestamp
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.Timestamp` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Topic.LabelsEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Topic.LabelsEntry.yml
@@ -16,10 +16,6 @@ items:
   source:
     id: LabelsEntry
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The abstract base class for a message.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Topic.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Topic.yml
@@ -56,10 +56,6 @@ items:
   source:
     id: Topic
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'A topic resource.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UninterpretedOption.NamePart.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UninterpretedOption.NamePart.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: NamePart
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.UninterpretedOption.NamePart` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UninterpretedOption.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UninterpretedOption.yml
@@ -19,10 +19,6 @@ items:
   source:
     id: UninterpretedOption
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `pubsub_v1.types.UninterpretedOption` class.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateSnapshotRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateSnapshotRequest.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: UpdateSnapshotRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the UpdateSnapshot method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateSubscriptionRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateSubscriptionRequest.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: UpdateSubscriptionRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the UpdateSubscription method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateTopicRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateTopicRequest.yml
@@ -27,10 +27,6 @@ items:
   source:
     id: UpdateTopicRequest
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Request for the UpdateTopic method.
 

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.yml
@@ -100,10 +100,6 @@ items:
   source:
     id: types
     path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/cloud/pubsub_v1/types.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `pubsub_v1.types` module.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsAsyncPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsAsyncPager.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: ListTopicSnapshotsAsyncPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 348
   summary: 'A pager for iterating through `list_topic_snapshots` requests.
 
@@ -70,10 +66,6 @@ items:
   source:
     id: ListTopicSnapshotsAsyncPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 348
   summary: 'Instantiates the pager.
 

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: ListTopicSnapshotsPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 286
   summary: 'A pager for iterating through `list_topic_snapshots` requests.
 
@@ -69,10 +65,6 @@ items:
   source:
     id: ListTopicSnapshotsPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 286
   summary: 'Instantiate the pager.
 

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsAsyncPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsAsyncPager.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: ListTopicSubscriptionsAsyncPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 220
   summary: 'A pager for iterating through `list_topic_subscriptions` requests.
 
@@ -70,10 +66,6 @@ items:
   source:
     id: ListTopicSubscriptionsAsyncPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 220
   summary: 'Instantiates the pager.
 

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: ListTopicSubscriptionsPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 158
   summary: 'A pager for iterating through `list_topic_subscriptions` requests.
 
@@ -70,10 +66,6 @@ items:
   source:
     id: ListTopicSubscriptionsPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 158
   summary: 'Instantiate the pager.
 

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicsAsyncPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicsAsyncPager.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: ListTopicsAsyncPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 92
   summary: 'A pager for iterating through `list_topics` requests.
 
@@ -70,10 +66,6 @@ items:
   source:
     id: ListTopicsAsyncPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 92
   summary: 'Instantiates the pager.
 

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicsPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicsPager.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: ListTopicsPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 30
   summary: 'A pager for iterating through `list_topics` requests.
 
@@ -69,10 +65,6 @@ items:
   source:
     id: ListTopicsPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 30
   summary: 'Instantiate the pager.
 

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.yml
@@ -16,10 +16,6 @@ items:
   source:
     id: pagers
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/publisher/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `pubsub_v1.services.publisher.pagers` module.
   syntax: {}

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSnapshotsAsyncPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSnapshotsAsyncPager.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: ListSnapshotsAsyncPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 220
   summary: 'A pager for iterating through `list_snapshots` requests.
 
@@ -70,10 +66,6 @@ items:
   source:
     id: ListSnapshotsAsyncPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 220
   summary: 'Instantiates the pager.
 

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: ListSnapshotsPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 158
   summary: 'A pager for iterating through `list_snapshots` requests.
 
@@ -69,10 +65,6 @@ items:
   source:
     id: ListSnapshotsPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 158
   summary: 'Instantiate the pager.
 

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsAsyncPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsAsyncPager.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: ListSubscriptionsAsyncPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 92
   summary: 'A pager for iterating through `list_subscriptions` requests.
 
@@ -70,10 +66,6 @@ items:
   source:
     id: ListSubscriptionsAsyncPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 92
   summary: 'Instantiates the pager.
 

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: ListSubscriptionsPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 30
   summary: 'A pager for iterating through `list_subscriptions` requests.
 
@@ -69,10 +65,6 @@ items:
   source:
     id: ListSubscriptionsPager
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 30
   summary: 'Instantiate the pager.
 

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.yml
@@ -14,10 +14,6 @@ items:
   source:
     id: pagers
     path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/gapic-combo/google/pubsub_v1/services/subscriber/pagers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: API documentation for `pubsub_v1.services.subscriber.pagers` module.
   syntax: {}

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.acl.ACL.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.acl.ACL.yml
@@ -33,10 +33,6 @@ items:
   source:
     id: ACL
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 105
   summary: 'Container class representing a list of access controls.
 
@@ -57,10 +53,6 @@ items:
   source:
     id: PREDEFINED_JSON_ACLS
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'See
 
@@ -81,10 +73,6 @@ items:
   source:
     id: add_entity
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 250
   summary: 'Add an entity to the ACL.
 
@@ -107,10 +95,6 @@ items:
   source:
     id: all
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 318
   summary: 'Factory method for an Entity representing all users.
 
@@ -133,10 +117,6 @@ items:
   source:
     id: all_authenticated
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 326
   summary: 'Factory method for an Entity representing all authenticated users.
 
@@ -159,10 +139,6 @@ items:
   source:
     id: clear
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 621
   summary: 'Remove all ACL entries.
 
@@ -220,10 +196,6 @@ items:
   source:
     id: client
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Abstract getter for the object client.
 
@@ -243,10 +215,6 @@ items:
   source:
     id: domain
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 307
   summary: 'Factory method for a domain Entity.
 
@@ -272,10 +240,6 @@ items:
   source:
     id: entity
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 259
   summary: 'Factory method for creating an Entity.
 
@@ -315,10 +279,6 @@ items:
   source:
     id: entity_from_dict
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 189
   summary: 'Build an _ACLEntity object from a dictionary of data.
 
@@ -351,10 +311,6 @@ items:
   source:
     id: get_entities
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 334
   summary: 'Get a list of all Entity objects.
 
@@ -377,10 +333,6 @@ items:
   source:
     id: get_entity
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 233
   summary: 'Gets an entity object from the ACL.
 
@@ -409,10 +361,6 @@ items:
   source:
     id: group
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 296
   summary: 'Factory method for a group Entity.
 
@@ -438,10 +386,6 @@ items:
   source:
     id: has_entity
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 221
   summary: 'Returns whether or not this ACL has any entries for an entity.
 
@@ -467,10 +411,6 @@ items:
   source:
     id: reload
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 363
   summary: 'Reload the ACL data from Cloud Storage.
 
@@ -504,10 +444,6 @@ items:
   source:
     id: reset
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 176
   summary: 'Remove all entities from the ACL, and clear the `loaded` flag.
 
@@ -528,10 +464,6 @@ items:
   source:
     id: save
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 488
   summary: 'Save this ACL for the current bucket.
 
@@ -583,10 +515,6 @@ items:
   source:
     id: save_predefined
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 556
   summary: 'Save this ACL for the current bucket using a predefined ACL.
 
@@ -640,10 +568,6 @@ items:
   source:
     id: user
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 285
   summary: 'Factory method for a user Entity.
 
@@ -669,10 +593,6 @@ items:
   source:
     id: validate_predefined
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 159
   summary: 'Ensures predefined is in list of predefined json values
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.acl.BucketACL.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.acl.BucketACL.yml
@@ -20,10 +20,6 @@ items:
   source:
     id: BucketACL
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 682
   summary: 'An ACL specifically for a bucket.
 
@@ -47,10 +43,6 @@ items:
   source:
     id: client
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The client bound to this ACL''s bucket.
 
@@ -71,10 +63,6 @@ items:
   source:
     id: reload_path
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Compute the path for GET API requests for this ACL.
 
@@ -95,10 +83,6 @@ items:
   source:
     id: save_path
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Compute the path for PATCH API requests for this ACL.
 
@@ -119,10 +103,6 @@ items:
   source:
     id: user_project
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Compute the user project charged for API requests for this ACL.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.acl.DefaultObjectACL.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.acl.DefaultObjectACL.yml
@@ -18,10 +18,6 @@ items:
   source:
     id: DefaultObjectACL
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 714
   summary: 'A class representing the default object ACL for a bucket.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.acl.ObjectACL.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.acl.ObjectACL.yml
@@ -20,10 +20,6 @@ items:
   source:
     id: ObjectACL
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 721
   summary: 'An ACL specifically for a Cloud Storage object / blob.
 
@@ -47,10 +43,6 @@ items:
   source:
     id: client
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The client bound to this ACL''s blob.
 
@@ -71,10 +63,6 @@ items:
   source:
     id: reload_path
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Compute the path for GET API requests for this ACL.
 
@@ -95,10 +83,6 @@ items:
   source:
     id: save_path
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Compute the path for PATCH API requests for this ACL.
 
@@ -119,10 +103,6 @@ items:
   source:
     id: user_project
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Compute the user project charged for API requests for this ACL.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.acl.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.acl.yml
@@ -15,10 +15,6 @@ items:
   source:
     id: acl
     path: tests/testdata/handwritten/google/cloud/storage/acl.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/acl.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Manage access to objects and buckets.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.batch.Batch.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.batch.Batch.yml
@@ -22,10 +22,6 @@ items:
   source:
     id: Batch
     path: tests/testdata/handwritten/google/cloud/storage/batch.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/batch.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 131
   summary: 'Proxy an underlying connection, batching up change operations.
 
@@ -48,10 +44,6 @@ items:
   source:
     id: current
     path: tests/testdata/handwritten/google/cloud/storage/batch.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/batch.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 275
   summary: 'Return the topmost batch, or None.
 
@@ -72,10 +64,6 @@ items:
   source:
     id: finish
     path: tests/testdata/handwritten/google/cloud/storage/batch.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/batch.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 250
   summary: 'Submit a single `multipart/mixed` request with deferred requests.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.batch.MIMEApplicationHTTP.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.batch.MIMEApplicationHTTP.yml
@@ -23,10 +23,6 @@ items:
   source:
     id: MIMEApplicationHTTP
     path: tests/testdata/handwritten/google/cloud/storage/batch.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/batch.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 34
   summary: 'MIME type for `application/http`.
 
@@ -71,10 +67,6 @@ items:
   source:
     id: MIMEApplicationHTTP
     path: tests/testdata/handwritten/google/cloud/storage/batch.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/batch.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 34
   summary: 'Create an application/* type MIME document.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.batch.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.batch.yml
@@ -13,10 +13,6 @@ items:
   source:
     id: batch
     path: tests/testdata/handwritten/google/cloud/storage/batch.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/batch.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Batch updates / deletes of storage buckets / blobs.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.blob.Blob.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.blob.Blob.yml
@@ -78,10 +78,6 @@ items:
   source:
     id: Blob
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 145
   summary: 'A wrapper around Cloud Storage''s concept of an `Object`.
 
@@ -132,10 +128,6 @@ items:
   source:
     id: Blob
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 145
   summary: "property `name`\n    Get the blob's name.\n\n"
   syntax:
@@ -154,10 +146,6 @@ items:
   source:
     id: STORAGE_CLASSES
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Allowed values for `storage_class`.
 
@@ -192,10 +180,6 @@ items:
   source:
     id: acl
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Create our ACL on demand.
 
@@ -216,10 +200,6 @@ items:
   source:
     id: bucket
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Bucket which contains the object.
 
@@ -242,10 +222,6 @@ items:
   source:
     id: cache_control
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -266,10 +242,6 @@ items:
   source:
     id: chunk_size
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Get the blob''s default chunk size.
 
@@ -292,10 +264,6 @@ items:
   source:
     id: client
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The client bound to this blob.
 
@@ -316,10 +284,6 @@ items:
   source:
     id: component_count
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Number of underlying components that make up this object.
 
@@ -346,10 +310,6 @@ items:
   source:
     id: compose
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3298
   summary: 'Concatenate source blobs into this one.
 
@@ -416,10 +376,6 @@ items:
   source:
     id: content_disposition
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -440,10 +396,6 @@ items:
   source:
     id: content_encoding
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -464,10 +416,6 @@ items:
   source:
     id: content_language
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -488,10 +436,6 @@ items:
   source:
     id: content_type
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -512,10 +456,6 @@ items:
   source:
     id: crc32c
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -535,10 +475,6 @@ items:
   source:
     id: create_resumable_upload_session
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2830
   summary: "Create a resumable upload session.\n\nResumable upload sessions allow\
     \ you to start an upload session from\none client and complete the session in\
@@ -645,10 +581,6 @@ items:
   source:
     id: custom_time
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the custom time for the object.
 
@@ -674,10 +606,6 @@ items:
   source:
     id: delete
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 714
   summary: 'Deletes a blob from Cloud Storage.
 
@@ -730,10 +658,6 @@ items:
   source:
     id: download_as_bytes
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1282
   summary: 'Download the contents of this blob as a bytes object.
 
@@ -827,10 +751,6 @@ items:
   source:
     id: download_as_string
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1405
   summary: '(Deprecated) Download the contents of this blob as a bytes object.
 
@@ -922,10 +842,6 @@ items:
   source:
     id: download_as_text
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1517
   summary: 'Download the contents of this blob as text (*not* bytes).
 
@@ -1012,10 +928,6 @@ items:
   source:
     id: download_to_file
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1010
   summary: 'DEPRECATED. Download the contents of this blob into a file-like object.
 
@@ -1127,10 +1039,6 @@ items:
   source:
     id: download_to_filename
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1146
   summary: 'Download the contents of this blob into a named file.
 
@@ -1230,10 +1138,6 @@ items:
   source:
     id: encryption_key
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the customer-supplied encryption key for the object.
 
@@ -1258,10 +1162,6 @@ items:
   source:
     id: etag
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the ETag for the object.
 
@@ -1290,10 +1190,6 @@ items:
   source:
     id: event_based_hold
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -1313,10 +1209,6 @@ items:
   source:
     id: exists
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 619
   summary: 'Determines whether or not this blob exists.
 
@@ -1375,10 +1267,6 @@ items:
   source:
     id: from_string
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 382
   summary: 'Get a constructor for blob object by URI.
 
@@ -1421,10 +1309,6 @@ items:
   source:
     id: generate_signed_url
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 413
   summary: 'Generates a signed URL for this blob.
 
@@ -1565,10 +1449,6 @@ items:
   source:
     id: generation
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the generation for the object.
 
@@ -1594,10 +1474,6 @@ items:
   source:
     id: get_iam_policy
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3009
   summary: 'Retrieve the IAM policy for the object.
 
@@ -1658,10 +1534,6 @@ items:
   source:
     id: id
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the ID for the object.
 
@@ -1691,10 +1563,6 @@ items:
   source:
     id: kms_key_name
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Resource name of Cloud KMS key used to encrypt the blob''s contents.
 
@@ -1717,10 +1585,6 @@ items:
   source:
     id: make_private
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3245
   summary: 'Update blob''s ACL, revoking read access for anonymous users.
 
@@ -1765,10 +1629,6 @@ items:
   source:
     id: make_public
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3192
   summary: 'Update blob''s ACL, granting read access to anonymous users.
 
@@ -1814,10 +1674,6 @@ items:
   source:
     id: md5_hash
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -1838,10 +1694,6 @@ items:
   source:
     id: media_link
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the media download URI for the object.
 
@@ -1868,10 +1720,6 @@ items:
   source:
     id: metadata
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: "Retrieve arbitrary/application specific metadata for the object.\n\nSee\
     \ https://cloud.google.com/storage/docs/json_api/v1/objects\n\n:setter: Update\
@@ -1896,10 +1744,6 @@ items:
   source:
     id: metageneration
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the metageneration for the object.
 
@@ -1925,10 +1769,6 @@ items:
   source:
     id: open
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3712
   summary: 'Create a file handler for file-like I/O to or from this blob.
 
@@ -2076,10 +1916,6 @@ items:
   source:
     id: owner
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve info about the owner of the object.
 
@@ -2105,10 +1941,6 @@ items:
   source:
     id: patch
     path: tests/testdata/handwritten/google/cloud/storage/_helpers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/_helpers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 281
   summary: 'Sends all changed properties in a PATCH request.
 
@@ -2160,10 +1992,6 @@ items:
   source:
     id: path
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Getter property for the URL path to this Blob.
 
@@ -2185,10 +2013,6 @@ items:
   source:
     id: path_helper
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 293
   summary: 'Relative URL path for a blob.
 
@@ -2218,10 +2042,6 @@ items:
   source:
     id: public_url
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The public URL for this blob.
 
@@ -2248,10 +2068,6 @@ items:
   source:
     id: reload
     path: tests/testdata/handwritten/google/cloud/storage/_helpers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/_helpers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 169
   summary: 'Reload properties from Cloud Storage.
 
@@ -2311,10 +2127,6 @@ items:
   source:
     id: retention_expiration_time
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve timestamp at which the object''s retention period expires.
 
@@ -2340,10 +2152,6 @@ items:
   source:
     id: rewrite
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3431
   summary: 'Rewrite source blob into this one.
 
@@ -2433,10 +2241,6 @@ items:
   source:
     id: self_link
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the URI for the object.
 
@@ -2462,10 +2266,6 @@ items:
   source:
     id: set_iam_policy
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3077
   summary: 'Update the IAM policy for the bucket.
 
@@ -2520,10 +2320,6 @@ items:
   source:
     id: size
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Size of the object, in bytes.
 
@@ -2550,10 +2346,6 @@ items:
   source:
     id: storage_class
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -2574,10 +2366,6 @@ items:
   source:
     id: temporary_hold
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -2597,10 +2385,6 @@ items:
   source:
     id: test_iam_permissions
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3138
   summary: 'API call:  test permissions
 
@@ -2655,10 +2439,6 @@ items:
   source:
     id: time_created
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the timestamp at which the object was created.
 
@@ -2685,10 +2465,6 @@ items:
   source:
     id: time_deleted
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the timestamp at which the object was deleted.
 
@@ -2715,10 +2491,6 @@ items:
   source:
     id: update
     path: tests/testdata/handwritten/google/cloud/storage/_helpers.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/_helpers.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 352
   summary: 'Sends all properties in a PUT request.
 
@@ -2769,10 +2541,6 @@ items:
   source:
     id: update_storage_class
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3585
   summary: 'Update blob''s storage class via a rewrite-in-place. This helper will
 
@@ -2866,10 +2634,6 @@ items:
   source:
     id: updated
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the timestamp at which the object was updated.
 
@@ -2895,10 +2659,6 @@ items:
   source:
     id: upload_from_file
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2388
   summary: "Upload the contents of this blob from a file-like object.\n\nThe content\
     \ type of the upload will be determined in order\nof precedence:\n\n- The value\
@@ -3007,10 +2767,6 @@ items:
   source:
     id: upload_from_filename
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2558
   summary: "Upload this blob's contents from the content of a named file.\n\nThe content\
     \ type of the upload will be determined in order\nof precedence:\n\n- The value\
@@ -3104,10 +2860,6 @@ items:
   source:
     id: upload_from_string
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2699
   summary: "Upload contents of this blob from the provided string.\n\n<aside class=\"\
     note\">\n<b>Note:</b>\nThe effect of uploading to an existing blob depends on\
@@ -3199,10 +2951,6 @@ items:
   source:
     id: user_project
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Project ID billed for API requests made via this blob.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.blob.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.blob.yml
@@ -12,10 +12,6 @@ items:
   source:
     id: blob
     path: tests/testdata/handwritten/google/cloud/storage/blob.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/blob.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Create / interact with Google Cloud Storage blobs.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.Bucket.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.Bucket.yml
@@ -81,10 +81,6 @@ items:
   source:
     id: Bucket
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 615
   summary: 'A class representing a Bucket on Cloud Storage.
 
@@ -120,10 +116,6 @@ items:
   source:
     id: Bucket
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 615
   summary: "property `name`\n    Get the bucket's name.\n\n"
   syntax:
@@ -141,10 +133,6 @@ items:
   source:
     id: STORAGE_CLASSES
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Allowed values for `storage_class`.
 
@@ -174,10 +162,6 @@ items:
   source:
     id: acl
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Create our ACL on demand.
 
@@ -197,10 +181,6 @@ items:
   source:
     id: add_lifecycle_abort_incomplete_multipart_upload_rule
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2317
   summary: 'Add a "abort incomplete multipart upload" rule to lifecycle rules.
 
@@ -238,10 +218,6 @@ items:
   source:
     id: add_lifecycle_delete_rule
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2285
   summary: 'Add a "delete" rule to lifecycle rules configured for this bucket.
 
@@ -271,10 +247,6 @@ items:
   source:
     id: add_lifecycle_set_storage_class_rule
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2300
   summary: 'Add a "set storage class" rule to lifecycle rules.
 
@@ -305,10 +277,6 @@ items:
   source:
     id: blob
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 758
   summary: 'Factory constructor for blob object.
 
@@ -357,10 +325,6 @@ items:
   source:
     id: clear_lifecyle_rules
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2277
   summary: "Clear lifecycle rules configured for this bucket.\n\nSee https://cloud.google.com/storage/docs/lifecycle\
     \ and\n     https://cloud.google.com/storage/docs/json_api/v1/buckets\n\n"
@@ -380,10 +344,6 @@ items:
   source:
     id: client
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The client bound to this bucket.
 
@@ -403,10 +363,6 @@ items:
   source:
     id: configure_website
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2663
   summary: 'Configure website-related properties.
 
@@ -452,10 +408,6 @@ items:
   source:
     id: copy_blob
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1771
   summary: 'Copy the given blob to the given bucket, optionally with a new name.
 
@@ -554,10 +506,6 @@ items:
   source:
     id: cors
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: "Retrieve or set CORS policies configured for this bucket.\n\nSee http://www.w3.org/TR/cors/\
     \ and\n     https://cloud.google.com/storage/docs/json_api/v1/buckets\n\n<aside\
@@ -584,10 +532,6 @@ items:
   source:
     id: create
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 915
   summary: 'DEPRECATED. Creates current bucket.
 
@@ -659,10 +603,6 @@ items:
   source:
     id: data_locations
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the list of regional locations for custom dual-region buckets.
 
@@ -695,10 +635,6 @@ items:
   source:
     id: default_event_based_hold
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Scalar property getter.
 
@@ -719,10 +655,6 @@ items:
   source:
     id: default_kms_key_name
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve / set default KMS encryption key for objects in the bucket.
 
@@ -753,10 +685,6 @@ items:
   source:
     id: default_object_acl
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Create our defaultObjectACL on demand.
 
@@ -776,10 +704,6 @@ items:
   source:
     id: delete
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1475
   summary: 'Delete this bucket.
 
@@ -852,10 +776,6 @@ items:
   source:
     id: delete_blob
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1578
   summary: 'Deletes a blob from the current bucket.
 
@@ -914,10 +834,6 @@ items:
   source:
     id: delete_blobs
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1658
   summary: 'Deletes a list of blobs from the current bucket.
 
@@ -998,10 +914,6 @@ items:
   source:
     id: disable_logging
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2427
   summary: 'Disable access logging for this bucket.
 
@@ -1025,10 +937,6 @@ items:
   source:
     id: disable_website
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2686
   summary: 'Disable the website configuration for this bucket.
 
@@ -1054,10 +962,6 @@ items:
   source:
     id: enable_logging
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2413
   summary: 'Enable access logging for this bucket.
 
@@ -1087,10 +991,6 @@ items:
   source:
     id: etag
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: "Retrieve the ETag for the bucket.\n\nSee https://tools.ietf.org/html/rfc2616#section-3.11\
     \ and\n     https://cloud.google.com/storage/docs/json_api/v1/buckets\n"
@@ -1112,10 +1012,6 @@ items:
   source:
     id: exists
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 831
   summary: 'Determines whether or not this bucket exists.
 
@@ -1170,10 +1066,6 @@ items:
   source:
     id: from_string
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 729
   summary: 'Get a constructor for bucket object by URI.
 
@@ -1216,10 +1108,6 @@ items:
   source:
     id: generate_signed_url
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3156
   summary: 'Generates a signed URL for this bucket.
 
@@ -1320,10 +1208,6 @@ items:
   source:
     id: generate_upload_policy
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3049
   summary: 'Create a signed upload policy for uploading objects.
 
@@ -1370,10 +1254,6 @@ items:
   source:
     id: get_blob
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1180
   summary: 'Get a blob object by name.
 
@@ -1446,10 +1326,6 @@ items:
   source:
     id: get_iam_policy
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2694
   summary: 'Retrieve the IAM policy for the bucket.
 
@@ -1502,10 +1378,6 @@ items:
   source:
     id: get_logging
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2401
   summary: 'Return info about access logging for this bucket.
 
@@ -1532,10 +1404,6 @@ items:
   source:
     id: get_notification
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1438
   summary: 'Get Pub / Sub notification for this bucket.
 
@@ -1582,10 +1450,6 @@ items:
   source:
     id: iam_configuration
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve IAM configuration for this bucket.
 
@@ -1608,10 +1472,6 @@ items:
   source:
     id: id
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the ID for the bucket.
 
@@ -1638,10 +1498,6 @@ items:
   source:
     id: labels
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve or set labels assigned to this bucket.
 
@@ -1690,10 +1546,6 @@ items:
   source:
     id: lifecycle_rules
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: "Retrieve or set lifecycle rules configured for this bucket.\n\nSee https://cloud.google.com/storage/docs/lifecycle\
     \ and\n     https://cloud.google.com/storage/docs/json_api/v1/buckets\n\n<aside\
@@ -1720,10 +1572,6 @@ items:
   source:
     id: list_blobs
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1287
   summary: 'DEPRECATED. Return an iterator used to find blobs in the bucket.
 
@@ -1819,10 +1667,6 @@ items:
   source:
     id: list_notifications
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1401
   summary: 'List Pub / Sub notifications for this bucket.
 
@@ -1866,10 +1710,6 @@ items:
   source:
     id: location
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve location configured for this bucket.
 
@@ -1900,10 +1740,6 @@ items:
   source:
     id: location_type
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the location type for the bucket.
 
@@ -1934,10 +1770,6 @@ items:
   source:
     id: lock_retention_policy
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 3103
   summary: 'Lock the bucket''s retention policy.
 
@@ -1974,10 +1806,6 @@ items:
   source:
     id: make_private
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2956
   summary: 'Update bucket''s ACL, revoking read access for anonymous users.
 
@@ -2033,10 +1861,6 @@ items:
   source:
     id: make_public
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2859
   summary: 'Update bucket''s ACL, granting read access to anonymous users.
 
@@ -2092,10 +1916,6 @@ items:
   source:
     id: metageneration
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the metageneration for the bucket.
 
@@ -2121,10 +1941,6 @@ items:
   source:
     id: notification
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 804
   summary: 'Factory:  create a notification resource for the bucket.
 
@@ -2150,10 +1966,6 @@ items:
   source:
     id: owner
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve info about the owner of the bucket.
 
@@ -2179,10 +1991,6 @@ items:
   source:
     id: patch
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1097
   summary: 'Sends all changed properties in a PATCH request.
 
@@ -2229,10 +2037,6 @@ items:
   source:
     id: path
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The URL path to this bucket.
 
@@ -2252,10 +2056,6 @@ items:
   source:
     id: path_helper
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1160
   summary: 'Relative URL path for a bucket.
 
@@ -2282,10 +2082,6 @@ items:
   source:
     id: project_number
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the number of the project to which the bucket is assigned.
 
@@ -2311,10 +2107,6 @@ items:
   source:
     id: reload
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1036
   summary: 'Reload properties from Cloud Storage.
 
@@ -2370,10 +2162,6 @@ items:
   source:
     id: rename_blob
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1918
   summary: 'Rename the given blob using copy and delete operations.
 
@@ -2484,10 +2272,6 @@ items:
   source:
     id: requester_pays
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Does the requester pay for API requests for this bucket?
 
@@ -2520,10 +2304,6 @@ items:
   source:
     id: retention_period
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve or set the retention period for items in the bucket.
 
@@ -2547,10 +2327,6 @@ items:
   source:
     id: retention_policy_effective_time
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the effective time of the bucket''s retention policy.
 
@@ -2574,10 +2350,6 @@ items:
   source:
     id: retention_policy_locked
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve whthere the bucket''s retention policy is locked.
 
@@ -2601,10 +2373,6 @@ items:
   source:
     id: rpo
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Get the RPO (Recovery Point Objective) of this bucket
 
@@ -2631,10 +2399,6 @@ items:
   source:
     id: self_link
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the URI for the bucket.
 
@@ -2660,10 +2424,6 @@ items:
   source:
     id: set_iam_policy
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2756
   summary: 'Update the IAM policy for the bucket.
 
@@ -2711,10 +2471,6 @@ items:
   source:
     id: storage_class
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve or set the storage class for the bucket.
 
@@ -2751,10 +2507,6 @@ items:
   source:
     id: test_iam_permissions
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 2812
   summary: 'API call:  test permissions
 
@@ -2802,10 +2554,6 @@ items:
   source:
     id: time_created
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the timestamp at which the bucket was created.
 
@@ -2831,10 +2579,6 @@ items:
   source:
     id: update
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 992
   summary: 'Sends all properties in a PUT request.
 
@@ -2881,10 +2625,6 @@ items:
   source:
     id: user_project
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Project ID to be billed for API requests made via this bucket.
 
@@ -2913,10 +2653,6 @@ items:
   source:
     id: versioning_enabled
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Is versioning enabled for this bucket?
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.IAMConfiguration.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.IAMConfiguration.yml
@@ -34,10 +34,6 @@ items:
   source:
     id: IAMConfiguration
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 438
   summary: 'Map a bucket''s IAM configuration.
 
@@ -60,10 +56,6 @@ items:
   source:
     id: bucket
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Bucket for which this instance is the policy.
 
@@ -86,10 +78,6 @@ items:
   source:
     id: bucket_policy_only_enabled
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Deprecated alias for `uniform_bucket_level_access_enabled`.
 
@@ -112,10 +100,6 @@ items:
   source:
     id: bucket_policy_only_locked_time
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Deprecated alias for `uniform_bucket_level_access_locked_time`.
 
@@ -137,10 +121,6 @@ items:
   source:
     id: clear
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.IAMConfiguration.clear` method.
   syntax:
@@ -156,10 +136,6 @@ items:
   source:
     id: copy
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.IAMConfiguration.copy` method.
   syntax:
@@ -176,10 +152,6 @@ items:
   source:
     id: from_api_repr
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 511
   summary: 'Factory:  construct instance from resource.
 
@@ -205,10 +177,6 @@ items:
   source:
     id: fromkeys
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Create a new dictionary with keys from iterable and values set to value.
 
@@ -229,10 +197,6 @@ items:
   source:
     id: get
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the value for key if key is in the dictionary, else default.
 
@@ -252,10 +216,6 @@ items:
   source:
     id: items
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.IAMConfiguration.items` method.
   syntax:
@@ -271,10 +231,6 @@ items:
   source:
     id: keys
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.IAMConfiguration.keys` method.
   syntax:
@@ -291,10 +247,6 @@ items:
   source:
     id: pop
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If key is not found, default is returned if given, otherwise KeyError
     is raised
@@ -315,10 +267,6 @@ items:
   source:
     id: popitem
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Remove and return a (key, value) pair as a 2-tuple.
 
@@ -345,10 +293,6 @@ items:
   source:
     id: public_access_prevention
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: "Setting for public access prevention policy. Options are 'inherited' (default)\
     \ or 'enforced'.\n\n    See: https://cloud.google.com/storage/docs/public-access-prevention\n"
@@ -369,10 +313,6 @@ items:
   source:
     id: setdefault
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Insert key with a value of default if key is not in the dictionary.
 
@@ -397,10 +337,6 @@ items:
   source:
     id: uniform_bucket_level_access_enabled
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If set, access checks only use bucket-level IAM policies or above.
 
@@ -423,10 +359,6 @@ items:
   source:
     id: uniform_bucket_level_access_locked_time
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Deadline for changing `uniform_bucket_level_access_enabled` from true
     to false.
@@ -460,10 +392,6 @@ items:
   source:
     id: update
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If E is present and has a .keys() method, then does:  for k in E: D[k]
     = E[k]
@@ -488,10 +416,6 @@ items:
   source:
     id: values
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.IAMConfiguration.values` method.
   syntax:

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.yml
@@ -28,10 +28,6 @@ items:
   source:
     id: LifecycleRuleAbortIncompleteMultipartUpload
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 403
   summary: 'Map a rule aborting incomplete multipart uploads of matching items.
 
@@ -53,10 +49,6 @@ items:
   source:
     id: clear
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.clear`
     method.
@@ -73,10 +65,6 @@ items:
   source:
     id: copy
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.copy`
     method.
@@ -94,10 +82,6 @@ items:
   source:
     id: from_api_repr
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 420
   summary: 'Factory:  construct instance from resource.
 
@@ -123,10 +107,6 @@ items:
   source:
     id: fromkeys
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Create a new dictionary with keys from iterable and values set to value.
 
@@ -147,10 +127,6 @@ items:
   source:
     id: get
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the value for key if key is in the dictionary, else default.
 
@@ -170,10 +146,6 @@ items:
   source:
     id: items
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.items`
     method.
@@ -190,10 +162,6 @@ items:
   source:
     id: keys
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.keys`
     method.
@@ -211,10 +179,6 @@ items:
   source:
     id: pop
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If key is not found, default is returned if given, otherwise KeyError
     is raised
@@ -235,10 +199,6 @@ items:
   source:
     id: popitem
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Remove and return a (key, value) pair as a 2-tuple.
 
@@ -264,10 +224,6 @@ items:
   source:
     id: setdefault
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Insert key with a value of default if key is not in the dictionary.
 
@@ -291,10 +247,6 @@ items:
   source:
     id: update
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If E is present and has a .keys() method, then does:  for k in E: D[k]
     = E[k]
@@ -319,10 +271,6 @@ items:
   source:
     id: values
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.values`
     method.

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleConditions.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleConditions.yml
@@ -39,10 +39,6 @@ items:
   source:
     id: LifecycleRuleConditions
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 147
   summary: 'Map a single lifecycle rule for a bucket.
 
@@ -125,10 +121,6 @@ items:
   source:
     id: age
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s age value.
 
@@ -147,10 +139,6 @@ items:
   source:
     id: clear
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleConditions.clear` method.
   syntax:
@@ -166,10 +154,6 @@ items:
   source:
     id: copy
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleConditions.copy` method.
   syntax:
@@ -187,10 +171,6 @@ items:
   source:
     id: created_before
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s created_before value.
 
@@ -211,10 +191,6 @@ items:
   source:
     id: custom_time_before
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s ''custom_time_before'' value.
 
@@ -235,10 +211,6 @@ items:
   source:
     id: days_since_custom_time
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s ''days_since_custom_time'' value.
 
@@ -259,10 +231,6 @@ items:
   source:
     id: days_since_noncurrent_time
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s ''days_since_noncurrent_time'' value.
 
@@ -282,10 +250,6 @@ items:
   source:
     id: from_api_repr
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 266
   summary: 'Factory:  construct instance from resource.
 
@@ -311,10 +275,6 @@ items:
   source:
     id: fromkeys
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Create a new dictionary with keys from iterable and values set to value.
 
@@ -335,10 +295,6 @@ items:
   source:
     id: get
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the value for key if key is in the dictionary, else default.
 
@@ -360,10 +316,6 @@ items:
   source:
     id: is_live
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s ''is_live'' value.
 
@@ -382,10 +334,6 @@ items:
   source:
     id: items
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleConditions.items` method.
   syntax:
@@ -401,10 +349,6 @@ items:
   source:
     id: keys
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleConditions.keys` method.
   syntax:
@@ -422,10 +366,6 @@ items:
   source:
     id: matches_prefix
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s ''matches_prefix'' value.
 
@@ -446,10 +386,6 @@ items:
   source:
     id: matches_storage_class
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s ''matches_storage_class'' value.
 
@@ -470,10 +406,6 @@ items:
   source:
     id: matches_suffix
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s ''matches_suffix'' value.
 
@@ -494,10 +426,6 @@ items:
   source:
     id: noncurrent_time_before
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s ''noncurrent_time_before'' value.
 
@@ -518,10 +446,6 @@ items:
   source:
     id: number_of_newer_versions
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Conditon''s ''number_of_newer_versions'' value.
 
@@ -541,10 +465,6 @@ items:
   source:
     id: pop
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If key is not found, default is returned if given, otherwise KeyError
     is raised
@@ -565,10 +485,6 @@ items:
   source:
     id: popitem
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Remove and return a (key, value) pair as a 2-tuple.
 
@@ -594,10 +510,6 @@ items:
   source:
     id: setdefault
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Insert key with a value of default if key is not in the dictionary.
 
@@ -621,10 +533,6 @@ items:
   source:
     id: update
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If E is present and has a .keys() method, then does:  for k in E: D[k]
     = E[k]
@@ -649,10 +557,6 @@ items:
   source:
     id: values
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleConditions.values` method.
   syntax:

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleDelete.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleDelete.yml
@@ -28,10 +28,6 @@ items:
   source:
     id: LifecycleRuleDelete
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 342
   summary: 'Map a lifecycle rule deleting matching items.
 
@@ -50,10 +46,6 @@ items:
   source:
     id: clear
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleDelete.clear` method.
   syntax:
@@ -69,10 +61,6 @@ items:
   source:
     id: copy
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleDelete.copy` method.
   syntax:
@@ -89,10 +77,6 @@ items:
   source:
     id: from_api_repr
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 354
   summary: 'Factory:  construct instance from resource.
 
@@ -118,10 +102,6 @@ items:
   source:
     id: fromkeys
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Create a new dictionary with keys from iterable and values set to value.
 
@@ -142,10 +122,6 @@ items:
   source:
     id: get
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the value for key if key is in the dictionary, else default.
 
@@ -165,10 +141,6 @@ items:
   source:
     id: items
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleDelete.items` method.
   syntax:
@@ -184,10 +156,6 @@ items:
   source:
     id: keys
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleDelete.keys` method.
   syntax:
@@ -204,10 +172,6 @@ items:
   source:
     id: pop
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If key is not found, default is returned if given, otherwise KeyError
     is raised
@@ -228,10 +192,6 @@ items:
   source:
     id: popitem
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Remove and return a (key, value) pair as a 2-tuple.
 
@@ -257,10 +217,6 @@ items:
   source:
     id: setdefault
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Insert key with a value of default if key is not in the dictionary.
 
@@ -284,10 +240,6 @@ items:
   source:
     id: update
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If E is present and has a .keys() method, then does:  for k in E: D[k]
     = E[k]
@@ -312,10 +264,6 @@ items:
   source:
     id: values
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleDelete.values` method.
   syntax:

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleSetStorageClass.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleSetStorageClass.yml
@@ -28,10 +28,6 @@ items:
   source:
     id: LifecycleRuleSetStorageClass
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 369
   summary: 'Map a lifecycle rule updating storage class of matching items.
 
@@ -53,10 +49,6 @@ items:
   source:
     id: clear
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleSetStorageClass.clear`
     method.
@@ -73,10 +65,6 @@ items:
   source:
     id: copy
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleSetStorageClass.copy`
     method.
@@ -94,10 +82,6 @@ items:
   source:
     id: from_api_repr
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 387
   summary: 'Factory:  construct instance from resource.
 
@@ -123,10 +107,6 @@ items:
   source:
     id: fromkeys
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Create a new dictionary with keys from iterable and values set to value.
 
@@ -147,10 +127,6 @@ items:
   source:
     id: get
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Return the value for key if key is in the dictionary, else default.
 
@@ -170,10 +146,6 @@ items:
   source:
     id: items
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleSetStorageClass.items`
     method.
@@ -190,10 +162,6 @@ items:
   source:
     id: keys
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleSetStorageClass.keys`
     method.
@@ -211,10 +179,6 @@ items:
   source:
     id: pop
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If key is not found, default is returned if given, otherwise KeyError
     is raised
@@ -235,10 +199,6 @@ items:
   source:
     id: popitem
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Remove and return a (key, value) pair as a 2-tuple.
 
@@ -264,10 +224,6 @@ items:
   source:
     id: setdefault
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Insert key with a value of default if key is not in the dictionary.
 
@@ -291,10 +247,6 @@ items:
   source:
     id: update
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'If E is present and has a .keys() method, then does:  for k in E: D[k]
     = E[k]
@@ -319,10 +271,6 @@ items:
   source:
     id: values
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: API documentation for `storage.bucket.LifecycleRuleSetStorageClass.values`
     method.

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.yml
@@ -17,10 +17,6 @@ items:
   source:
     id: bucket
     path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/bucket.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Create / interact with Google Cloud Storage buckets.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.client.Client.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.client.Client.yml
@@ -39,10 +39,6 @@ items:
   source:
     id: Client
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 66
   summary: 'Client to bundle configuration needed for API requests.
 
@@ -90,10 +86,6 @@ items:
   source:
     id: SCOPE
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The scopes required for authenticating as a Cloud Storage consumer.
 
@@ -112,10 +104,6 @@ items:
   source:
     id: batch
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 298
   summary: 'Factory constructor for batch object.
 
@@ -147,10 +135,6 @@ items:
   source:
     id: bucket
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 279
   summary: 'Factory constructor for bucket object.
 
@@ -189,10 +173,6 @@ items:
   source:
     id: create_anonymous_client
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 174
   summary: 'Factory: return client with anonymous credentials.
 
@@ -224,10 +204,6 @@ items:
   source:
     id: create_bucket
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 817
   summary: 'Create a new bucket via a POST request.
 
@@ -305,10 +281,6 @@ items:
   source:
     id: create_hmac_key
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1360
   summary: 'Create an HMAC key for a service account.
 
@@ -362,10 +334,6 @@ items:
   source:
     id: current_batch
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Currently-active batch.
 
@@ -388,10 +356,6 @@ items:
   source:
     id: download_blob_to_file
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 953
   summary: 'Download the contents of a blob object or blob URI into a file-like object.
 
@@ -480,10 +444,6 @@ items:
   source:
     id: generate_signed_post_policy_v4
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1517
   summary: 'Generate a V4 signed policy object. Generated policy object allows user
     to upload objects with a POST request.
@@ -565,10 +525,6 @@ items:
   source:
     id: get_bucket
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 705
   summary: 'Retrieve a bucket via a GET request.
 
@@ -625,10 +581,6 @@ items:
   source:
     id: get_hmac_key_metadata
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1493
   summary: 'Return a metadata instance for the given HMAC key.
 
@@ -663,10 +615,6 @@ items:
   source:
     id: get_service_account_email
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 251
   summary: 'Get the email address of the project''s GCS service account
 
@@ -701,10 +649,6 @@ items:
   source:
     id: list_blobs
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1094
   summary: 'Return an iterator used to find blobs in the bucket.
 
@@ -813,10 +757,6 @@ items:
   source:
     id: list_buckets
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1255
   summary: 'Get all buckets in the project associated to the client.
 
@@ -892,10 +832,6 @@ items:
   source:
     id: list_hmac_keys
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 1424
   summary: 'List HMAC keys for a project.
 
@@ -946,10 +882,6 @@ items:
   source:
     id: lookup_bucket
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 770
   summary: 'Get a bucket by name, returning None if not found.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.client.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.client.yml
@@ -12,10 +12,6 @@ items:
   source:
     id: client
     path: tests/testdata/handwritten/google/cloud/storage/client.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/client.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Client for interacting with the Google Cloud Storage API.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.constants.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.constants.yml
@@ -11,10 +11,6 @@ items:
   source:
     id: constants
     path: tests/testdata/handwritten/google/cloud/storage/constants.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/constants.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Constants used across google.cloud.storage modules.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.BlobReader.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.BlobReader.yml
@@ -32,10 +32,6 @@ items:
   source:
     id: BlobReader
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 59
   summary: 'A file-like object that reads from a blob.
 
@@ -80,10 +76,6 @@ items:
   source:
     id: close
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 211
   summary: 'Flush and close the IO object.
 
@@ -107,10 +99,6 @@ items:
   source:
     id: read
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 123
   summary: 'Read and return up to n bytes.
 
@@ -157,10 +145,6 @@ items:
   source:
     id: read1
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 168
   summary: 'Read and return up to n bytes, with at most one read() call
 
@@ -188,10 +172,6 @@ items:
   source:
     id: readable
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 218
   summary: 'Return whether object was opened for reading.
 
@@ -215,10 +195,6 @@ items:
   source:
     id: seek
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 171
   summary: 'Seek within the blob.
 
@@ -246,10 +222,6 @@ items:
   source:
     id: seekable
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 224
   summary: 'Return whether object supports random access.
 
@@ -275,10 +247,6 @@ items:
   source:
     id: writable
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 221
   summary: 'Return whether object was opened for writing.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.BlobWriter.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.BlobWriter.yml
@@ -32,10 +32,6 @@ items:
   source:
     id: BlobWriter
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 228
   summary: 'A file-like object that writes to a blob.
 
@@ -97,10 +93,6 @@ items:
   source:
     id: close
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 429
   summary: 'Flush and close the IO object.
 
@@ -124,10 +116,6 @@ items:
   source:
     id: flush
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 419
   summary: 'Flush write buffers, if applicable.
 
@@ -151,10 +139,6 @@ items:
   source:
     id: readable
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 438
   summary: 'Return whether object was opened for reading.
 
@@ -178,10 +162,6 @@ items:
   source:
     id: seekable
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 444
   summary: 'Return whether object supports random access.
 
@@ -207,10 +187,6 @@ items:
   source:
     id: tell
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 416
   summary: 'Return current stream position.
 
@@ -231,10 +207,6 @@ items:
   source:
     id: writable
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 441
   summary: 'Return whether object was opened for writing.
 
@@ -258,10 +230,6 @@ items:
   source:
     id: write
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 349
   summary: 'Write the given buffer to the IO stream.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.SlidingBuffer.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.SlidingBuffer.yml
@@ -20,10 +20,6 @@ items:
   source:
     id: SlidingBuffer
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 448
   summary: 'A non-rewindable buffer that frees memory of chunks already consumed.
 
@@ -71,10 +67,6 @@ items:
   source:
     id: __len__
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 531
   summary: 'Determine the size of the buffer by seeking to the end.
 
@@ -95,10 +87,6 @@ items:
   source:
     id: flush
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 489
   summary: 'Delete already-read data (all data to the left of the position).
 
@@ -119,10 +107,6 @@ items:
   source:
     id: read
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 481
   summary: 'Read and move the cursor.
 
@@ -143,10 +127,6 @@ items:
   source:
     id: seek
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 505
   summary: 'Seek to a position (backwards only) within the internal buffer.
 
@@ -177,10 +157,6 @@ items:
   source:
     id: tell
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 501
   summary: 'Report how many bytes have been read from the buffer in total.
 
@@ -201,10 +177,6 @@ items:
   source:
     id: write
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 471
   summary: 'Append to the end of the buffer without changing the position.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.yml
@@ -14,10 +14,6 @@ items:
   source:
     id: fileio
     path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/fileio.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Module for file-like access of blobs, usually invoked via Blob.open().
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.hmac_key.HMACKeyMetadata.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.hmac_key.HMACKeyMetadata.yml
@@ -31,10 +31,6 @@ items:
   source:
     id: HMACKeyMetadata
     path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 28
   summary: 'Metadata about an HMAC service account key withn Cloud Storage.
 
@@ -67,10 +63,6 @@ items:
   source:
     id: ACTIVE_STATE
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Key is active, and may be used to sign requests.
 
@@ -89,10 +81,6 @@ items:
   source:
     id: DELETED_STATE
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Key is deleted.  It cannot be re-activated.
 
@@ -111,10 +99,6 @@ items:
   source:
     id: INACTIVE_STATE
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Key is inactive, and may not be used to sign requests.
 
@@ -137,10 +121,6 @@ items:
   source:
     id: access_id
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Access ID of the key.
 
@@ -162,10 +142,6 @@ items:
   source:
     id: delete
     path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 277
   summary: 'Delete the key from Cloud Storage.
 
@@ -196,10 +172,6 @@ items:
   source:
     id: etag
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'ETag identifying the version of the key metadata.
 
@@ -221,10 +193,6 @@ items:
   source:
     id: exists
     path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 190
   summary: 'Determine whether or not the key for this metadata exists.
 
@@ -255,10 +223,6 @@ items:
   source:
     id: id
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'ID of the key, including the Project ID and the Access ID.
 
@@ -281,10 +245,6 @@ items:
   source:
     id: path
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Resource path for the metadata''s key.
 
@@ -305,10 +265,6 @@ items:
   source:
     id: project
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Project ID associated with the key.
 
@@ -330,10 +286,6 @@ items:
   source:
     id: reload
     path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 222
   summary: 'Reload properties from Cloud Storage.
 
@@ -364,10 +316,6 @@ items:
   source:
     id: service_account_email
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Service account e-mail address associated with the key.
 
@@ -390,10 +338,6 @@ items:
   source:
     id: state
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: "Get / set key's state.\n\nOne of:\n    - `ACTIVE`\n    - `INACTIVE`\n\
     \    - `DELETED`\n"
@@ -415,10 +359,6 @@ items:
   source:
     id: time_created
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the timestamp at which the HMAC key was created.
 
@@ -441,10 +381,6 @@ items:
   source:
     id: update
     path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 249
   summary: 'Save writable properties to Cloud Storage.
 
@@ -476,10 +412,6 @@ items:
   source:
     id: updated
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Retrieve the timestamp at which the HMAC key was created.
 
@@ -503,10 +435,6 @@ items:
   source:
     id: user_project
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Project ID to be billed for API requests made via this bucket.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.hmac_key.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.hmac_key.yml
@@ -12,10 +12,6 @@ items:
   source:
     id: hmac_key
     path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/hmac_key.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Configure HMAC keys that can be used to authenticate requests to Google
     Cloud Storage.

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.notification.BucketNotification.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.notification.BucketNotification.yml
@@ -31,10 +31,6 @@ items:
   source:
     id: BucketNotification
     path: tests/testdata/handwritten/google/cloud/storage/notification.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/notification.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 48
   summary: 'Represent a single notification resource for a bucket.
 
@@ -86,10 +82,6 @@ items:
   source:
     id: blob_name_prefix
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Prefix of blob names for which notification events are published.
 
@@ -110,10 +102,6 @@ items:
   source:
     id: bucket
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Bucket to which the notification is bound.
 
@@ -134,10 +122,6 @@ items:
   source:
     id: client
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The client bound to this notfication.
 
@@ -157,10 +141,6 @@ items:
   source:
     id: create
     path: tests/testdata/handwritten/google/cloud/storage/notification.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/notification.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 233
   summary: 'API wrapper: create the notification.
 
@@ -205,10 +185,6 @@ items:
   source:
     id: custom_attributes
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Custom attributes passed with notification events.
 
@@ -228,10 +204,6 @@ items:
   source:
     id: delete
     path: tests/testdata/handwritten/google/cloud/storage/notification.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/notification.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 374
   summary: 'Delete this notification.
 
@@ -278,10 +250,6 @@ items:
   source:
     id: etag
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Server-set ETag of notification resource.
 
@@ -302,10 +270,6 @@ items:
   source:
     id: event_types
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Event types for which notification events are published.
 
@@ -325,10 +289,6 @@ items:
   source:
     id: exists
     path: tests/testdata/handwritten/google/cloud/storage/notification.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/notification.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 285
   summary: 'Test whether this notification exists.
 
@@ -375,10 +335,6 @@ items:
   source:
     id: from_api_repr
     path: tests/testdata/handwritten/google/cloud/storage/notification.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/notification.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 125
   summary: 'Construct an instance from the JSON repr returned by the server.
 
@@ -411,10 +367,6 @@ items:
   source:
     id: notification_id
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Server-set ID of notification resource.
 
@@ -435,10 +387,6 @@ items:
   source:
     id: path
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'The URL path for this notification.
 
@@ -459,10 +407,6 @@ items:
   source:
     id: payload_format
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Format of payload of notification events.
 
@@ -482,10 +426,6 @@ items:
   source:
     id: reload
     path: tests/testdata/handwritten/google/cloud/storage/notification.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/notification.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 332
   summary: 'Update this notification from the server configuration.
 
@@ -530,10 +470,6 @@ items:
   source:
     id: self_link
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Server-set ETag of notification resource.
 
@@ -554,10 +490,6 @@ items:
   source:
     id: topic_name
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Topic name to which notifications are published.
 
@@ -578,10 +510,6 @@ items:
   source:
     id: topic_project
     path: null
-    remote:
-      branch: add_goldens
-      path: null
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: null
   summary: 'Project ID of topic to which notifications are published.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.notification.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.notification.yml
@@ -12,10 +12,6 @@ items:
   source:
     id: notification
     path: tests/testdata/handwritten/google/cloud/storage/notification.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/notification.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Configure bucket notification resources to interact with Google Cloud
     Pub/Sub.

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.retry.ConditionalRetryPolicy.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.retry.ConditionalRetryPolicy.yml
@@ -14,10 +14,6 @@ items:
   source:
     id: ConditionalRetryPolicy
     path: tests/testdata/handwritten/google/cloud/storage/retry.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/retry.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 71
   summary: 'A class for use when an API call is only conditionally safe to retry.
 

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.retry.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.retry.yml
@@ -16,10 +16,6 @@ items:
   source:
     id: retry
     path: tests/testdata/handwritten/google/cloud/storage/retry.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/retry.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 0
   summary: 'Helpers for configuring retries with exponential back-off.
 
@@ -40,10 +36,6 @@ items:
   source:
     id: is_etag_in_data
     path: tests/testdata/handwritten/google/cloud/storage/retry.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/retry.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 124
   summary: 'Return True if an etag is contained in the request body.
 
@@ -66,10 +58,6 @@ items:
   source:
     id: is_etag_in_json
     path: tests/testdata/handwritten/google/cloud/storage/retry.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/retry.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 133
   summary: '`is_etag_in_json` is supported for backwards-compatibility reasons only;
 
@@ -91,10 +79,6 @@ items:
   source:
     id: is_generation_specified
     path: tests/testdata/handwritten/google/cloud/storage/retry.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/retry.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 111
   summary: 'Return True if generation or if_generation_match is specified.
 
@@ -114,10 +98,6 @@ items:
   source:
     id: is_metageneration_specified
     path: tests/testdata/handwritten/google/cloud/storage/retry.py
-    remote:
-      branch: add_goldens
-      path: tests/testdata/handwritten/google/cloud/storage/retry.py
-      repo: https://github.com/googleapis/sphinx-docfx-yaml
     startLine: 118
   summary: 'Return True if if_metageneration_match is specified.
 


### PR DESCRIPTION
The `remote` settings are not consumed for c.g.c. usage or anywhere else. Removing it in the meanwhile because this discrepancy is causing test failures and also causing local test failure for repo.

Fixes #264.

- [x] Tests pass
