### PR TITLE
feat!: retrieve all markdown pages

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -26,6 +26,8 @@ import shutil
 import black
 import logging
 
+from collections import defaultdict
+from collections.abc import MutableSet
 from pathlib import Path
 from functools import partial
 from itertools import zip_longest
@@ -160,8 +162,11 @@ def build_init(app):
     app.env.docfx_uid_names = {}
     # This stores file path for class when inspect cannot retrieve file path
     app.env.docfx_class_paths = {}
-    # This stores the name and href of the markdown pages.
-    app.env.markdown_pages = []
+    # This stores the name and href of the nested markdown pages.
+    app.env.markdown_pages = defaultdict(list)
+    # This stores all the markdown pages moved from the plugin, will be used
+    # to compare and delete unused pages.
+    app.env.moved_markdown_pages = set()
 
     app.env.docfx_xrefs = {}
 
@@ -1547,6 +1552,68 @@ def search_cross_references(obj, current_object_name: str, known_uids: List[str]
                     markdown_utils.reformat_markdown_to_html(attribute_type))
 
 
+# Type alias used for toc_yaml entries.
+_toc_yaml_type_alias = dict[str, any]
+
+def merge_markdown_and_package_toc(
+    app,
+    pkg_toc_yaml: _toc_yaml_type_alias,
+    markdown_toc_yaml: _toc_yaml_type_alias,
+    known_uids: set[str],
+) -> tuple[MutableSet[str], list[_toc_yaml_type_alias]]:
+    """
+    Merges the markdown and package table of contents.
+
+    Args:
+        app: Sphinx application.
+        pkg_toc_yaml: table of content for package files.
+        markdown_toc_yaml: table fo content for markdown files.
+
+    Returns:
+        A set of markdown pages that has been added, and the merged table of
+        contents file, with files in the correct position.
+    """
+    added_pages = set()
+
+    pkg_toc_queue = [pkg_toc_yaml]
+    for entry in pkg_toc_queue:
+        if (children := entry.get('items')):
+            pkg_toc_queue.extend(children)
+        entry_name = entry['name'].lower()
+        if entry_name not in markdown_toc_yaml:
+            continue
+
+        markdown_pages_to_add = []
+        for page in markdown_toc_yaml[entry_name]:
+            if page['href'].split('.')[0] not in known_uids and (
+                page['href'] not in added_pages):
+                markdown_pages_to_add.append(
+                    {'name': page['name'], 'href': page['href']}
+                )
+
+        if not markdown_pages_to_add:
+            continue
+
+        markdown_pages_to_add = sorted(
+            markdown_pages_to_add,
+            key=lambda entry: entry['href'])
+
+        entry['items'] = markdown_pages_to_add + entry['items']
+        added_pages.update({
+            page['href'] for page in markdown_pages_to_add
+        })
+
+    if (top_level_pages := markdown_toc_yaml.get('/')) is None or (
+        top_level_pages and top_level_pages[0]['href'] != 'index.md'):
+        return added_pages, [pkg_toc_yaml]
+
+    added_pages.update({
+        page['href'] for page in top_level_pages
+    })
+
+    return added_pages, top_level_pages + [pkg_toc_yaml]
+
+
 def build_finished(app, exception):
     """
     Output YAML on the file system.
@@ -1799,13 +1866,26 @@ def build_finished(app, exception):
 
     sanitize_uidname_field(pkg_toc_yaml)
 
+    known_uids = {
+        uid.split('.')[-1]
+        for uid in app.env.docfx_uid_names
+    }
+
+    added_pages, pkg_toc_yaml = merge_markdown_and_package_toc(
+        app, pkg_toc_yaml[0], app.env.markdown_pages, known_uids)
+
+    # Remove unused pages after merging the table of contents.
+    if added_pages:
+        markdown_utils.remove_unused_pages(
+            added_pages, app.env.moved_markdown_pages, normalized_outdir)
+
     toc_file = os.path.join(normalized_outdir, 'toc.yml')
     with open(toc_file, 'w') as writable:
         writable.write(
             dump(
                 [{
                     'name': app.config.project,
-                    'items': app.env.markdown_pages + pkg_toc_yaml
+                    'items': pkg_toc_yaml
                 }],
                 default_flow_style=False,
             )

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1557,7 +1557,7 @@ _toc_yaml_type_alias = dict[str, any]
 
 def merge_markdown_and_package_toc(
     app,
-    pkg_toc_yaml: _toc_yaml_type_alias,
+    pkg_toc_yaml: list[_toc_yaml_type_alias],
     markdown_toc_yaml: _toc_yaml_type_alias,
     known_uids: set[str],
 ) -> tuple[MutableSet[str], list[_toc_yaml_type_alias]]:
@@ -1575,7 +1575,7 @@ def merge_markdown_and_package_toc(
     """
     added_pages = set()
 
-    pkg_toc_queue = [pkg_toc_yaml]
+    pkg_toc_queue = [package for package in pkg_toc_yaml]
     for entry in pkg_toc_queue:
         if (children := entry.get('items')):
             pkg_toc_queue.extend(children)
@@ -1611,7 +1611,7 @@ def merge_markdown_and_package_toc(
         page['href'] for page in top_level_pages
     })
 
-    return added_pages, top_level_pages + [pkg_toc_yaml]
+    return added_pages, top_level_pages + pkg_toc_yaml
 
 
 def build_finished(app, exception):
@@ -1872,7 +1872,7 @@ def build_finished(app, exception):
     }
 
     added_pages, pkg_toc_yaml = merge_markdown_and_package_toc(
-        app, pkg_toc_yaml[0], app.env.markdown_pages, known_uids)
+        app, pkg_toc_yaml, app.env.markdown_pages, known_uids)
 
     # Remove unused pages after merging the table of contents.
     if added_pages:

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1558,18 +1558,18 @@ def merge_markdown_and_package_toc(
         toc_yaml_entry: list[_toc_yaml_type_alias],
     ) -> list[_toc_yaml_type_alias]:
         """Flattens and retrieves all children within pkg_toc_yaml."""
-        toc_queue = list(toc_yaml_entry)
-        for entry in toc_queue:
+        entries = list(toc_yaml_entry)
+        for entry in toc_yaml_entry:
             if (children := entry.get('items')):
-                toc_queue.extend(_flatten_toc(children))
-                toc_queue.extend(children)
-        return toc_queue
+                entries.extend(_flatten_toc(children))
+                entries.extend(children)
+        return entries
 
     added_pages = set()
 
-    pkg_toc_queue = _flatten_toc(pkg_toc_yaml)
+    pkg_toc_entries = _flatten_toc(pkg_toc_yaml)
 
-    for entry in pkg_toc_queue:
+    for entry in pkg_toc_entries:
         entry_name = entry['name'].lower()
         if entry_name not in markdown_toc_yaml:
             continue

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1537,7 +1537,6 @@ def search_cross_references(obj, current_object_name: str, known_uids: List[str]
 _toc_yaml_type_alias = dict[str, any]
 
 def merge_markdown_and_package_toc(
-    app: sphinx.application,
     pkg_toc_yaml: list[_toc_yaml_type_alias],
     markdown_toc_yaml: _toc_yaml_type_alias,
     known_uids: set[str],
@@ -1546,7 +1545,6 @@ def merge_markdown_and_package_toc(
     Merges the markdown and package table of contents.
 
     Args:
-        app: Sphinx application.
         pkg_toc_yaml: table of content for package files.
         markdown_toc_yaml: table fo content for markdown files.
 
@@ -1562,7 +1560,6 @@ def merge_markdown_and_package_toc(
         for entry in toc_yaml_entry:
             if (children := entry.get('items')):
                 entries.extend(_flatten_toc(children))
-                entries.extend(children)
         return entries
 
     added_pages = set()
@@ -1851,7 +1848,7 @@ def build_finished(app, exception):
     }
 
     added_pages, pkg_toc_yaml = merge_markdown_and_package_toc(
-        app, pkg_toc_yaml, app.env.markdown_pages, known_uids)
+        pkg_toc_yaml, app.env.markdown_pages, known_uids)
 
     # Remove unused pages after merging the table of contents.
     if added_pages:

--- a/docfx_yaml/markdown_utils.py
+++ b/docfx_yaml/markdown_utils.py
@@ -262,7 +262,7 @@ def move_markdown_pages(
     base_markdown_dir = Path(app.builder.outdir).parent / "markdown"
 
     markdown_dir = (
-        base_markdown_dir / '/'.join(cwd)
+        base_markdown_dir.joinpath(*cwd)
         if cwd
         else base_markdown_dir
     )

--- a/docfx_yaml/markdown_utils.py
+++ b/docfx_yaml/markdown_utils.py
@@ -16,11 +16,12 @@
 """Markdown related utilities for Sphinx DocFX YAML extension."""
 
 
+from collections.abc import MutableSet
 import os
 from pathlib import Path
 import re
 import shutil
-from typing import Iterable
+from typing import Iterable, List, Optional
 
 from docuploader import shell
 import sphinx.application
@@ -231,7 +232,11 @@ def _prepend_markdown_header(filename: str, mdfile: Iterable[str]) -> None:
     mdfile.write(file_content)
 
 
-def move_markdown_pages(app: sphinx.application, outdir: Path) -> None:
+def move_markdown_pages(
+    app: sphinx.application,
+    outdir: Path,
+    cwd: Optional[List[str]] = [],
+) -> None:
     """Moves markdown pages to be added to the generated reference documentation.
 
     Markdown pages may be hand written or auto generated. They're processed
@@ -254,7 +259,14 @@ def move_markdown_pages(app: sphinx.application, outdir: Path) -> None:
         'readme.md': 'index.md',
     }
 
-    markdown_dir = Path(app.builder.outdir).parent / "markdown"
+    base_markdown_dir = Path(app.builder.outdir).parent / "markdown"
+
+    markdown_dir = (
+        base_markdown_dir / '/'.join(cwd)
+        if cwd
+        else base_markdown_dir
+    )
+
     if not markdown_dir.exists():
         print("There's no markdown file to move.")
         return
@@ -264,6 +276,12 @@ def move_markdown_pages(app: sphinx.application, outdir: Path) -> None:
 
     # For each file, if it is a markdown file move to the top level pages.
     for mdfile in markdown_dir.iterdir():
+        if mdfile.is_dir():
+            cwd.append(mdfile.name)
+            move_markdown_pages(app, outdir, cwd)
+            # Restore the original cwd after finish working on the directory.
+            cwd.pop()
+
         if mdfile.is_file() and mdfile.name.lower() not in files_to_ignore:
             mdfile_name = ""
 
@@ -288,6 +306,7 @@ def move_markdown_pages(app: sphinx.application, outdir: Path) -> None:
             mdfile_outdir = f"{outdir}/{mdfile_name_to_use}"
 
             shutil.copy(mdfile, mdfile_outdir)
+            app.env.moved_markdown_pages.add(mdfile_name_to_use)
 
             _highlight_md_codeblocks(mdfile_outdir)
             _clean_image_links(mdfile_outdir)
@@ -297,20 +316,29 @@ def move_markdown_pages(app: sphinx.application, outdir: Path) -> None:
                 # Save the index page entry.
                 index_page_entry = {
                     'name': 'Overview',
-                    'href': 'index.md'
+                    'href': 'index.md',
                 }
                 continue
 
+            if not cwd:
+                # Use '/' to reserve for top level pages.
+                app.env.markdown_pages['/'].append({
+                    'name': name,
+                    'href': mdfile_name_to_use,
+                })
+                continue
+
             # Add the file to the TOC later.
-            app.env.markdown_pages.append({
+            app.env.markdown_pages[cwd[-1]].append({
                 'name': name,
                 'href': mdfile_name_to_use,
             })
 
-    if app.env.markdown_pages:
-        # Sort the TOC alphabetically based on href entry.
-        app.env.markdown_pages = sorted(
-            app.env.markdown_pages,
+    if app.env.markdown_pages.get('/'):
+        # Sort the top level pages. Other pages will be sorted when they're
+        # added to package level files accordingly.
+        app.env.markdown_pages['/'] = sorted(
+            app.env.markdown_pages['/'],
             key=lambda entry: entry['href'],
         )
 
@@ -318,10 +346,42 @@ def move_markdown_pages(app: sphinx.application, outdir: Path) -> None:
             return
 
         # Place the Overview page at the top of the list.
-        app.env.markdown_pages.insert(
+        app.env.markdown_pages['/'].insert(
             0,
             index_page_entry,
         )
+
+
+def remove_unused_pages(
+    added_pages: MutableSet[str],
+    all_pages: MutableSet[str],
+    outdir: Path,
+) -> None:
+    """Removes unused markdown pages after merging the table of contents.
+
+    Pages may be generated as part of generating the document. API pages
+    are needed and may be generated as part of Sphinx config, but if not
+    used they will be identified and removed.
+
+    Args:
+        added_pages: markdown pages that have been added to the merged
+            table of contents.
+        all_pages: set of all markdown pages generated.
+        outdir: output directory containing the markdown pages.
+    """
+
+    pages_to_remove = set(
+        page for page in all_pages
+        if page not in added_pages
+    )
+
+    for page in pages_to_remove:
+        try:
+            os.remove(f"{outdir}/{page}")
+        except FileNotFoundError:
+            # This shouldn't happen, but in case we fail, ignore the failure
+            # and continue deleting other files.
+            print(f"Could not delete {page}.")
 
 
 def run_sphinx_markdown() -> None:

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     package_dir={'': '.'},
     packages=packages,
     install_requires=dependencies,
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     include_package_data=True,
     zip_safe=False,
     **extra_setup

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,9 +1,11 @@
 from docfx_yaml import markdown_utils
 
-
 import unittest
+from unittest.mock import patch
 from parameterized import parameterized
+import pathlib
 
+import os
 from yaml import load, Loader
 
 import tempfile
@@ -246,6 +248,30 @@ For example:
             header_line_got = markdown_utils._extract_header_from_markdown(mdfile)
 
         self.assertFalse(header_line_got)
+
+
+    def test_remove_unused_pages(self):
+        # Check that pages are removed as expected.
+        added_page = ['safe.md']
+        all_pages = ['to_delete.md', 'safe.md']
+        outdir = pathlib.Path('output_path')
+
+        expected_delete_call = f"{outdir}/to_delete.md"
+
+        with patch('os.remove') as mock_os_remove:
+            markdown_utils.remove_unused_pages(added_page, all_pages, outdir)
+            mock_os_remove.assert_called_once_with(expected_delete_call)
+
+
+    def test_remove_unused_pages_with_exception(self):
+        # Check that the method still runs as expected.
+        added_page = ['safe.md']
+        all_pages = ['does_not_exist.md', 'safe.md']
+        outdir = pathlib.Path('output_path')
+
+        self.assertFalse(os.path.isfile(outdir / 'does_not_exist.md'))
+
+        markdown_utils.remove_unused_pages(added_page, all_pages, outdir)
 
 
 if __name__ == '__main__':

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -8,6 +8,7 @@ import pathlib
 import os
 from yaml import load, Loader
 
+import pytest
 import tempfile
 
 class TestGenerate(unittest.TestCase):
@@ -271,7 +272,10 @@ For example:
 
         self.assertFalse(os.path.isfile(outdir / 'does_not_exist.md'))
 
-        markdown_utils.remove_unused_pages(added_page, all_pages, outdir)
+        try:
+            markdown_utils.remove_unused_pages(added_page, all_pages, outdir)
+        except FileNotFoundError:
+            pytest.fail('Should not have thrown an exception.')
 
 
 if __name__ == '__main__':

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -816,5 +816,74 @@ this is not a properly formatted warning.
             self.assertDictEqual(attribute_got, attribute_want)
 
 
+    def test_merge_markdown_and_package_toc(self):
+        known_uids = {'acl','batch','blob','client','constants','fileio','hmac_key','notification','retry'}
+        markdown_pages = {
+            'storage': [
+                {'name': 'FileIO', 'href': 'fileio.md'},
+                {'name': 'Retry', 'href': 'retry.md'},
+                {'name': 'Notification', 'href': 'notification.md'},
+                {'name': 'HMAC Key Metadata', 'href': 'hmac_key.md'},
+                {'name': 'Batches', 'href': 'batch.md'},
+                {'name': 'Constants', 'href': 'constants.md'},
+                {'name': 'Storage Client', 'href': 'client.md'},
+                {'name': 'Blobs / Objects', 'href': 'blobs.md'}
+            ],
+            'acl': [
+                {'name': 'ACL', 'href': 'acl.md'},
+                {'name': 'ACL guide', 'href': 'acl_guide.md'}
+            ],
+            '/': [
+                {'name': 'Overview', 'href': 'index.md'},
+                {'name': 'Changelog', 'href': 'changelog.md'}
+            ],
+        }
+        pkg_toc_yaml = [
+            {'name': 'Storage',
+                'items': [
+                    {'name': 'acl', 'uid': 'google.cloud.storage.acl', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.acl'}]},
+                    {'name': 'batch', 'uid': 'google.cloud.storage.batch', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.batch'}]},
+                    {'name': 'blob', 'uid': 'google.cloud.storage.blob', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.blob'}]},
+                    {'name': 'bucket', 'uid': 'google.cloud.storage.bucket', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.bucket'}]},
+                    {'name': 'client', 'uid': 'google.cloud.storage.client', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.client'}]},
+                    {'name': 'constants', 'uid': 'google.cloud.storage.constants'},
+                    {'name': 'fileio', 'uid': 'google.cloud.storage.fileio', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.fileio'}]},
+                    {'name': 'hmac_key', 'uid': 'google.cloud.storage.hmac_key', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.hmac_key'}]},
+                    {'name': 'notification', 'uid': 'google.cloud.storage.notification', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.notification'}]},
+                    {'name': 'retry', 'uid': 'google.cloud.storage.retry', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.retry'}]},
+                ]
+             },
+        ]
+
+        added_pages, merged_pkg_toc_yaml = extension.merge_markdown_and_package_toc(
+            pkg_toc_yaml, markdown_pages, known_uids)
+
+        expected_added_pages = {'index.md', 'changelog.md', 'blobs.md', 'acl_guide.md'}
+        expected_merged_pkg_toc_yaml = [
+            {'name': 'Overview', 'href': 'index.md'},
+            {'name': 'Changelog', 'href': 'changelog.md'},
+            {'name': 'Storage',
+                'items': [
+                    {'name': 'Blobs / Objects', 'href': 'blobs.md'},
+                    {'name': 'acl', 'uid': 'google.cloud.storage.acl', 'items': [
+                        {'name': 'ACL guide', 'href': 'acl_guide.md'},
+                        {'name': 'Overview', 'uid': 'google.cloud.storage.acl'},
+                    ]},
+                    {'name': 'batch', 'uid': 'google.cloud.storage.batch', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.batch'}]},
+                    {'name': 'blob', 'uid': 'google.cloud.storage.blob', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.blob'}]},
+                    {'name': 'bucket', 'uid': 'google.cloud.storage.bucket', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.bucket'}]},
+                    {'name': 'client', 'uid': 'google.cloud.storage.client', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.client'}]},
+                    {'name': 'constants', 'uid': 'google.cloud.storage.constants'},
+                    {'name': 'fileio', 'uid': 'google.cloud.storage.fileio', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.fileio'}]},
+                    {'name': 'hmac_key', 'uid': 'google.cloud.storage.hmac_key', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.hmac_key'}]},
+                    {'name': 'notification', 'uid': 'google.cloud.storage.notification', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.notification'}]},
+                    {'name': 'retry', 'uid': 'google.cloud.storage.retry', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.retry'}]},
+                ]
+             },
+        ]
+        self.assertSetEqual(added_pages, expected_added_pages)
+        self.assertListEqual(merged_pkg_toc_yaml, expected_merged_pkg_toc_yaml)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testdata/goldens/handwritten/blobs.md
+++ b/tests/testdata/goldens/handwritten/blobs.md
@@ -1,0 +1,2518 @@
+# Blobs / Objects
+
+Create / interact with Google Cloud Storage blobs.
+
+
+### _class_ google.cloud.storage.blob.Blob(name, bucket, chunk_size=None, encryption_key=None, kms_key_name=None, generation=None)
+Bases: `google.cloud.storage._helpers._PropertyMixin`
+
+A wrapper around Cloud Storage’s concept of an `Object`.
+
+
+* **Parameters**
+
+    
+    * **name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The name of the blob.  This corresponds to the unique path of
+    the object in the bucket. If bytes, will be converted to a
+    unicode object. Blob / object names can contain any sequence
+    of valid unicode characters, of length 1-1024 bytes when
+    UTF-8 encoded.
+
+
+    * **bucket** ([`google.cloud.storage.bucket.Bucket`](buckets.md#google.cloud.storage.bucket.Bucket)) – The bucket to which this blob belongs.
+
+
+    * **chunk_size** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The size of a chunk of data whenever iterating (in bytes).
+    This must be a multiple of 256 KB per the API specification. If not
+    specified, the chunk_size of the blob itself is used. If that is not
+    specified, a default value of 40 MB is used.
+
+
+    * **encryption_key** ([*bytes*](https://python.readthedocs.io/en/latest/library/stdtypes.html#bytes)) – (Optional) 32 byte encryption key for customer-supplied encryption.
+    See [https://cloud.google.com/storage/docs/encryption#customer-supplied](https://cloud.google.com/storage/docs/encryption#customer-supplied).
+
+
+    * **kms_key_name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Resource name of Cloud KMS key used to encrypt the blob’s
+    contents.
+
+
+    * **generation** (*long*) – (Optional) If present, selects a specific revision of this object.
+
+
+property `name`
+
+    Get the blob’s name.
+
+
+#### STORAGE_CLASSES(_ = ('STANDARD', 'NEARLINE', 'COLDLINE', 'ARCHIVE', 'MULTI_REGIONAL', 'REGIONAL'_ )
+Allowed values for `storage_class`.
+
+See
+[https://cloud.google.com/storage/docs/json_api/v1/objects#storageClass](https://cloud.google.com/storage/docs/json_api/v1/objects#storageClass)
+[https://cloud.google.com/storage/docs/per-object-storage-class](https://cloud.google.com/storage/docs/per-object-storage-class)
+
+**NOTE**: This list does not include ‘DURABLE_REDUCED_AVAILABILITY’, which
+is only documented for buckets (and deprecated).
+
+
+#### _property_ acl()
+Create our ACL on demand.
+
+
+#### _property_ bucket()
+Bucket which contains the object.
+
+
+* **Return type**
+
+    [`Bucket`](buckets.md#google.cloud.storage.bucket.Bucket)
+
+
+
+* **Returns**
+
+    The object’s bucket.
+
+
+
+#### _property_ cache_control()
+HTTP ‘Cache-Control’ header for this object.
+
+See [RFC 7234]([https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2))
+and [API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)).
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+#### _property_ chunk_size()
+Get the blob’s default chunk size.
+
+
+* **Return type**
+
+    int or `NoneType`
+
+
+
+* **Returns**
+
+    The current blob’s chunk size, if it is set.
+
+
+
+#### _property_ client()
+The client bound to this blob.
+
+
+#### _property_ component_count()
+Number of underlying components that make up this object.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    int or `NoneType`
+
+
+
+* **Returns**
+
+    The component count (in case of a composed object) or
+    `None` if the blob’s resource has not been loaded from
+    the server.  This property will not be set on objects
+    not created via `compose`.
+
+
+
+#### compose(sources, client=None, timeout=60, if_generation_match=None, if_metageneration_match=None, if_source_generation_match=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Concatenate source blobs into this one.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+See [API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects/compose](https://cloud.google.com/storage/docs/json_api/v1/objects/compose))
+and a [code sample]([https://cloud.google.com/storage/docs/samples/storage-compose-file#storage_compose_file-python](https://cloud.google.com/storage/docs/samples/storage-compose-file#storage_compose_file-python)).
+
+
+* **Parameters**
+
+    
+    * **sources** (list of `Blob`) – Blobs whose contents will be composed into this blob.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use. If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **if_generation_match** (*long*) – (Optional) Makes the operation conditional on whether the
+    destination object’s current generation matches the given value.
+    Setting to 0 makes the operation succeed only if there are no live
+    versions of the object.
+    Note: In a previous version, this argument worked identically to the
+    `if_source_generation_match` argument. For
+    backwards-compatibility reasons, if a list is passed in,
+    this argument will behave like `if_source_generation_match`
+    and also issue a DeprecationWarning.
+
+
+    * **if_metageneration_match** (*long*) – (Optional) Makes the operation conditional on whether the
+    destination object’s current metageneration matches the given
+    value.
+
+    If a list of long is passed in, no match operation will be
+    performed.  (Deprecated: type(list of long) is supported for
+    backwards-compatability reasons only.)
+
+
+
+    * **if_source_generation_match** (*list of long*) – (Optional) Makes the operation conditional on whether the current
+    generation of each source blob matches the corresponding generation.
+    The list must match `sources` item-to-item.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+#### _property_ content_disposition()
+HTTP ‘Content-Disposition’ header for this object.
+
+See [RFC 6266]([https://tools.ietf.org/html/rfc7234#section-5.2](https://tools.ietf.org/html/rfc7234#section-5.2)) and
+[API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)).
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+#### _property_ content_encoding()
+HTTP ‘Content-Encoding’ header for this object.
+
+See [RFC 7231]([https://tools.ietf.org/html/rfc7231#section-3.1.2.2](https://tools.ietf.org/html/rfc7231#section-3.1.2.2)) and
+[API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)).
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+#### _property_ content_language()
+HTTP ‘Content-Language’ header for this object.
+
+See [BCP47]([https://tools.ietf.org/html/bcp47](https://tools.ietf.org/html/bcp47)) and
+[API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)).
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+#### _property_ content_type()
+HTTP ‘Content-Type’ header for this object.
+
+See [RFC 2616]([https://tools.ietf.org/html/rfc2616#section-14.17](https://tools.ietf.org/html/rfc2616#section-14.17)) and
+[API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)).
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+#### _property_ crc32c()
+CRC32C checksum for this object.
+
+This returns the blob’s CRC32C checksum. To retrieve the value, first use a
+reload method of the Blob class which loads the blob’s properties from the server.
+
+See [RFC 4960]([https://tools.ietf.org/html/rfc4960#appendix-B](https://tools.ietf.org/html/rfc4960#appendix-B)) and
+[API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)).
+
+If not set before upload, the server will compute the hash.
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+#### create_resumable_upload_session(content_type=None, size=None, origin=None, client=None, timeout=60, checksum=None, predefined_acl=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Create a resumable upload session.
+
+Resumable upload sessions allow you to start an upload session from
+one client and complete the session in another. This method is called
+by the initiator to set the metadata and limits. The initiator then
+passes the session URL to the client that will upload the binary data.
+The client performs a PUT request on the session URL to complete the
+upload. This process allows untrusted clients to upload to an
+access-controlled bucket.
+
+For more details, see the
+documentation on [signed URLs]([https://cloud.google.com/storage/docs/access-control/signed-urls#signing-resumable](https://cloud.google.com/storage/docs/access-control/signed-urls#signing-resumable)).
+
+The content type of the upload will be determined in order
+of precedence:
+
+
+* The value passed in to this method (if not [`None`](https://python.readthedocs.io/en/latest/library/constants.html#None))
+
+
+* The value stored on the current blob
+
+
+* The default value (‘application/octet-stream’)
+
+**NOTE**: The effect of uploading to an existing blob depends on the
+“versioning” and “lifecycle” policies defined on the blob’s
+bucket.  In the absence of those policies, upload will
+overwrite any existing contents.
+
+See the [object versioning]([https://cloud.google.com/storage/docs/object-versioning](https://cloud.google.com/storage/docs/object-versioning))
+and [lifecycle]([https://cloud.google.com/storage/docs/lifecycle](https://cloud.google.com/storage/docs/lifecycle))
+API documents for details.
+
+If `encryption_key` is set, the blob will be encrypted with
+a [customer-supplied]([https://cloud.google.com/storage/docs/encryption#customer-supplied](https://cloud.google.com/storage/docs/encryption#customer-supplied))
+encryption key.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **size** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The maximum number of bytes that can be uploaded using
+    this session. If the size is not known when creating the session,
+    this should be left blank.
+
+
+    * **content_type** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Type of content being uploaded.
+
+
+    * **origin** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) If set, the upload can only be completed by a user-agent
+    that uploads from the given origin. This can be useful when passing
+    the session to a web client.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **checksum** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The type of checksum to compute to verify
+    the integrity of the object. After the upload is complete, the
+    server-computed checksum of the resulting object will be checked
+    and google.resumable_media.common.DataCorruption will be raised on
+    a mismatch. On a validation failure, the client will attempt to
+    delete the uploaded object automatically. Supported values
+    are “md5”, “crc32c” and None. The default is None.
+
+
+    * **predefined_acl** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Predefined access control list
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. A None value will disable
+    retries. A google.api_core.retry.Retry value will enable retries,
+    and the object will define retriable response codes and errors and
+    configure backoff and timeout options.
+    A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a
+    Retry object and activates it only if certain conditions are met.
+    This class exists to provide safe defaults for RPC calls that are
+    not technically safe to retry normally (due to potential data
+    duplication or other side-effects) but become safe to retry if a
+    condition such as if_generation_match is set.
+    See the retry.py source code and docstrings in this package
+    (google.cloud.storage.retry) for information on retry types and how
+    to configure them.
+    Media operations (downloads and uploads) do not support non-default
+    predicates in a Retry object. The default will always be used. Other
+    configuration changes for Retry objects such as delays and deadlines
+    are respected.
+
+
+
+* **Return type**
+
+    [str](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)
+
+
+
+* **Returns**
+
+    The resumable upload session URL. The upload can be
+    completed by making an HTTP PUT request with the
+    file’s contents.
+
+
+
+* **Raises**
+
+    `google.cloud.exceptions.GoogleCloudError`
+    if the session creation response returns an error status.
+
+
+
+#### _property_ custom_time()
+Retrieve the custom time for the object.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    [`datetime.datetime`](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.datetime) or `NoneType`
+
+
+
+* **Returns**
+
+    Datetime object parsed from RFC3339 valid timestamp, or
+    `None` if the blob’s resource has not been loaded from
+    the server (see `reload()`).
+
+
+
+#### delete(client=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Deletes a blob from Cloud Storage.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use. If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Raises**
+
+    `google.cloud.exceptions.NotFound`
+    (propagated from
+    [`google.cloud.storage.bucket.Bucket.delete_blob()`](buckets.md#google.cloud.storage.bucket.Bucket.delete_blob)).
+
+
+
+#### download_as_bytes(client=None, start=None, end=None, raw_download=False, if_etag_match=None, if_etag_not_match=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, checksum='md5', retry=<google.api_core.retry.Retry object>)
+Download the contents of this blob as a bytes object.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use. If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **start** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The first byte in a range to be downloaded.
+
+
+    * **end** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The last byte in a range to be downloaded.
+
+
+    * **raw_download** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) If true, download the object without any expansion.
+
+
+    * **if_etag_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_match](generation_metageneration.md#using-if-etag-match)
+
+
+    * **if_etag_not_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_not_match](generation_metageneration.md#using-if-etag-not-match)
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **checksum** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The type of checksum to compute to verify the integrity
+    of the object. The response headers must contain a checksum of the
+    requested type. If the headers lack an appropriate checksum (for
+    instance in the case of transcoded or ranged downloads where the
+    remote service does not know the correct checksum, including
+    downloads where chunk_size is set) an INFO-level log will be
+    emitted. Supported values are “md5”, “crc32c” and None. The default
+    is “md5”.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. A None value will disable
+    retries. A google.api_core.retry.Retry value will enable retries,
+    and the object will define retriable response codes and errors and
+    configure backoff and timeout options.
+
+    A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a
+    Retry object and activates it only if certain conditions are met.
+    This class exists to provide safe defaults for RPC calls that are
+    not technically safe to retry normally (due to potential data
+    duplication or other side-effects) but become safe to retry if a
+    condition such as if_metageneration_match is set.
+
+    See the retry.py source code and docstrings in this package
+    (google.cloud.storage.retry) for information on retry types and how
+    to configure them.
+
+    Media operations (downloads and uploads) do not support non-default
+    predicates in a Retry object. The default will always be used. Other
+    configuration changes for Retry objects such as delays and deadlines
+    are respected.
+
+
+
+
+* **Return type**
+
+    [bytes](https://python.readthedocs.io/en/latest/library/stdtypes.html#bytes)
+
+
+
+* **Returns**
+
+    The data stored in this blob.
+
+
+
+* **Raises**
+
+    `google.cloud.exceptions.NotFound`
+
+
+
+#### download_as_string(client=None, start=None, end=None, raw_download=False, if_etag_match=None, if_etag_not_match=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+(Deprecated) Download the contents of this blob as a bytes object.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+**NOTE**: Deprecated alias for `download_as_bytes()`.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use. If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **start** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The first byte in a range to be downloaded.
+
+
+    * **end** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The last byte in a range to be downloaded.
+
+
+    * **raw_download** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) If true, download the object without any expansion.
+
+
+    * **if_etag_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_match](generation_metageneration.md#using-if-etag-match)
+
+
+    * **if_etag_not_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_not_match](generation_metageneration.md#using-if-etag-not-match)
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. A None value will disable
+    retries. A google.api_core.retry.Retry value will enable retries,
+    and the object will define retriable response codes and errors and
+    configure backoff and timeout options.
+
+    A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a
+    Retry object and activates it only if certain conditions are met.
+    This class exists to provide safe defaults for RPC calls that are
+    not technically safe to retry normally (due to potential data
+    duplication or other side-effects) but become safe to retry if a
+    condition such as if_metageneration_match is set.
+
+    See the retry.py source code and docstrings in this package
+    (google.cloud.storage.retry) for information on retry types and how
+    to configure them.
+
+    Media operations (downloads and uploads) do not support non-default
+    predicates in a Retry object. The default will always be used. Other
+    configuration changes for Retry objects such as delays and deadlines
+    are respected.
+
+
+
+
+* **Return type**
+
+    [bytes](https://python.readthedocs.io/en/latest/library/stdtypes.html#bytes)
+
+
+
+* **Returns**
+
+    The data stored in this blob.
+
+
+
+* **Raises**
+
+    `google.cloud.exceptions.NotFound`
+
+
+
+#### download_as_text(client=None, start=None, end=None, raw_download=False, encoding=None, if_etag_match=None, if_etag_not_match=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+Download the contents of this blob as text (*not* bytes).
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use. If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **start** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The first byte in a range to be downloaded.
+
+
+    * **end** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The last byte in a range to be downloaded.
+
+
+    * **raw_download** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) If true, download the object without any expansion.
+
+
+    * **encoding** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) encoding to be used to decode the
+    downloaded bytes.  Defaults to the `charset` param of
+    attr:content_type, or else to “utf-8”.
+
+
+    * **if_etag_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_match](generation_metageneration.md#using-if-etag-match)
+
+
+    * **if_etag_not_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_not_match](generation_metageneration.md#using-if-etag-not-match)
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. A None value will disable
+    retries. A google.api_core.retry.Retry value will enable retries,
+    and the object will define retriable response codes and errors and
+    configure backoff and timeout options.
+
+    A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a
+    Retry object and activates it only if certain conditions are met.
+    This class exists to provide safe defaults for RPC calls that are
+    not technically safe to retry normally (due to potential data
+    duplication or other side-effects) but become safe to retry if a
+    condition such as if_metageneration_match is set.
+
+    See the retry.py source code and docstrings in this package
+    (google.cloud.storage.retry) for information on retry types and how
+    to configure them.
+
+    Media operations (downloads and uploads) do not support non-default
+    predicates in a Retry object. The default will always be used. Other
+    configuration changes for Retry objects such as delays and deadlines
+    are respected.
+
+
+
+
+* **Return type**
+
+    text
+
+
+
+* **Returns**
+
+    The data stored in this blob, decoded to text.
+
+
+
+#### download_to_file(file_obj, client=None, start=None, end=None, raw_download=False, if_etag_match=None, if_etag_not_match=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, checksum='md5', retry=<google.api_core.retry.Retry object>)
+DEPRECATED. Download the contents of this blob into a file-like object.
+
+**NOTE**: If the server-set property, `media_link`, is not yet
+initialized, makes an additional API request to load it.
+
+If the `chunk_size` of a current blob is None, will download data
+in single download request otherwise it will download the `chunk_size`
+of data in each request.
+
+For more fine-grained control over the download process, check out
+[google-resumable-media]([https://googleapis.dev/python/google-resumable-media/latest/index.html](https://googleapis.dev/python/google-resumable-media/latest/index.html)).
+For example, this library allows downloading **parts** of a blob rather than the whole thing.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **file_obj** (*file*) – A file handle to which to write the blob’s data.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **start** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The first byte in a range to be downloaded.
+
+
+    * **end** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The last byte in a range to be downloaded.
+
+
+    * **raw_download** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) If true, download the object without any expansion.
+
+
+    * **if_etag_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_match](generation_metageneration.md#using-if-etag-match)
+
+
+    * **if_etag_not_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_not_match](generation_metageneration.md#using-if-etag-not-match)
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **checksum** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The type of checksum to compute to verify the integrity
+    of the object. The response headers must contain a checksum of the
+    requested type. If the headers lack an appropriate checksum (for
+    instance in the case of transcoded or ranged downloads where the
+    remote service does not know the correct checksum, including
+    downloads where chunk_size is set) an INFO-level log will be
+    emitted. Supported values are “md5”, “crc32c” and None. The default
+    is “md5”.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. A None value will disable
+    retries. A google.api_core.retry.Retry value will enable retries,
+    and the object will define retriable response codes and errors and
+    configure backoff and timeout options.
+
+    A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a
+    Retry object and activates it only if certain conditions are met.
+    This class exists to provide safe defaults for RPC calls that are
+    not technically safe to retry normally (due to potential data
+    duplication or other side-effects) but become safe to retry if a
+    condition such as if_metageneration_match is set.
+
+    See the retry.py source code and docstrings in this package
+    (google.cloud.storage.retry) for information on retry types and how
+    to configure them.
+
+    Media operations (downloads and uploads) do not support non-default
+    predicates in a Retry object. The default will always be used. Other
+    configuration changes for Retry objects such as delays and deadlines
+    are respected.
+
+
+
+
+* **Raises**
+
+    `google.cloud.exceptions.NotFound`
+
+
+
+#### download_to_filename(filename, client=None, start=None, end=None, raw_download=False, if_etag_match=None, if_etag_not_match=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, checksum='md5', retry=<google.api_core.retry.Retry object>)
+Download the contents of this blob into a named file.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+See a [code sample]([https://cloud.google.com/storage/docs/samples/storage-download-encrypted-file#storage_download_encrypted_file-python](https://cloud.google.com/storage/docs/samples/storage-download-encrypted-file#storage_download_encrypted_file-python))
+to download a file with a [customer-supplied encryption key]([https://cloud.google.com/storage/docs/encryption#customer-supplied](https://cloud.google.com/storage/docs/encryption#customer-supplied)).
+
+
+* **Parameters**
+
+    
+    * **filename** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – A filename to be passed to `open`.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use. If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **start** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The first byte in a range to be downloaded.
+
+
+    * **end** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The last byte in a range to be downloaded.
+
+
+    * **raw_download** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) If true, download the object without any expansion.
+
+
+    * **if_etag_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_match](generation_metageneration.md#using-if-etag-match)
+
+
+    * **if_etag_not_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_not_match](generation_metageneration.md#using-if-etag-not-match)
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **checksum** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The type of checksum to compute to verify the integrity
+    of the object. The response headers must contain a checksum of the
+    requested type. If the headers lack an appropriate checksum (for
+    instance in the case of transcoded or ranged downloads where the
+    remote service does not know the correct checksum, including
+    downloads where chunk_size is set) an INFO-level log will be
+    emitted. Supported values are “md5”, “crc32c” and None. The default
+    is “md5”.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. A None value will disable
+    retries. A google.api_core.retry.Retry value will enable retries,
+    and the object will define retriable response codes and errors and
+    configure backoff and timeout options.
+
+    A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a
+    Retry object and activates it only if certain conditions are met.
+    This class exists to provide safe defaults for RPC calls that are
+    not technically safe to retry normally (due to potential data
+    duplication or other side-effects) but become safe to retry if a
+    condition such as if_metageneration_match is set.
+
+    See the retry.py source code and docstrings in this package
+    (google.cloud.storage.retry) for information on retry types and how
+    to configure them.
+
+    Media operations (downloads and uploads) do not support non-default
+    predicates in a Retry object. The default will always be used. Other
+    configuration changes for Retry objects such as delays and deadlines
+    are respected.
+
+
+
+
+* **Raises**
+
+    `google.cloud.exceptions.NotFound`
+
+
+
+#### _property_ encryption_key()
+Retrieve the customer-supplied encryption key for the object.
+
+
+* **Return type**
+
+    bytes or `NoneType`
+
+
+
+* **Returns**
+
+    The encryption key or `None` if no customer-supplied encryption key was used,
+    or the blob’s resource has not been loaded from the server.
+
+
+
+#### _property_ etag()
+Retrieve the ETag for the object.
+
+See [RFC 2616 (etags)]([https://tools.ietf.org/html/rfc2616#section-3.11](https://tools.ietf.org/html/rfc2616#section-3.11)) and
+[API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)).
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    The blob etag or `None` if the blob’s resource has not
+    been loaded from the server.
+
+
+
+#### _property_ event_based_hold()
+Is an event-based hold active on the object?
+
+See [API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)).
+
+If the property is not set locally, returns [`None`](https://python.readthedocs.io/en/latest/library/constants.html#None).
+
+
+* **Return type**
+
+    bool or `NoneType`
+
+
+
+#### exists(client=None, if_etag_match=None, if_etag_not_match=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+Determines whether or not this blob exists.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **if_etag_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_match](generation_metageneration.md#using-if-etag-match)
+
+
+    * **if_etag_not_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_not_match](generation_metageneration.md#using-if-etag-not-match)
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    [bool](https://python.readthedocs.io/en/latest/library/functions.html#bool)
+
+
+
+* **Returns**
+
+    True if the blob exists in Cloud Storage.
+
+
+
+#### _classmethod_ from_string(uri, client=None)
+Get a constructor for blob object by URI.
+
+```python
+from google.cloud import storage
+from google.cloud.storage.blob import Blob
+client = storage.Client()
+blob = Blob.from_string("gs://bucket/object", client=client)
+```
+
+
+* **Parameters**
+
+    
+    * **uri** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The blob uri pass to get blob object.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  Application code should
+    *always* pass `client`.
+
+
+
+* **Return type**
+
+    `google.cloud.storage.blob.Blob`
+
+
+
+* **Returns**
+
+    The blob object created.
+
+
+
+#### generate_signed_url(expiration=None, api_access_endpoint='https://storage.googleapis.com', method='GET', content_md5=None, content_type=None, response_disposition=None, response_type=None, generation=None, headers=None, query_parameters=None, client=None, credentials=None, version=None, service_account_email=None, access_token=None, virtual_hosted_style=False, bucket_bound_hostname=None, scheme='http')
+Generates a signed URL for this blob.
+
+**NOTE**: If you are on Google Compute Engine, you can’t generate a signed
+URL using GCE service account.
+If you’d like to be able to generate a signed URL from GCE,
+you can use a standard service account from a JSON file rather
+than a GCE service account.
+
+If you have a blob that you want to allow access to for a set
+amount of time, you can use this method to generate a URL that
+is only valid within a certain time period.
+
+See a [code sample]([https://cloud.google.com/storage/docs/samples/storage-generate-signed-url-v4#storage_generate_signed_url_v4-python](https://cloud.google.com/storage/docs/samples/storage-generate-signed-url-v4#storage_generate_signed_url_v4-python)).
+
+This is particularly useful if you don’t want publicly
+accessible blobs, but don’t want to require users to explicitly
+log in.
+
+If `bucket_bound_hostname` is set as an argument of `api_access_endpoint`,
+`https` works only if using a `CDN`.
+
+
+* **Parameters**
+
+    
+    * **expiration** (*Union**[**Integer**, *[*datetime.datetime*](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.datetime)*, *[*datetime.timedelta*](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.timedelta)*]*) – Point in time when the signed URL should expire. If a `datetime`
+    instance is passed without an explicit `tzinfo` set,  it will be
+    assumed to be `UTC`.
+
+
+    * **api_access_endpoint** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) URI base.
+
+
+    * **method** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The HTTP verb that will be used when requesting the URL.
+
+
+    * **content_md5** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The MD5 hash of the object referenced by `resource`.
+
+
+    * **content_type** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The content type of the object referenced by
+    `resource`.
+
+
+    * **response_disposition** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Content disposition of responses to requests for the
+    signed URL.  For example, to enable the signed URL to initiate a
+    file of `blog.png`, use the value `'attachment;
+    filename=blob.png'`.
+
+
+    * **response_type** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Content type of responses to requests for the signed
+    URL. Ignored if content_type is set on object/blob metadata.
+
+
+    * **generation** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) A value that indicates which generation of the resource
+    to fetch.
+
+
+    * **headers** ([*dict*](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)) – (Optional) Additional HTTP headers to be included as part of the
+    signed URLs. See:
+    [https://cloud.google.com/storage/docs/xml-api/reference-headers](https://cloud.google.com/storage/docs/xml-api/reference-headers)
+    Requests using the signed URL *must* pass the specified header
+    (name and value) with each request for the URL.
+
+
+    * **query_parameters** ([*dict*](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)) – (Optional) Additional query parameters to be included as part of the
+    signed URLs. See:
+    [https://cloud.google.com/storage/docs/xml-api/reference-headers#query](https://cloud.google.com/storage/docs/xml-api/reference-headers#query)
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **credentials** ([`google.auth.credentials.Credentials`](https://googleapis.dev/python/google-auth/latest/reference/google.auth.credentials.html#google.auth.credentials.Credentials)) – (Optional) The authorization credentials to attach to requests.
+    These credentials identify this application to the service.  If
+    none are specified, the client will attempt to ascertain the
+    credentials from the environment.
+
+
+    * **version** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The version of signed credential to create.  Must be one
+    of ‘v2’ | ‘v4’.
+
+
+    * **service_account_email** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) E-mail address of the service account.
+
+
+    * **access_token** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Access token for a service account.
+
+
+    * **virtual_hosted_style** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) If true, then construct the URL relative the bucket’s
+    virtual hostname, e.g., ‘<bucket-name>.storage.googleapis.com’.
+
+
+    * **bucket_bound_hostname** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) If passed, then construct the URL relative to the
+    bucket-bound hostname.  Value can be a bare or with scheme, e.g.,
+    ‘example.com’ or ‘[http://example.com](http://example.com)’.  See:
+    [https://cloud.google.com/storage/docs/request-endpoints#cname](https://cloud.google.com/storage/docs/request-endpoints#cname)
+
+
+    * **scheme** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) If `bucket_bound_hostname` is passed as a bare
+    hostname, use this value as the scheme.  `https` will work only
+    when using a CDN.  Defaults to `"http"`.
+
+
+
+* **Raises**
+
+    [`ValueError`](https://python.readthedocs.io/en/latest/library/exceptions.html#ValueError) when version is invalid.
+
+
+
+* **Raises**
+
+    [`TypeError`](https://python.readthedocs.io/en/latest/library/exceptions.html#TypeError) when expiration is not a valid type.
+
+
+
+* **Raises**
+
+    [`AttributeError`](https://python.readthedocs.io/en/latest/library/exceptions.html#AttributeError) if credentials is not an instance
+    of [`google.auth.credentials.Signing`](https://googleapis.dev/python/google-auth/latest/reference/google.auth.credentials.html#google.auth.credentials.Signing).
+
+
+
+* **Return type**
+
+    [str](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)
+
+
+
+* **Returns**
+
+    A signed URL you can use to access the resource
+    until expiration.
+
+
+
+#### _property_ generation()
+Retrieve the generation for the object.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    int or `NoneType`
+
+
+
+* **Returns**
+
+    The generation of the blob or `None` if the blob’s
+    resource has not been loaded from the server.
+
+
+
+#### get_iam_policy(client=None, requested_policy_version=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+Retrieve the IAM policy for the object.
+
+**NOTE**: Blob- / object-level IAM support does not yet exist and methods
+currently call an internal ACL backend not providing any utility
+beyond the blob’s `acl` at this time. The API may be enhanced
+in the future and is currently undocumented. Use `acl` for
+managing object access control.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the current object’s bucket.
+
+
+    * **requested_policy_version** (int or `NoneType`) – (Optional) The version of IAM policies to request.  If a policy
+    with a condition is requested without setting this, the server will
+    return an error.  This must be set to a value of 3 to retrieve IAM
+    policies containing conditions. This is to prevent client code that
+    isn’t aware of IAM conditions from interpreting and modifying
+    policies incorrectly.  The service might return a policy with
+    version lower than the one that was requested, based on the feature
+    syntax in the policy fetched.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    [`google.api_core.iam.Policy`](https://googleapis.dev/python/google-api-core/latest/iam.html#google.api_core.iam.Policy)
+
+
+
+* **Returns**
+
+    the policy instance, based on the resource returned from
+    the `getIamPolicy` API request.
+
+
+
+#### _property_ id()
+Retrieve the ID for the object.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+The ID consists of the bucket name, object name, and generation number.
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    The ID of the blob or `None` if the blob’s
+    resource has not been loaded from the server.
+
+
+
+#### _property_ kms_key_name()
+Resource name of Cloud KMS key used to encrypt the blob’s contents.
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    The resource name or `None` if no Cloud KMS key was used,
+    or the blob’s resource has not been loaded from the server.
+
+
+
+#### make_private(client=None, timeout=60, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Update blob’s ACL, revoking read access for anonymous users.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the blob’s bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+#### make_public(client=None, timeout=60, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Update blob’s ACL, granting read access to anonymous users.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the blob’s bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+#### _property_ md5_hash()
+MD5 hash for this object.
+
+This returns the blob’s MD5 hash. To retrieve the value, first use a
+reload method of the Blob class which loads the blob’s properties from the server.
+
+See [RFC 1321]([https://tools.ietf.org/html/rfc1321](https://tools.ietf.org/html/rfc1321)) and
+[API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)).
+
+If not set before upload, the server will compute the hash.
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+#### _property_ media_link()
+Retrieve the media download URI for the object.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    The media link for the blob or `None` if the blob’s
+    resource has not been loaded from the server.
+
+
+
+#### _property_ metadata()
+Retrieve arbitrary/application specific metadata for the object.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Setter**
+
+    Update arbitrary/application specific metadata for the
+    object.
+
+
+
+* **Getter**
+
+    Retrieve arbitrary/application specific metadata for
+    the object.
+
+
+
+* **Return type**
+
+    dict or `NoneType`
+
+
+
+* **Returns**
+
+    The metadata associated with the blob or `None` if the
+    property is not set.
+
+
+
+#### _property_ metageneration()
+Retrieve the metageneration for the object.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    int or `NoneType`
+
+
+
+* **Returns**
+
+    The metageneration of the blob or `None` if the blob’s
+    resource has not been loaded from the server.
+
+
+
+#### open(mode='r', chunk_size=None, ignore_flush=None, encoding=None, errors=None, newline=None, \*\*kwargs)
+Create a file handler for file-like I/O to or from this blob.
+
+This method can be used as a context manager, just like Python’s
+built-in ‘open()’ function.
+
+While reading, as with other read methods, if blob.generation is not set
+the most recent blob generation will be used. Because the file-like IO
+reader downloads progressively in chunks, this could result in data from
+multiple versions being mixed together. If this is a concern, use
+either bucket.get_blob(), or blob.reload(), which will download the
+latest generation number and set it; or, if the generation is known, set
+it manually, for instance with bucket.blob(generation=123456).
+
+Checksumming (hashing) to verify data integrity is disabled for reads
+using this feature because reads are implemented using request ranges,
+which do not provide checksums to validate. See
+[https://cloud.google.com/storage/docs/hashes-etags](https://cloud.google.com/storage/docs/hashes-etags) for details.
+
+See a [code sample]([https://github.com/googleapis/python-storage/blob/main/samples/snippets/storage_fileio_write_read.py](https://github.com/googleapis/python-storage/blob/main/samples/snippets/storage_fileio_write_read.py)).
+
+Keyword arguments to pass to the underlying API calls.
+For both uploads and downloads, the following arguments are
+supported:
+
+
+* `if_generation_match`
+
+
+* `if_generation_not_match`
+
+
+* `if_metageneration_match`
+
+
+* `if_metageneration_not_match`
+
+
+* `timeout`
+
+
+* `retry`
+
+For downloads only, the following additional arguments are supported:
+
+
+* `raw_download`
+
+For uploads only, the following additional arguments are supported:
+
+
+* `content_type`
+
+
+* `num_retries`
+
+
+* `predefined_acl`
+
+
+* `checksum`
+
+**NOTE**: `num_retries` is supported for backwards-compatibility
+reasons only; please use `retry` with a Retry object or
+ConditionalRetryPolicy instead.
+
+
+* **Parameters**
+
+    
+    * **mode** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) A mode string, as per standard Python open() semantics.The first
+    character must be ‘r’, to open the blob for reading, or ‘w’ to open
+    it for writing. The second character, if present, must be ‘t’ for
+    (unicode) text mode, or ‘b’ for bytes mode. If the second character
+    is omitted, text mode is the default.
+
+
+    * **chunk_size** (*long*) – (Optional) For reads, the minimum number of bytes to read at a time.
+    If fewer bytes than the chunk_size are requested, the remainder is
+    buffered. For writes, the maximum number of bytes to buffer before
+    sending data to the server, and the size of each request when data
+    is sent. Writes are implemented as a “resumable upload”, so
+    chunk_size for writes must be exactly a multiple of 256KiB as with
+    other resumable uploads. The default is 40 MiB.
+
+
+    * **ignore_flush** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) For non text-mode writes, makes flush() do nothing
+    instead of raising an error. flush() without closing is not
+    supported by the remote service and therefore calling it normally
+    results in io.UnsupportedOperation. However, that behavior is
+    incompatible with some consumers and wrappers of file objects in
+    Python, such as zipfile.ZipFile or io.TextIOWrapper. Setting
+    ignore_flush will cause flush() to successfully do nothing, for
+    compatibility with those contexts. The correct way to actually flush
+    data to the remote server is to close() (using a context manager,
+    such as in the example, will cause this to happen automatically).
+
+
+    * **encoding** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) For text mode only, the name of the encoding that the stream will
+    be decoded or encoded with. If omitted, it defaults to
+    locale.getpreferredencoding(False).
+
+
+    * **errors** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) For text mode only, an optional string that specifies how encoding
+    and decoding errors are to be handled. Pass ‘strict’ to raise a
+    ValueError exception if there is an encoding error (the default of
+    None has the same effect), or pass ‘ignore’ to ignore errors. (Note
+    that ignoring encoding errors can lead to data loss.) Other more
+    rarely-used options are also available; see the Python ‘io’ module
+    documentation for ‘io.TextIOWrapper’ for a complete list.
+
+
+    * **newline** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) For text mode only, controls how line endings are handled. It can
+    be None, ‘’, ‘n’, ‘r’, and ‘rn’. If None, reads use “universal
+    newline mode” and writes use the system default. See the Python
+    ‘io’ module documentation for ‘io.TextIOWrapper’ for details.
+
+
+
+* **Returns**
+
+    A ‘BlobReader’ or ‘BlobWriter’ from
+    ‘google.cloud.storage.fileio’, or an ‘io.TextIOWrapper’ around one
+    of those classes, depending on the ‘mode’ argument.
+
+
+
+#### _property_ owner()
+Retrieve info about the owner of the object.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    dict or `NoneType`
+
+
+
+* **Returns**
+
+    Mapping of owner’s role/ID, or `None` if the blob’s
+    resource has not been loaded from the server.
+
+
+
+#### patch(client=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Sends all changed properties in a PATCH request.
+
+Updates the `_properties` with the response from the backend.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – the client to use. If not passed, falls back to the
+    `client` stored on the current object.
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+#### _property_ path()
+Getter property for the URL path to this Blob.
+
+
+* **Return type**
+
+    [str](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)
+
+
+
+* **Returns**
+
+    The URL path to this Blob.
+
+
+
+#### _static_ path_helper(bucket_path, blob_name)
+Relative URL path for a blob.
+
+
+* **Parameters**
+
+    
+    * **bucket_path** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The URL path for a bucket.
+
+
+    * **blob_name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The name of the blob.
+
+
+
+* **Return type**
+
+    [str](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)
+
+
+
+* **Returns**
+
+    The relative URL path for `blob_name`.
+
+
+
+#### _property_ public_url()
+The public URL for this blob.
+
+Use `make_public()` to enable anonymous access via the returned
+URL.
+
+
+* **Return type**
+
+    string
+
+
+
+* **Returns**
+
+    The public URL for this blob.
+
+
+
+#### reload(client=None, projection='noAcl', if_etag_match=None, if_etag_not_match=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+Reload properties from Cloud Storage.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – the client to use. If not passed, falls back to the
+    `client` stored on the current object.
+
+
+    * **projection** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) If used, must be ‘full’ or ‘noAcl’.
+    Defaults to `'noAcl'`. Specifies the set of
+    properties to return.
+
+
+    * **if_etag_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_match](generation_metageneration.md#using-if-etag-match)
+
+
+    * **if_etag_not_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]**)*) – (Optional) See [Using if_etag_not_match](generation_metageneration.md#using-if-etag-not-match)
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+#### _property_ retention_expiration_time()
+Retrieve timestamp at which the object’s retention period expires.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    [`datetime.datetime`](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.datetime) or `NoneType`
+
+
+
+* **Returns**
+
+    Datetime object parsed from RFC3339 valid timestamp, or
+    `None` if the property is not set locally.
+
+
+
+#### rewrite(source, token=None, client=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, if_source_generation_match=None, if_source_generation_not_match=None, if_source_metageneration_match=None, if_source_metageneration_not_match=None, timeout=60, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Rewrite source blob into this one.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **source** (`Blob`) – blob whose contents will be rewritten into this blob.
+
+
+    * **token** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Token returned from an earlier, not-completed call to
+    rewrite the same source blob.  If passed, result will include
+    updated status, total bytes written.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+    Note that the generation to be matched is that of the
+    `destination` blob.
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+    Note that the generation to be matched is that of the
+    `destination` blob.
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+    Note that the metageneration to be matched is that of the
+    `destination` blob.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+    Note that the metageneration to be matched is that of the
+    `destination` blob.
+
+
+    * **if_source_generation_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s generation matches the given value.
+
+
+    * **if_source_generation_not_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s generation does not match the given value.
+
+
+    * **if_source_metageneration_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s current metageneration matches the given value.
+
+
+    * **if_source_metageneration_not_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s current metageneration does not match the given value.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    [tuple](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)
+
+
+
+* **Returns**
+
+    `(token, bytes_rewritten, total_bytes)`, where `token`
+    is a rewrite token (`None` if the rewrite is complete),
+    `bytes_rewritten` is the number of bytes rewritten so far,
+    and `total_bytes` is the total number of bytes to be
+    rewritten.
+
+
+
+#### _property_ self_link()
+Retrieve the URI for the object.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    The self link for the blob or `None` if the blob’s
+    resource has not been loaded from the server.
+
+
+
+#### set_iam_policy(policy, client=None, timeout=60, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Update the IAM policy for the bucket.
+
+**NOTE**: Blob- / object-level IAM support does not yet exist and methods
+currently call an internal ACL backend not providing any utility
+beyond the blob’s `acl` at this time. The API may be enhanced
+in the future and is currently undocumented. Use `acl` for
+managing object access control.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **policy** ([`google.api_core.iam.Policy`](https://googleapis.dev/python/google-api-core/latest/iam.html#google.api_core.iam.Policy)) – policy instance used to update bucket’s IAM policy.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the current bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    [`google.api_core.iam.Policy`](https://googleapis.dev/python/google-api-core/latest/iam.html#google.api_core.iam.Policy)
+
+
+
+* **Returns**
+
+    the policy instance, based on the resource returned from
+    the `setIamPolicy` API request.
+
+
+
+#### _property_ size()
+Size of the object, in bytes.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    int or `NoneType`
+
+
+
+* **Returns**
+
+    The size of the blob or `None` if the blob’s
+    resource has not been loaded from the server.
+
+
+
+#### _property_ storage_class()
+Retrieve the storage class for the object.
+
+This can only be set at blob / object **creation** time. If you’d
+like to change the storage class **after** the blob / object already
+exists in a bucket, call `update_storage_class()` (which uses
+`rewrite()`).
+
+See [https://cloud.google.com/storage/docs/storage-classes](https://cloud.google.com/storage/docs/storage-classes)
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    If set, one of
+    [`STANDARD_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.STANDARD_STORAGE_CLASS),
+    [`NEARLINE_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.NEARLINE_STORAGE_CLASS),
+    [`COLDLINE_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.COLDLINE_STORAGE_CLASS),
+    [`ARCHIVE_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.ARCHIVE_STORAGE_CLASS),
+    [`MULTI_REGIONAL_LEGACY_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.MULTI_REGIONAL_LEGACY_STORAGE_CLASS),
+    [`REGIONAL_LEGACY_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.REGIONAL_LEGACY_STORAGE_CLASS),
+    `DURABLE_REDUCED_AVAILABILITY_STORAGE_CLASS`,
+    else `None`.
+
+
+
+#### _property_ temporary_hold()
+Is a temporary hold active on the object?
+
+See [API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)).
+
+If the property is not set locally, returns [`None`](https://python.readthedocs.io/en/latest/library/constants.html#None).
+
+
+* **Return type**
+
+    bool or `NoneType`
+
+
+
+#### test_iam_permissions(permissions, client=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+API call:  test permissions
+
+**NOTE**: Blob- / object-level IAM support does not yet exist and methods
+currently call an internal ACL backend not providing any utility
+beyond the blob’s `acl` at this time. The API may be enhanced
+in the future and is currently undocumented. Use `acl` for
+managing object access control.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **permissions** (*list of string*) – the permissions to check
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the current bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    list of string
+
+
+
+* **Returns**
+
+    the permissions returned by the `testIamPermissions` API
+    request.
+
+
+
+#### _property_ time_created()
+Retrieve the timestamp at which the object was created.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    [`datetime.datetime`](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.datetime) or `NoneType`
+
+
+
+* **Returns**
+
+    Datetime object parsed from RFC3339 valid timestamp, or
+    `None` if the blob’s resource has not been loaded from
+    the server (see `reload()`).
+
+
+
+#### _property_ time_deleted()
+Retrieve the timestamp at which the object was deleted.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    [`datetime.datetime`](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.datetime) or `NoneType`
+
+
+
+* **Returns**
+
+    Datetime object parsed from RFC3339 valid timestamp, or
+    `None` if the blob’s resource has not been loaded from
+    the server (see `reload()`). If the blob has
+    not been deleted, this will never be set.
+
+
+
+#### update(client=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Sends all properties in a PUT request.
+
+Updates the `_properties` with the response from the backend.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – the client to use. If not passed, falls back to the
+    `client` stored on the current object.
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+#### update_storage_class(new_class, client=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, if_source_generation_match=None, if_source_generation_not_match=None, if_source_metageneration_match=None, if_source_metageneration_not_match=None, timeout=60, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Update blob’s storage class via a rewrite-in-place. This helper will
+wait for the rewrite to complete before returning, so it may take some
+time for large files.
+
+See
+[https://cloud.google.com/storage/docs/per-object-storage-class](https://cloud.google.com/storage/docs/per-object-storage-class)
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **new_class** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – new storage class for the object.   One of:
+    [`NEARLINE_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.NEARLINE_STORAGE_CLASS),
+    [`COLDLINE_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.COLDLINE_STORAGE_CLASS),
+    [`ARCHIVE_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.ARCHIVE_STORAGE_CLASS),
+    [`STANDARD_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.STANDARD_STORAGE_CLASS),
+    [`MULTI_REGIONAL_LEGACY_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.MULTI_REGIONAL_LEGACY_STORAGE_CLASS),
+    or
+    [`REGIONAL_LEGACY_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.REGIONAL_LEGACY_STORAGE_CLASS).
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+    Note that the generation to be matched is that of the
+    `destination` blob.
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+    Note that the generation to be matched is that of the
+    `destination` blob.
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+    Note that the metageneration to be matched is that of the
+    `destination` blob.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+    Note that the metageneration to be matched is that of the
+    `destination` blob.
+
+
+    * **if_source_generation_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s generation matches the given value.
+
+
+    * **if_source_generation_not_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s generation does not match the given value.
+
+
+    * **if_source_metageneration_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s current metageneration matches the given value.
+
+
+    * **if_source_metageneration_not_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s current metageneration does not match the given value.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+#### _property_ updated()
+Retrieve the timestamp at which the object was updated.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/objects](https://cloud.google.com/storage/docs/json_api/v1/objects)
+
+
+* **Return type**
+
+    [`datetime.datetime`](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.datetime) or `NoneType`
+
+
+
+* **Returns**
+
+    Datetime object parsed from RFC3339 valid timestamp, or
+    `None` if the blob’s resource has not been loaded from
+    the server (see `reload()`).
+
+
+
+#### upload_from_file(file_obj, rewind=False, size=None, content_type=None, num_retries=None, client=None, predefined_acl=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, checksum=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Upload the contents of this blob from a file-like object.
+
+The content type of the upload will be determined in order
+of precedence:
+
+
+* The value passed in to this method (if not [`None`](https://python.readthedocs.io/en/latest/library/constants.html#None))
+
+
+* The value stored on the current blob
+
+
+* The default value (‘application/octet-stream’)
+
+**NOTE**: The effect of uploading to an existing blob depends on the
+“versioning” and “lifecycle” policies defined on the blob’s
+bucket.  In the absence of those policies, upload will
+overwrite any existing contents.
+
+See the [object versioning]([https://cloud.google.com/storage/docs/object-versioning](https://cloud.google.com/storage/docs/object-versioning))
+and [lifecycle]([https://cloud.google.com/storage/docs/lifecycle](https://cloud.google.com/storage/docs/lifecycle))
+API documents for details.
+
+If the size of the data to be uploaded exceeds 8 MB a resumable media
+request will be used, otherwise the content and the metadata will be
+uploaded in a single multipart upload request.
+
+For more fine-grained over the upload process, check out
+[google-resumable-media]([https://googleapis.dev/python/google-resumable-media/latest/index.html](https://googleapis.dev/python/google-resumable-media/latest/index.html)).
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **file_obj** (*file*) – A file handle opened in binary mode for reading.
+
+
+    * **rewind** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – If True, seek to the beginning of the file handle before writing
+    the file to Cloud Storage.
+
+
+    * **size** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – The number of bytes to be uploaded (which will be read from
+    `file_obj`). If not provided, the upload will be concluded once
+    `file_obj` is exhausted.
+
+
+    * **content_type** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Type of content being uploaded.
+
+
+    * **num_retries** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – Number of upload retries. By default, only uploads with
+    if_generation_match set will be retried, as uploads without the
+    argument are not guaranteed to be idempotent. Setting num_retries
+    will override this default behavior and guarantee retries even when
+    if_generation_match is not set.  (Deprecated: This argument
+    will be removed in a future release.)
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **predefined_acl** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Predefined access control list
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **checksum** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The type of checksum to compute to verify
+    the integrity of the object. If the upload is completed in a single
+    request, the checksum will be entirely precomputed and the remote
+    server will handle verification and error handling. If the upload
+    is too large and must be transmitted in multiple requests, the
+    checksum will be incrementally computed and the client will handle
+    verification and error handling, raising
+    google.resumable_media.common.DataCorruption on a mismatch and
+    attempting to delete the corrupted file. Supported values are
+    “md5”, “crc32c” and None. The default is None.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. A None value will disable
+    retries. A google.api_core.retry.Retry value will enable retries,
+    and the object will define retriable response codes and errors and
+    configure backoff and timeout options.
+
+    A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a
+    Retry object and activates it only if certain conditions are met.
+    This class exists to provide safe defaults for RPC calls that are
+    not technically safe to retry normally (due to potential data
+    duplication or other side-effects) but become safe to retry if a
+    condition such as if_generation_match is set.
+
+    See the retry.py source code and docstrings in this package
+    (google.cloud.storage.retry) for information on retry types and how
+    to configure them.
+
+    Media operations (downloads and uploads) do not support non-default
+    predicates in a Retry object. The default will always be used. Other
+    configuration changes for Retry objects such as delays and deadlines
+    are respected.
+
+
+
+
+* **Raises**
+
+    `GoogleCloudError`
+    if the upload response returns an error status.
+
+
+
+#### upload_from_filename(filename, content_type=None, num_retries=None, client=None, predefined_acl=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, checksum=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Upload this blob’s contents from the content of a named file.
+
+The content type of the upload will be determined in order
+of precedence:
+
+
+* The value passed in to this method (if not [`None`](https://python.readthedocs.io/en/latest/library/constants.html#None))
+
+
+* The value stored on the current blob
+
+
+* The value given by `mimetypes.guess_type`
+
+
+* The default value (‘application/octet-stream’)
+
+**NOTE**: The effect of uploading to an existing blob depends on the
+“versioning” and “lifecycle” policies defined on the blob’s
+bucket.  In the absence of those policies, upload will
+overwrite any existing contents.
+
+See the [object versioning]([https://cloud.google.com/storage/docs/object-versioning](https://cloud.google.com/storage/docs/object-versioning))
+and [lifecycle]([https://cloud.google.com/storage/docs/lifecycle](https://cloud.google.com/storage/docs/lifecycle))
+API documents for details.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+See a [code sample]([https://cloud.google.com/storage/docs/samples/storage-upload-encrypted-file#storage_upload_encrypted_file-python](https://cloud.google.com/storage/docs/samples/storage-upload-encrypted-file#storage_upload_encrypted_file-python))
+to upload a file with a
+[customer-supplied encryption key]([https://cloud.google.com/storage/docs/encryption#customer-supplied](https://cloud.google.com/storage/docs/encryption#customer-supplied)).
+
+
+* **Parameters**
+
+    
+    * **filename** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The path to the file.
+
+
+    * **content_type** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Type of content being uploaded.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **num_retries** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – Number of upload retries. By default, only uploads with
+    if_generation_match set will be retried, as uploads without the
+    argument are not guaranteed to be idempotent. Setting num_retries
+    will override this default behavior and guarantee retries even when
+    if_generation_match is not set.  (Deprecated: This argument
+    will be removed in a future release.)
+
+
+    * **predefined_acl** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Predefined access control list
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **checksum** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The type of checksum to compute to verify
+    the integrity of the object. If the upload is completed in a single
+    request, the checksum will be entirely precomputed and the remote
+    server will handle verification and error handling. If the upload
+    is too large and must be transmitted in multiple requests, the
+    checksum will be incrementally computed and the client will handle
+    verification and error handling, raising
+    google.resumable_media.common.DataCorruption on a mismatch and
+    attempting to delete the corrupted file. Supported values are
+    “md5”, “crc32c” and None. The default is None.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. A None value will disable
+    retries. A google.api_core.retry.Retry value will enable retries,
+    and the object will define retriable response codes and errors and
+    configure backoff and timeout options.
+
+    A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a
+    Retry object and activates it only if certain conditions are met.
+    This class exists to provide safe defaults for RPC calls that are
+    not technically safe to retry normally (due to potential data
+    duplication or other side-effects) but become safe to retry if a
+    condition such as if_generation_match is set.
+
+    See the retry.py source code and docstrings in this package
+    (google.cloud.storage.retry) for information on retry types and how
+    to configure them.
+
+    Media operations (downloads and uploads) do not support non-default
+    predicates in a Retry object. The default will always be used. Other
+    configuration changes for Retry objects such as delays and deadlines
+    are respected.
+
+
+
+
+#### upload_from_string(data, content_type='text/plain', num_retries=None, client=None, predefined_acl=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, checksum=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Upload contents of this blob from the provided string.
+
+**NOTE**: The effect of uploading to an existing blob depends on the
+“versioning” and “lifecycle” policies defined on the blob’s
+bucket.  In the absence of those policies, upload will
+overwrite any existing contents.
+
+See the [object versioning]([https://cloud.google.com/storage/docs/object-versioning](https://cloud.google.com/storage/docs/object-versioning))
+and [lifecycle]([https://cloud.google.com/storage/docs/lifecycle](https://cloud.google.com/storage/docs/lifecycle))
+API documents for details.
+
+If `user_project` is set on the bucket, bills the API request
+to that project.
+
+
+* **Parameters**
+
+    
+    * **data** ([*bytes*](https://python.readthedocs.io/en/latest/library/stdtypes.html#bytes)* or *[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The data to store in this blob.  If the value is text, it will be
+    encoded as UTF-8.
+
+
+    * **content_type** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Type of content being uploaded. Defaults to
+    `'text/plain'`.
+
+
+    * **num_retries** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – Number of upload retries. By default, only uploads with
+    if_generation_match set will be retried, as uploads without the
+    argument are not guaranteed to be idempotent. Setting num_retries
+    will override this default behavior and guarantee retries even when
+    if_generation_match is not set.  (Deprecated: This argument
+    will be removed in a future release.)
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back to the
+    `client` stored on the blob’s bucket.
+
+
+    * **predefined_acl** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Predefined access control list
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **checksum** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The type of checksum to compute to verify
+    the integrity of the object. If the upload is completed in a single
+    request, the checksum will be entirely precomputed and the remote
+    server will handle verification and error handling. If the upload
+    is too large and must be transmitted in multiple requests, the
+    checksum will be incrementally computed and the client will handle
+    verification and error handling, raising
+    google.resumable_media.common.DataCorruption on a mismatch and
+    attempting to delete the corrupted file. Supported values are
+    “md5”, “crc32c” and None. The default is None.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. A None value will disable
+    retries. A google.api_core.retry.Retry value will enable retries,
+    and the object will define retriable response codes and errors and
+    configure backoff and timeout options.
+
+    A google.cloud.storage.retry.ConditionalRetryPolicy value wraps a
+    Retry object and activates it only if certain conditions are met.
+    This class exists to provide safe defaults for RPC calls that are
+    not technically safe to retry normally (due to potential data
+    duplication or other side-effects) but become safe to retry if a
+    condition such as if_generation_match is set.
+
+    See the retry.py source code and docstrings in this package
+    (google.cloud.storage.retry) for information on retry types and how
+    to configure them.
+
+    Media operations (downloads and uploads) do not support non-default
+    predicates in a Retry object. The default will always be used. Other
+    configuration changes for Retry objects such as delays and deadlines
+    are respected.
+
+
+
+
+#### _property_ user_project()
+Project ID billed for API requests made via this blob.
+
+Derived from bucket’s value.
+
+
+* **Return type**
+
+    [str](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)

--- a/tests/testdata/goldens/handwritten/buckets.md
+++ b/tests/testdata/goldens/handwritten/buckets.md
@@ -1,0 +1,2695 @@
+# Buckets
+
+Create / interact with Google Cloud Storage buckets.
+
+
+### _class_ google.cloud.storage.bucket.Bucket(client, name=None, user_project=None)
+Bases: `google.cloud.storage._helpers._PropertyMixin`
+
+A class representing a Bucket on Cloud Storage.
+
+
+* **Parameters**
+
+    
+    * **client** ([`google.cloud.storage.client.Client`](client.md#google.cloud.storage.client.Client)) – A client which holds credentials and project configuration
+    for the bucket (which requires a project).
+
+
+    * **name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The name of the bucket. Bucket names must start and end with a
+    number or letter.
+
+
+    * **user_project** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) the project ID to be billed for API
+    requests made via this instance.
+
+
+property `name`
+
+    Get the bucket’s name.
+
+
+#### STORAGE_CLASSES(_ = ('STANDARD', 'NEARLINE', 'COLDLINE', 'ARCHIVE', 'MULTI_REGIONAL', 'REGIONAL', 'DURABLE_REDUCED_AVAILABILITY'_ )
+Allowed values for `storage_class`.
+
+Default value is `STANDARD_STORAGE_CLASS`.
+
+See
+[https://cloud.google.com/storage/docs/json_api/v1/buckets#storageClass](https://cloud.google.com/storage/docs/json_api/v1/buckets#storageClass)
+[https://cloud.google.com/storage/docs/storage-classes](https://cloud.google.com/storage/docs/storage-classes)
+
+
+#### _property_ acl()
+Create our ACL on demand.
+
+
+#### add_lifecycle_abort_incomplete_multipart_upload_rule(\*\*kw)
+Add a “abort incomplete multipart upload” rule to lifecycle rules.
+
+**NOTE**: The “age” lifecycle condition is the only supported condition
+for this rule.
+
+This defines a [lifecycle configuration]([https://cloud.google.com/storage/docs/lifecycle](https://cloud.google.com/storage/docs/lifecycle)),
+which is set on the bucket. For the general format of a lifecycle configuration, see the
+[bucket resource representation for JSON]([https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)).
+
+
+* **Params kw**
+
+    arguments passed to `LifecycleRuleConditions`.
+
+
+
+#### add_lifecycle_delete_rule(\*\*kw)
+Add a “delete” rule to lifecycle rules configured for this bucket.
+
+This defines a [lifecycle configuration]([https://cloud.google.com/storage/docs/lifecycle](https://cloud.google.com/storage/docs/lifecycle)),
+which is set on the bucket. For the general format of a lifecycle configuration, see the
+[bucket resource representation for JSON]([https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)).
+See also a [code sample]([https://cloud.google.com/storage/docs/samples/storage-enable-bucket-lifecycle-management#storage_enable_bucket_lifecycle_management-python](https://cloud.google.com/storage/docs/samples/storage-enable-bucket-lifecycle-management#storage_enable_bucket_lifecycle_management-python)).
+
+
+* **Params kw**
+
+    arguments passed to `LifecycleRuleConditions`.
+
+
+
+#### add_lifecycle_set_storage_class_rule(storage_class, \*\*kw)
+Add a “set storage class” rule to lifecycle rules.
+
+This defines a [lifecycle configuration]([https://cloud.google.com/storage/docs/lifecycle](https://cloud.google.com/storage/docs/lifecycle)),
+which is set on the bucket. For the general format of a lifecycle configuration, see the
+[bucket resource representation for JSON]([https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)).
+
+
+* **Parameters**
+
+    **storage_class** (str, one of `STORAGE_CLASSES`.) – new storage class to assign to matching items.
+
+
+
+* **Params kw**
+
+    arguments passed to `LifecycleRuleConditions`.
+
+
+
+#### blob(blob_name, chunk_size=None, encryption_key=None, kms_key_name=None, generation=None)
+Factory constructor for blob object.
+
+**NOTE**: This will not make an HTTP request; it simply instantiates
+a blob object owned by this bucket.
+
+
+* **Parameters**
+
+    
+    * **blob_name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The name of the blob to be instantiated.
+
+
+    * **chunk_size** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – The size of a chunk of data whenever iterating
+    (in bytes). This must be a multiple of 256 KB per
+    the API specification.
+
+
+    * **encryption_key** ([*bytes*](https://python.readthedocs.io/en/latest/library/stdtypes.html#bytes)) – (Optional) 32 byte encryption key for customer-supplied encryption.
+
+
+    * **kms_key_name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Resource name of KMS key used to encrypt blob’s content.
+
+
+    * **generation** (*long*) – (Optional) If present, selects a specific revision of
+    this object.
+
+
+
+* **Return type**
+
+    [`google.cloud.storage.blob.Blob`](blobs.md#google.cloud.storage.blob.Blob)
+
+
+
+* **Returns**
+
+    The blob object created.
+
+
+
+#### clear_lifecyle_rules()
+Clear lifecycle rules configured for this bucket.
+
+See [https://cloud.google.com/storage/docs/lifecycle](https://cloud.google.com/storage/docs/lifecycle) and
+
+    [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+
+#### _property_ client()
+The client bound to this bucket.
+
+
+#### configure_website(main_page_suffix=None, not_found_page=None)
+Configure website-related properties.
+
+See [https://cloud.google.com/storage/docs/static-website](https://cloud.google.com/storage/docs/static-website)
+
+**NOTE**: This configures the bucket’s website-related properties,controlling how
+the service behaves when accessing bucket contents as a web site.
+See [tutorials]([https://cloud.google.com/storage/docs/hosting-static-website](https://cloud.google.com/storage/docs/hosting-static-website)) and
+[code samples]([https://cloud.google.com/storage/docs/samples/storage-define-bucket-website-configuration#storage_define_bucket_website_configuration-python](https://cloud.google.com/storage/docs/samples/storage-define-bucket-website-configuration#storage_define_bucket_website_configuration-python))
+for more information.
+
+
+* **Parameters**
+
+    
+    * **main_page_suffix** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The page to use as the main page
+    of a directory.
+    Typically something like index.html.
+
+
+    * **not_found_page** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The file to use when a page isn’t found.
+
+
+
+#### copy_blob(blob, destination_bucket, new_name=None, client=None, preserve_acl=True, source_generation=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, if_source_generation_match=None, if_source_generation_not_match=None, if_source_metageneration_match=None, if_source_metageneration_not_match=None, timeout=60, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Copy the given blob to the given bucket, optionally with a new name.
+
+If `user_project` is set, bills the API request to that project.
+
+See [API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/objects/copy](https://cloud.google.com/storage/docs/json_api/v1/objects/copy))
+and a [code sample]([https://cloud.google.com/storage/docs/samples/storage-copy-file#storage_copy_file-python](https://cloud.google.com/storage/docs/samples/storage-copy-file#storage_copy_file-python)).
+
+
+* **Parameters**
+
+    
+    * **blob** ([`google.cloud.storage.blob.Blob`](blobs.md#google.cloud.storage.blob.Blob)) – The blob to be copied.
+
+
+    * **destination_bucket** (`google.cloud.storage.bucket.Bucket`) – The bucket into which the blob should be
+    copied.
+
+
+    * **new_name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The new name for the copied file.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use. If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **preserve_acl** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – DEPRECATED. This argument is not functional!
+    (Optional) Copies ACL from old blob to new blob.
+    Default: True.
+
+
+    * **source_generation** (*long*) – (Optional) The generation of the blob to be
+    copied.
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+    Note that the generation to be matched is that of the
+    `destination` blob.
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+    Note that the generation to be matched is that of the
+    `destination` blob.
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+    Note that the metageneration to be matched is that of the
+    `destination` blob.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+    Note that the metageneration to be matched is that of the
+    `destination` blob.
+
+
+    * **if_source_generation_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s generation matches the given value.
+
+
+    * **if_source_generation_not_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s generation does not match the given value.
+
+
+    * **if_source_metageneration_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s current metageneration matches the given value.
+
+
+    * **if_source_metageneration_not_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s current metageneration does not match the given value.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    [`google.cloud.storage.blob.Blob`](blobs.md#google.cloud.storage.blob.Blob)
+
+
+
+* **Returns**
+
+    The new Blob.
+
+
+
+#### _property_ cors()
+Retrieve or set CORS policies configured for this bucket.
+
+See [http://www.w3.org/TR/cors/](http://www.w3.org/TR/cors/) and
+
+    [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+**NOTE**: The getter for this property returns a list which contains
+*copies* of the bucket’s CORS policy mappings.  Mutating the list
+or one of its dicts has no effect unless you then re-assign the
+dict via the setter.  E.g.:
+
+```python
+>>> policies = bucket.cors
+>>> policies.append({'origin': '/foo', ...})
+>>> policies[1]['maxAgeSeconds'] = 3600
+>>> del policies[0]
+>>> bucket.cors = policies
+>>> bucket.update()
+```
+
+
+* **Setter**
+
+    Set CORS policies for this bucket.
+
+
+
+* **Getter**
+
+    Gets the CORS policies for this bucket.
+
+
+
+* **Return type**
+
+    list of dictionaries
+
+
+
+* **Returns**
+
+    A sequence of mappings describing each CORS policy.
+
+
+
+#### create(client=None, project=None, location=None, predefined_acl=None, predefined_default_object_acl=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+DEPRECATED. Creates current bucket.
+
+**NOTE**: Direct use of this method is deprecated. Use `Client.create_bucket()` instead.
+
+If the bucket already exists, will raise
+`google.cloud.exceptions.Conflict`.
+
+This implements “storage.buckets.insert”.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use. If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **project** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The project under which the bucket is to
+    be created. If not passed, uses the project set on
+    the client.
+
+
+    * **location** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The location of the bucket. If not passed,
+    the default location, US, will be used. See
+    [https://cloud.google.com/storage/docs/bucket-locations](https://cloud.google.com/storage/docs/bucket-locations)
+
+
+    * **predefined_acl** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Name of predefined ACL to apply to bucket. See:
+    [https://cloud.google.com/storage/docs/access-control/lists#predefined-acl](https://cloud.google.com/storage/docs/access-control/lists#predefined-acl)
+
+
+    * **predefined_default_object_acl** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Name of predefined ACL to apply to bucket’s objects. See:
+    [https://cloud.google.com/storage/docs/access-control/lists#predefined-acl](https://cloud.google.com/storage/docs/access-control/lists#predefined-acl)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Raises**
+
+    [**ValueError**](https://python.readthedocs.io/en/latest/library/exceptions.html#ValueError) – if `project` is None and client’s
+    `project` is also None.
+
+
+
+#### _property_ data_locations()
+Retrieve the list of regional locations for custom dual-region buckets.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets) and
+[https://cloud.google.com/storage/docs/locations](https://cloud.google.com/storage/docs/locations)
+
+Returns `None` if the property has not been set before creation,
+if the bucket’s resource has not been loaded from the server,
+or if the bucket is not a dual-regions bucket.
+:rtype: list of str or `NoneType`
+
+
+#### _property_ default_event_based_hold()
+Are uploaded objects automatically placed under an even-based hold?
+
+If True, uploaded objects will be placed under an event-based hold to
+be released at a future time. When released an object will then begin
+the retention period determined by the policy retention period for the
+object bucket.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+If the property is not set locally, returns `None`.
+
+
+* **Return type**
+
+    bool or `NoneType`
+
+
+
+#### _property_ default_kms_key_name()
+Retrieve / set default KMS encryption key for objects in the bucket.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+
+* **Setter**
+
+    Set default KMS encryption key for items in this bucket.
+
+
+
+* **Getter**
+
+    Get default KMS encryption key for items in this bucket.
+
+
+
+* **Return type**
+
+    [str](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)
+
+
+
+* **Returns**
+
+    Default KMS encryption key, or `None` if not set.
+
+
+
+#### _property_ default_object_acl()
+Create our defaultObjectACL on demand.
+
+
+#### delete(force=False, client=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+Delete this bucket.
+
+The bucket **must** be empty in order to submit a delete request. If
+`force=True` is passed, this will first attempt to delete all the
+objects / blobs in the bucket (i.e. try to empty the bucket).
+
+If the bucket doesn’t exist, this will raise
+`google.cloud.exceptions.NotFound`. If the bucket is not empty
+(and `force=False`), will raise `google.cloud.exceptions.Conflict`.
+
+If `force=True` and the bucket contains more than 256 objects / blobs
+this will cowardly refuse to delete the objects (or the bucket). This
+is to prevent accidental bucket deletion and to prevent extremely long
+runtime of this method.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **force** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – If True, empties the bucket’s objects then deletes it.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use. If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **if_metageneration_match** (*long*) – (Optional) Make the operation conditional on whether the
+    blob’s current metageneration matches the given value.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) Make the operation conditional on whether the
+    blob’s current metageneration does not match the given value.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Raises**
+
+    [`ValueError`](https://python.readthedocs.io/en/latest/library/exceptions.html#ValueError) if `force` is `True` and the bucket
+    contains more than 256 objects / blobs.
+
+
+
+#### delete_blob(blob_name, client=None, generation=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Deletes a blob from the current bucket.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **blob_name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – A blob name to delete.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use. If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **generation** (*long*) – (Optional) If present, permanently deletes a specific
+    revision of this object.
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Raises**
+
+    `google.cloud.exceptions.NotFound` Raises a NotFound
+    if the blob isn’t found. To suppress
+    the exception, use `delete_blobs()` by passing a no-op
+    `on_error` callback.
+
+
+
+#### delete_blobs(blobs, on_error=None, client=None, preserve_generation=False, timeout=60, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Deletes a list of blobs from the current bucket.
+
+Uses `delete_blob()` to delete each individual blob.
+
+By default, any generation information in the list of blobs is ignored, and the
+live versions of all blobs are deleted. Set preserve_generation to True
+if blob generation should instead be propagated from the list of blobs.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **blobs** ([*list*](https://python.readthedocs.io/en/latest/library/stdtypes.html#list)) – A list of [`Blob`](blobs.md#google.cloud.storage.blob.Blob)-s or
+    blob names to delete.
+
+
+    * **on_error** (*callable*) – (Optional) Takes single argument: `blob`.
+    Called once for each blob raising
+    `NotFound`;
+    otherwise, the exception is propagated.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **preserve_generation** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) Deletes only the generation specified on the blob object,
+    instead of the live version, if set to True. Only :class:~google.cloud.storage.blob.Blob
+    objects can have their generation set in this way.
+    Default: False.
+
+
+    * **if_generation_match** (*list of long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+    Note that the length of the list must match the length of
+    The list must match `blobs` item-to-item.
+
+
+    * **if_generation_not_match** (*list of long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+    The list must match `blobs` item-to-item.
+
+
+    * **if_metageneration_match** (*list of long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+    The list must match `blobs` item-to-item.
+
+
+    * **if_metageneration_not_match** (*list of long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+    The list must match `blobs` item-to-item.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Raises**
+
+    `NotFound` (if
+    on_error is not passed).
+
+
+
+#### disable_logging()
+Disable access logging for this bucket.
+
+See [https://cloud.google.com/storage/docs/access-logs#disabling](https://cloud.google.com/storage/docs/access-logs#disabling)
+
+
+#### disable_website()
+Disable the website configuration for this bucket.
+
+This is really just a shortcut for setting the website-related
+attributes to `None`.
+
+
+#### enable_logging(bucket_name, object_prefix='')
+Enable access logging for this bucket.
+
+See [https://cloud.google.com/storage/docs/access-logs](https://cloud.google.com/storage/docs/access-logs)
+
+
+* **Parameters**
+
+    
+    * **bucket_name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – name of bucket in which to store access logs
+
+
+    * **object_prefix** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – prefix for access log filenames
+
+
+
+#### _property_ etag()
+Retrieve the ETag for the bucket.
+
+See [https://tools.ietf.org/html/rfc2616#section-3.11](https://tools.ietf.org/html/rfc2616#section-3.11) and
+
+    [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    The bucket etag or `None` if the bucket’s
+    resource has not been loaded from the server.
+
+
+
+#### exists(client=None, timeout=60, if_etag_match=None, if_etag_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, retry=<google.api_core.retry.Retry object>)
+Determines whether or not this bucket exists.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use. If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **if_etag_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) Make the operation conditional on whether the
+    bucket’s current ETag matches the given value.
+
+
+    * **if_etag_not_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]**)*) – (Optional) Make the operation conditional on whether the
+    bucket’s current ETag does not match the given value.
+
+
+    * **if_metageneration_match** (*long*) – (Optional) Make the operation conditional on whether the
+    bucket’s current metageneration matches the given value.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) Make the operation conditional on whether the
+    bucket’s current metageneration does not match the given value.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    [bool](https://python.readthedocs.io/en/latest/library/functions.html#bool)
+
+
+
+* **Returns**
+
+    True if the bucket exists in Cloud Storage.
+
+
+
+#### _classmethod_ from_string(uri, client=None)
+Get a constructor for bucket object by URI.
+
+```python
+from google.cloud import storage
+from google.cloud.storage.bucket import Bucket
+client = storage.Client()
+bucket = Bucket.from_string("gs://bucket", client=client)
+```
+
+
+* **Parameters**
+
+    
+    * **uri** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The bucket uri pass to get bucket object.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  Application code should
+    *always* pass `client`.
+
+
+
+* **Return type**
+
+    `google.cloud.storage.bucket.Bucket`
+
+
+
+* **Returns**
+
+    The bucket object created.
+
+
+
+#### generate_signed_url(expiration=None, api_access_endpoint='https://storage.googleapis.com', method='GET', headers=None, query_parameters=None, client=None, credentials=None, version=None, virtual_hosted_style=False, bucket_bound_hostname=None, scheme='http')
+Generates a signed URL for this bucket.
+
+**NOTE**: If you are on Google Compute Engine, you can’t generate a signed
+URL using GCE service account. If you’d like to be able to generate
+a signed URL from GCE, you can use a standard service account from a
+JSON file rather than a GCE service account.
+
+If you have a bucket that you want to allow access to for a set
+amount of time, you can use this method to generate a URL that
+is only valid within a certain time period.
+
+If `bucket_bound_hostname` is set as an argument of `api_access_endpoint`,
+`https` works only if using a `CDN`.
+
+
+* **Parameters**
+
+    
+    * **expiration** (*Union**[**Integer**, *[*datetime.datetime*](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.datetime)*, *[*datetime.timedelta*](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.timedelta)*]*) – Point in time when the signed URL should expire. If
+    a `datetime` instance is passed without an explicit
+    `tzinfo` set,  it will be assumed to be `UTC`.
+
+
+    * **api_access_endpoint** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) URI base.
+
+
+    * **method** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The HTTP verb that will be used when requesting the URL.
+
+
+    * **headers** ([*dict*](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)) – (Optional) Additional HTTP headers to be included as part of the
+    signed URLs.  See:
+    [https://cloud.google.com/storage/docs/xml-api/reference-headers](https://cloud.google.com/storage/docs/xml-api/reference-headers)
+    Requests using the signed URL *must* pass the specified header
+    (name and value) with each request for the URL.
+
+
+    * **query_parameters** ([*dict*](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)) – (Optional) Additional query parameters to be included as part of the
+    signed URLs.  See:
+    [https://cloud.google.com/storage/docs/xml-api/reference-headers#query](https://cloud.google.com/storage/docs/xml-api/reference-headers#query)
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the blob’s bucket.
+
+
+    * **credentials** ([`google.auth.credentials.Credentials`](https://googleapis.dev/python/google-auth/latest/reference/google.auth.credentials.html#google.auth.credentials.Credentials) or
+    `NoneType`) – The authorization credentials to attach to requests.
+    These credentials identify this application to the service.
+    If none are specified, the client will attempt to ascertain
+    the credentials from the environment.
+
+
+    * **version** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) The version of signed credential to create.
+    Must be one of ‘v2’ | ‘v4’.
+
+
+    * **virtual_hosted_style** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) If true, then construct the URL relative the bucket’s
+    virtual hostname, e.g., ‘<bucket-name>.storage.googleapis.com’.
+
+
+    * **bucket_bound_hostname** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) If pass, then construct the URL relative to the bucket-bound hostname.
+    Value cane be a bare or with scheme, e.g., ‘example.com’ or ‘[http://example.com](http://example.com)’.
+    See: [https://cloud.google.com/storage/docs/request-endpoints#cname](https://cloud.google.com/storage/docs/request-endpoints#cname)
+
+
+    * **scheme** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) If `bucket_bound_hostname` is passed as a bare hostname, use
+    this value as the scheme.  `https` will work only when using a CDN.
+    Defaults to `"http"`.
+
+
+
+* **Raises**
+
+    [`ValueError`](https://python.readthedocs.io/en/latest/library/exceptions.html#ValueError) when version is invalid.
+
+
+
+* **Raises**
+
+    [`TypeError`](https://python.readthedocs.io/en/latest/library/exceptions.html#TypeError) when expiration is not a valid type.
+
+
+
+* **Raises**
+
+    [`AttributeError`](https://python.readthedocs.io/en/latest/library/exceptions.html#AttributeError) if credentials is not an instance
+    of [`google.auth.credentials.Signing`](https://googleapis.dev/python/google-auth/latest/reference/google.auth.credentials.html#google.auth.credentials.Signing).
+
+
+
+* **Return type**
+
+    [str](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)
+
+
+
+* **Returns**
+
+    A signed URL you can use to access the resource
+    until expiration.
+
+
+
+#### generate_upload_policy(conditions, expiration=None, client=None)
+Create a signed upload policy for uploading objects.
+
+This method generates and signs a policy document. You can use
+[policy documents]([https://cloud.google.com/storage/docs/xml-api/post-object-forms](https://cloud.google.com/storage/docs/xml-api/post-object-forms))
+to allow visitors to a website to upload files to
+Google Cloud Storage without giving them direct write access.
+See a [code sample]([https://cloud.google.com/storage/docs/xml-api/post-object-forms#python](https://cloud.google.com/storage/docs/xml-api/post-object-forms#python)).
+
+
+* **Parameters**
+
+    
+    * **expiration** (*datetime*) – (Optional) Expiration in UTC. If not specified, the
+    policy will expire in 1 hour.
+
+
+    * **conditions** ([*list*](https://python.readthedocs.io/en/latest/library/stdtypes.html#list)) – A list of conditions as described in the
+    policy documents documentation.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+
+* **Return type**
+
+    [dict](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)
+
+
+
+* **Returns**
+
+    A dictionary of (form field name, form field value) of form
+    fields that should be added to your HTML upload form in order
+    to attach the signature.
+
+
+
+#### get_blob(blob_name, client=None, encryption_key=None, generation=None, if_etag_match=None, if_etag_not_match=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, timeout=60, retry=<google.api_core.retry.Retry object>, \*\*kwargs)
+Get a blob object by name.
+
+See a [code sample]([https://cloud.google.com/storage/docs/samples/storage-get-metadata#storage_get_metadata-python](https://cloud.google.com/storage/docs/samples/storage-get-metadata#storage_get_metadata-python))
+on how to retrieve metadata of an object.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **blob_name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The name of the blob to retrieve.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **encryption_key** ([*bytes*](https://python.readthedocs.io/en/latest/library/stdtypes.html#bytes)) – (Optional) 32 byte encryption key for customer-supplied encryption.
+    See
+    [https://cloud.google.com/storage/docs/encryption#customer-supplied](https://cloud.google.com/storage/docs/encryption#customer-supplied).
+
+
+    * **generation** (*long*) – (Optional) If present, selects a specific revision of this object.
+
+
+    * **if_etag_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_match](generation_metageneration.md#using-if-etag-match)
+
+
+    * **if_etag_not_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) See [Using if_etag_not_match](generation_metageneration.md#using-if-etag-not-match)
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+    * **kwargs** – Keyword arguments to pass to the
+    [`Blob`](blobs.md#google.cloud.storage.blob.Blob) constructor.
+
+
+
+* **Return type**
+
+    [`google.cloud.storage.blob.Blob`](blobs.md#google.cloud.storage.blob.Blob) or None
+
+
+
+* **Returns**
+
+    The blob object if it exists, otherwise None.
+
+
+
+#### get_iam_policy(client=None, requested_policy_version=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+Retrieve the IAM policy for the bucket.
+
+See [API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/buckets/getIamPolicy](https://cloud.google.com/storage/docs/json_api/v1/buckets/getIamPolicy))
+and a [code sample]([https://cloud.google.com/storage/docs/samples/storage-view-bucket-iam-members#storage_view_bucket_iam_members-python](https://cloud.google.com/storage/docs/samples/storage-view-bucket-iam-members#storage_view_bucket_iam_members-python)).
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **requested_policy_version** (int or `NoneType`) – (Optional) The version of IAM policies to request.
+    If a policy with a condition is requested without
+    setting this, the server will return an error.
+    This must be set to a value of 3 to retrieve IAM
+    policies containing conditions. This is to prevent
+    client code that isn’t aware of IAM conditions from
+    interpreting and modifying policies incorrectly.
+    The service might return a policy with version lower
+    than the one that was requested, based on the
+    feature syntax in the policy fetched.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    [`google.api_core.iam.Policy`](https://googleapis.dev/python/google-api-core/latest/iam.html#google.api_core.iam.Policy)
+
+
+
+* **Returns**
+
+    the policy instance, based on the resource returned from
+    the `getIamPolicy` API request.
+
+
+
+#### get_logging()
+Return info about access logging for this bucket.
+
+See [https://cloud.google.com/storage/docs/access-logs#status](https://cloud.google.com/storage/docs/access-logs#status)
+
+
+* **Return type**
+
+    [dict](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict) or None
+
+
+
+* **Returns**
+
+    a dict w/ keys, `logBucket` and `logObjectPrefix`
+    (if logging is enabled), or None (if not).
+
+
+
+#### get_notification(notification_id, client=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+Get Pub / Sub notification for this bucket.
+
+See [API reference docs]([https://cloud.google.com/storage/docs/json_api/v1/notifications/get](https://cloud.google.com/storage/docs/json_api/v1/notifications/get))
+and a [code sample]([https://cloud.google.com/storage/docs/samples/storage-print-pubsub-bucket-notification#storage_print_pubsub_bucket_notification-python](https://cloud.google.com/storage/docs/samples/storage-print-pubsub-bucket-notification#storage_print_pubsub_bucket_notification-python)).
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **notification_id** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The notification id to retrieve the notification configuration.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    [`BucketNotification`](notification.md#google.cloud.storage.notification.BucketNotification)
+
+
+
+* **Returns**
+
+    notification instance.
+
+
+
+#### _property_ iam_configuration()
+Retrieve IAM configuration for this bucket.
+
+
+* **Return type**
+
+    `IAMConfiguration`
+
+
+
+* **Returns**
+
+    an instance for managing the bucket’s IAM configuration.
+
+
+
+#### _property_ id()
+Retrieve the ID for the bucket.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    The ID of the bucket or `None` if the bucket’s
+    resource has not been loaded from the server.
+
+
+
+#### _property_ labels()
+Retrieve or set labels assigned to this bucket.
+
+See
+[https://cloud.google.com/storage/docs/json_api/v1/buckets#labels](https://cloud.google.com/storage/docs/json_api/v1/buckets#labels)
+
+**NOTE**: The getter for this property returns a dict which is a *copy*
+of the bucket’s labels.  Mutating that dict has no effect unless
+you then re-assign the dict via the setter.  E.g.:
+
+```python
+>>> labels = bucket.labels
+>>> labels['new_key'] = 'some-label'
+>>> del labels['old_key']
+>>> bucket.labels = labels
+>>> bucket.update()
+```
+
+
+* **Setter**
+
+    Set labels for this bucket.
+
+
+
+* **Getter**
+
+    Gets the labels for this bucket.
+
+
+
+* **Return type**
+
+    [`dict`](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)
+
+
+
+* **Returns**
+
+    Name-value pairs (string->string) labelling the bucket.
+
+
+
+#### _property_ lifecycle_rules()
+Retrieve or set lifecycle rules configured for this bucket.
+
+See [https://cloud.google.com/storage/docs/lifecycle](https://cloud.google.com/storage/docs/lifecycle) and
+
+    [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+**NOTE**: The getter for this property returns a generator which yields
+*copies* of the bucket’s lifecycle rules mappings.  Mutating the
+output dicts has no effect unless you then re-assign the dict via
+the setter.  E.g.:
+
+```python
+>>> rules = list(bucket.lifecycle_rules)
+>>> rules.append({'origin': '/foo', ...})
+>>> rules[1]['rule']['action']['type'] = 'Delete'
+>>> del rules[0]
+>>> bucket.lifecycle_rules = rules
+>>> bucket.update()
+```
+
+
+* **Setter**
+
+    Set lifecycle rules for this bucket.
+
+
+
+* **Getter**
+
+    Gets the lifecycle rules for this bucket.
+
+
+
+* **Return type**
+
+    generator([dict](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict))
+
+
+
+* **Returns**
+
+    A sequence of mappings describing each lifecycle rule.
+
+
+
+#### list_blobs(max_results=None, page_token=None, prefix=None, delimiter=None, start_offset=None, end_offset=None, include_trailing_delimiter=None, versions=None, projection='noAcl', fields=None, client=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+DEPRECATED. Return an iterator used to find blobs in the bucket.
+
+**NOTE**: Direct use of this method is deprecated. Use `Client.list_blobs` instead.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **max_results** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) The maximum number of blobs to return.
+
+
+    * **page_token** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) If present, return the next batch of blobs, using the
+    value, which must correspond to the `nextPageToken` value
+    returned in the previous response.  Deprecated: use the `pages`
+    property of the returned iterator instead of manually passing the
+    token.
+
+
+    * **prefix** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Prefix used to filter blobs.
+
+
+    * **delimiter** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Delimiter, used with `prefix` to
+    emulate hierarchy.
+
+
+    * **start_offset** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Filter results to objects whose names are
+    lexicographically equal to or after `startOffset`. If
+    `endOffset` is also set, the objects listed will have names
+    between `startOffset` (inclusive) and `endOffset` (exclusive).
+
+
+    * **end_offset** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Filter results to objects whose names are
+    lexicographically before `endOffset`. If `startOffset` is also
+    set, the objects listed will have names between `startOffset`
+    (inclusive) and `endOffset` (exclusive).
+
+
+    * **include_trailing_delimiter** (*boolean*) – (Optional) If true, objects that end in exactly one instance of
+    `delimiter` will have their metadata included in `items` in
+    addition to `prefixes`.
+
+
+    * **versions** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) Whether object versions should be returned
+    as separate blobs.
+
+
+    * **projection** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) If used, must be ‘full’ or ‘noAcl’.
+    Defaults to `'noAcl'`. Specifies the set of
+    properties to return.
+
+
+    * **fields** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) Selector specifying which fields to include
+    in a partial response. Must be a list of fields. For
+    example to get a partial response with just the next
+    page token and the name and language of each blob returned:
+    `'items(name,contentLanguage),nextPageToken'`.
+    See: [https://cloud.google.com/storage/docs/json_api/v1/parameters#fields](https://cloud.google.com/storage/docs/json_api/v1/parameters#fields)
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client)) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    [`Iterator`](https://googleapis.dev/python/google-api-core/latest/page_iterator.html#google.api_core.page_iterator.Iterator)
+
+
+
+* **Returns**
+
+    Iterator of all [`Blob`](blobs.md#google.cloud.storage.blob.Blob)
+    in this bucket matching the arguments.
+
+
+
+#### list_notifications(client=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+List Pub / Sub notifications for this bucket.
+
+See:
+[https://cloud.google.com/storage/docs/json_api/v1/notifications/list](https://cloud.google.com/storage/docs/json_api/v1/notifications/list)
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    list of [`BucketNotification`](notification.md#google.cloud.storage.notification.BucketNotification)
+
+
+
+* **Returns**
+
+    notification instances
+
+
+
+#### _property_ location()
+Retrieve location configured for this bucket.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets) and
+[https://cloud.google.com/storage/docs/locations](https://cloud.google.com/storage/docs/locations)
+
+Returns `None` if the property has not been set before creation,
+or if the bucket’s resource has not been loaded from the server.
+:rtype: str or `NoneType`
+
+
+#### _property_ location_type()
+Retrieve the location type for the bucket.
+
+See [https://cloud.google.com/storage/docs/storage-classes](https://cloud.google.com/storage/docs/storage-classes)
+
+
+* **Getter**
+
+    Gets the the location type for this bucket.
+
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    If set, one of
+    [`MULTI_REGION_LOCATION_TYPE`](constants.md#google.cloud.storage.constants.MULTI_REGION_LOCATION_TYPE),
+    [`REGION_LOCATION_TYPE`](constants.md#google.cloud.storage.constants.REGION_LOCATION_TYPE), or
+    [`DUAL_REGION_LOCATION_TYPE`](constants.md#google.cloud.storage.constants.DUAL_REGION_LOCATION_TYPE),
+    else `None`.
+
+
+
+#### lock_retention_policy(client=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+Lock the bucket’s retention policy.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the blob’s bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Raises**
+
+    [**ValueError**](https://python.readthedocs.io/en/latest/library/exceptions.html#ValueError) – if the bucket has no metageneration (i.e., new or never reloaded);
+    if the bucket has no retention policy assigned;
+    if the bucket’s retention policy is already locked.
+
+
+
+#### make_private(recursive=False, future=False, client=None, timeout=60, if_metageneration_match=None, if_metageneration_not_match=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Update bucket’s ACL, revoking read access for anonymous users.
+
+
+* **Parameters**
+
+    
+    * **recursive** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – If True, this will make all blobs inside the bucket
+    private as well.
+
+
+    * **future** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – If True, this will make all objects created in the
+    future private as well.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) Make the operation conditional on whether the
+    blob’s current metageneration matches the given value.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) Make the operation conditional on whether the
+    blob’s current metageneration does not match the given value.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Raises**
+
+    [**ValueError**](https://python.readthedocs.io/en/latest/library/exceptions.html#ValueError) – If `recursive` is True, and the bucket contains more than 256
+    blobs.  This is to prevent extremely long runtime of this
+    method.  For such buckets, iterate over the blobs returned by
+    `list_blobs()` and call
+    [`make_private()`](blobs.md#google.cloud.storage.blob.Blob.make_private)
+    for each blob.
+
+
+
+#### make_public(recursive=False, future=False, client=None, timeout=60, if_metageneration_match=None, if_metageneration_not_match=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Update bucket’s ACL, granting read access to anonymous users.
+
+
+* **Parameters**
+
+    
+    * **recursive** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – If True, this will make all blobs inside the bucket
+    public as well.
+
+
+    * **future** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – If True, this will make all objects created in the
+    future public as well.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) Make the operation conditional on whether the
+    blob’s current metageneration matches the given value.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) Make the operation conditional on whether the
+    blob’s current metageneration does not match the given value.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Raises**
+
+    [**ValueError**](https://python.readthedocs.io/en/latest/library/exceptions.html#ValueError) – If `recursive` is True, and the bucket contains more than 256
+    blobs.  This is to prevent extremely long runtime of this
+    method.  For such buckets, iterate over the blobs returned by
+    `list_blobs()` and call
+    [`make_public()`](blobs.md#google.cloud.storage.blob.Blob.make_public)
+    for each blob.
+
+
+
+#### _property_ metageneration()
+Retrieve the metageneration for the bucket.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+
+* **Return type**
+
+    int or `NoneType`
+
+
+
+* **Returns**
+
+    The metageneration of the bucket or `None` if the bucket’s
+    resource has not been loaded from the server.
+
+
+
+#### notification(topic_name=None, topic_project=None, custom_attributes=None, event_types=None, blob_name_prefix=None, payload_format='NONE', notification_id=None)
+Factory:  create a notification resource for the bucket.
+
+See: [`BucketNotification`](notification.md#google.cloud.storage.notification.BucketNotification) for parameters.
+
+
+* **Return type**
+
+    [`BucketNotification`](notification.md#google.cloud.storage.notification.BucketNotification)
+
+
+
+#### _property_ owner()
+Retrieve info about the owner of the bucket.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+
+* **Return type**
+
+    dict or `NoneType`
+
+
+
+* **Returns**
+
+    Mapping of owner’s role/ID. Returns `None` if the bucket’s
+    resource has not been loaded from the server.
+
+
+
+#### patch(client=None, timeout=60, if_metageneration_match=None, if_metageneration_not_match=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Sends all changed properties in a PATCH request.
+
+Updates the `_properties` with the response from the backend.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – the client to use. If not passed, falls back to the
+    `client` stored on the current object.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) Make the operation conditional on whether the
+    blob’s current metageneration matches the given value.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) Make the operation conditional on whether the
+    blob’s current metageneration does not match the given value.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+#### _property_ path()
+The URL path to this bucket.
+
+
+#### _static_ path_helper(bucket_name)
+Relative URL path for a bucket.
+
+
+* **Parameters**
+
+    **bucket_name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The bucket name in the path.
+
+
+
+* **Return type**
+
+    [str](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)
+
+
+
+* **Returns**
+
+    The relative URL path for `bucket_name`.
+
+
+
+#### _property_ project_number()
+Retrieve the number of the project to which the bucket is assigned.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+
+* **Return type**
+
+    int or `NoneType`
+
+
+
+* **Returns**
+
+    The project number that owns the bucket or `None` if
+    the bucket’s resource has not been loaded from the server.
+
+
+
+#### reload(client=None, projection='noAcl', timeout=60, if_etag_match=None, if_etag_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, retry=<google.api_core.retry.Retry object>)
+Reload properties from Cloud Storage.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – the client to use. If not passed, falls back to the
+    `client` stored on the current object.
+
+
+    * **projection** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – (Optional) If used, must be ‘full’ or ‘noAcl’.
+    Defaults to `'noAcl'`. Specifies the set of
+    properties to return.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **if_etag_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]*) – (Optional) Make the operation conditional on whether the
+    bucket’s current ETag matches the given value.
+
+
+    * **if_etag_not_match** (*Union**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*, **Set**[*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*]**]**)*) – (Optional) Make the operation conditional on whether the
+    bucket’s current ETag does not match the given value.
+
+
+    * **if_metageneration_match** (*long*) – (Optional) Make the operation conditional on whether the
+    bucket’s current metageneration matches the given value.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) Make the operation conditional on whether the
+    bucket’s current metageneration does not match the given value.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+#### rename_blob(blob, new_name, client=None, if_generation_match=None, if_generation_not_match=None, if_metageneration_match=None, if_metageneration_not_match=None, if_source_generation_match=None, if_source_generation_not_match=None, if_source_metageneration_match=None, if_source_metageneration_not_match=None, timeout=60, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Rename the given blob using copy and delete operations.
+
+If `user_project` is set, bills the API request to that project.
+
+Effectively, copies blob to the same bucket with a new name, then
+deletes the blob.
+
+**WARNING**: This method will first duplicate the data and then delete the
+old blob.  This means that with very large objects renaming
+could be a very (temporarily) costly or a very slow operation.
+If you need more control over the copy and deletion, instead
+use google.cloud.storage.blob.Blob.copy_to and
+google.cloud.storage.blob.Blob.delete directly.
+
+
+* **Parameters**
+
+    
+    * **blob** ([`google.cloud.storage.blob.Blob`](blobs.md#google.cloud.storage.blob.Blob)) – The blob to be renamed.
+
+
+    * **new_name** ([*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)) – The new name for this blob.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **if_generation_match** (*long*) – (Optional) See [Using if_generation_match](generation_metageneration.md#using-if-generation-match)
+    Note that the generation to be matched is that of the
+    `destination` blob.
+
+
+    * **if_generation_not_match** (*long*) – (Optional) See [Using if_generation_not_match](generation_metageneration.md#using-if-generation-not-match)
+    Note that the generation to be matched is that of the
+    `destination` blob.
+
+
+    * **if_metageneration_match** (*long*) – (Optional) See [Using if_metageneration_match](generation_metageneration.md#using-if-metageneration-match)
+    Note that the metageneration to be matched is that of the
+    `destination` blob.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) See [Using if_metageneration_not_match](generation_metageneration.md#using-if-metageneration-not-match)
+    Note that the metageneration to be matched is that of the
+    `destination` blob.
+
+
+    * **if_source_generation_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s generation matches the given value. Also used in the
+    (implied) delete request.
+
+
+    * **if_source_generation_not_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s generation does not match the given value. Also used in
+    the (implied) delete request.
+
+
+    * **if_source_metageneration_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s current metageneration matches the given value. Also used
+    in the (implied) delete request.
+
+
+    * **if_source_metageneration_not_match** (*long*) – (Optional) Makes the operation conditional on whether the source
+    object’s current metageneration does not match the given value.
+    Also used in the (implied) delete request.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    `Blob`
+
+
+
+* **Returns**
+
+    The newly-renamed blob.
+
+
+
+#### _property_ requester_pays()
+Does the requester pay for API requests for this bucket?
+
+See [https://cloud.google.com/storage/docs/requester-pays](https://cloud.google.com/storage/docs/requester-pays) for
+details.
+
+
+* **Setter**
+
+    Update whether requester pays for this bucket.
+
+
+
+* **Getter**
+
+    Query whether requester pays for this bucket.
+
+
+
+* **Return type**
+
+    [bool](https://python.readthedocs.io/en/latest/library/functions.html#bool)
+
+
+
+* **Returns**
+
+    True if requester pays for API requests for the bucket,
+    else False.
+
+
+
+#### _property_ retention_period()
+Retrieve or set the retention period for items in the bucket.
+
+
+* **Return type**
+
+    int or `NoneType`
+
+
+
+* **Returns**
+
+    number of seconds to retain items after upload or release
+    from event-based lock, or `None` if the property is not
+    set locally.
+
+
+
+#### _property_ retention_policy_effective_time()
+Retrieve the effective time of the bucket’s retention policy.
+
+
+* **Return type**
+
+    datetime.datetime or `NoneType`
+
+
+
+* **Returns**
+
+    point-in time at which the bucket’s retention policy is
+    effective, or `None` if the property is not
+    set locally.
+
+
+
+#### _property_ retention_policy_locked()
+Retrieve whthere the bucket’s retention policy is locked.
+
+
+* **Return type**
+
+    [bool](https://python.readthedocs.io/en/latest/library/functions.html#bool)
+
+
+
+* **Returns**
+
+    True if the bucket’s policy is locked, or else False
+    if the policy is not locked, or the property is not
+    set locally.
+
+
+
+#### _property_ rpo()
+Get the RPO (Recovery Point Objective) of this bucket
+
+See: [https://cloud.google.com/storage/docs/managing-turbo-replication](https://cloud.google.com/storage/docs/managing-turbo-replication)
+
+“ASYNC_TURBO” or “DEFAULT”
+:rtype: str
+
+
+#### _property_ self_link()
+Retrieve the URI for the bucket.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    The self link for the bucket or `None` if
+    the bucket’s resource has not been loaded from the server.
+
+
+
+#### set_iam_policy(policy, client=None, timeout=60, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Update the IAM policy for the bucket.
+
+See
+[https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy](https://cloud.google.com/storage/docs/json_api/v1/buckets/setIamPolicy)
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **policy** ([`google.api_core.iam.Policy`](https://googleapis.dev/python/google-api-core/latest/iam.html#google.api_core.iam.Policy)) – policy instance used to update bucket’s IAM policy.
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    [`google.api_core.iam.Policy`](https://googleapis.dev/python/google-api-core/latest/iam.html#google.api_core.iam.Policy)
+
+
+
+* **Returns**
+
+    the policy instance, based on the resource returned from
+    the `setIamPolicy` API request.
+
+
+
+#### _property_ storage_class()
+Retrieve or set the storage class for the bucket.
+
+See [https://cloud.google.com/storage/docs/storage-classes](https://cloud.google.com/storage/docs/storage-classes)
+
+
+* **Setter**
+
+    Set the storage class for this bucket.
+
+
+
+* **Getter**
+
+    Gets the the storage class for this bucket.
+
+
+
+* **Return type**
+
+    str or `NoneType`
+
+
+
+* **Returns**
+
+    If set, one of
+    [`NEARLINE_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.NEARLINE_STORAGE_CLASS),
+    [`COLDLINE_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.COLDLINE_STORAGE_CLASS),
+    [`ARCHIVE_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.ARCHIVE_STORAGE_CLASS),
+    [`STANDARD_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.STANDARD_STORAGE_CLASS),
+    [`MULTI_REGIONAL_LEGACY_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.MULTI_REGIONAL_LEGACY_STORAGE_CLASS),
+    [`REGIONAL_LEGACY_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.REGIONAL_LEGACY_STORAGE_CLASS),
+    or
+    [`DURABLE_REDUCED_AVAILABILITY_LEGACY_STORAGE_CLASS`](constants.md#google.cloud.storage.constants.DURABLE_REDUCED_AVAILABILITY_LEGACY_STORAGE_CLASS),
+    else `None`.
+
+
+
+#### test_iam_permissions(permissions, client=None, timeout=60, retry=<google.api_core.retry.Retry object>)
+API call:  test permissions
+
+See
+[https://cloud.google.com/storage/docs/json_api/v1/buckets/testIamPermissions](https://cloud.google.com/storage/docs/json_api/v1/buckets/testIamPermissions)
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **permissions** (*list of string*) – the permissions to check
+
+
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – (Optional) The client to use.  If not passed, falls back
+    to the `client` stored on the current bucket.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+* **Return type**
+
+    list of string
+
+
+
+* **Returns**
+
+    the permissions returned by the `testIamPermissions` API
+    request.
+
+
+
+#### _property_ time_created()
+Retrieve the timestamp at which the bucket was created.
+
+See [https://cloud.google.com/storage/docs/json_api/v1/buckets](https://cloud.google.com/storage/docs/json_api/v1/buckets)
+
+
+* **Return type**
+
+    [`datetime.datetime`](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.datetime) or `NoneType`
+
+
+
+* **Returns**
+
+    Datetime object parsed from RFC3339 valid timestamp, or
+    `None` if the bucket’s resource has not been loaded
+    from the server.
+
+
+
+#### update(client=None, timeout=60, if_metageneration_match=None, if_metageneration_not_match=None, retry=<google.cloud.storage.retry.ConditionalRetryPolicy object>)
+Sends all properties in a PUT request.
+
+Updates the `_properties` with the response from the backend.
+
+If `user_project` is set, bills the API request to that project.
+
+
+* **Parameters**
+
+    
+    * **client** ([`Client`](client.md#google.cloud.storage.client.Client) or
+    `NoneType`) – the client to use. If not passed, falls back to the
+    `client` stored on the current object.
+
+
+    * **timeout** ([*float*](https://python.readthedocs.io/en/latest/library/functions.html#float)* or *[*tuple*](https://python.readthedocs.io/en/latest/library/stdtypes.html#tuple)) – (Optional) The amount of time, in seconds, to wait
+    for the server response.  See: [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * **if_metageneration_match** (*long*) – (Optional) Make the operation conditional on whether the
+    blob’s current metageneration matches the given value.
+
+
+    * **if_metageneration_not_match** (*long*) – (Optional) Make the operation conditional on whether the
+    blob’s current metageneration does not match the given value.
+
+
+    * **retry** ([*google.api_core.retry.Retry*](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry)* or *[*google.cloud.storage.retry.ConditionalRetryPolicy*](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy)) – (Optional) How to retry the RPC. See: [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+
+#### _property_ user_project()
+Project ID to be billed for API requests made via this bucket.
+
+If unset, API requests are billed to the bucket owner.
+
+A user project is required for all operations on Requester Pays buckets.
+
+See [https://cloud.google.com/storage/docs/requester-pays#requirements](https://cloud.google.com/storage/docs/requester-pays#requirements) for details.
+
+
+* **Return type**
+
+    [str](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)
+
+
+
+#### _property_ versioning_enabled()
+Is versioning enabled for this bucket?
+
+See  [https://cloud.google.com/storage/docs/object-versioning](https://cloud.google.com/storage/docs/object-versioning) for
+details.
+
+
+* **Setter**
+
+    Update whether versioning is enabled for this bucket.
+
+
+
+* **Getter**
+
+    Query whether versioning is enabled for this bucket.
+
+
+
+* **Return type**
+
+    [bool](https://python.readthedocs.io/en/latest/library/functions.html#bool)
+
+
+
+* **Returns**
+
+    True if enabled, else False.
+
+
+
+### _class_ google.cloud.storage.bucket.IAMConfiguration(bucket, public_access_prevention=<object object>, uniform_bucket_level_access_enabled=<object object>, uniform_bucket_level_access_locked_time=<object object>, bucket_policy_only_enabled=<object object>, bucket_policy_only_locked_time=<object object>)
+Bases: [`dict`](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)
+
+Map a bucket’s IAM configuration.
+
+
+* **Params bucket**
+
+    Bucket for which this instance is the policy.
+
+
+
+* **Params public_access_prevention**
+
+    (Optional) Whether the public access prevention policy is ‘inherited’ (default) or ‘enforced’
+    See: [https://cloud.google.com/storage/docs/public-access-prevention](https://cloud.google.com/storage/docs/public-access-prevention)
+
+
+
+* **Params bucket_policy_only_enabled**
+
+    (Optional) Whether the IAM-only policy is enabled for the bucket.
+
+
+
+* **Params uniform_bucket_level_locked_time**
+
+    (Optional) When the bucket’s IAM-only policy was enabled.
+    This value should normally only be set by the back-end API.
+
+
+
+* **Params bucket_policy_only_enabled**
+
+    Deprecated alias for `uniform_bucket_level_access_enabled`.
+
+
+
+* **Params bucket_policy_only_locked_time**
+
+    Deprecated alias for `uniform_bucket_level_access_locked_time`.
+
+
+
+#### _property_ bucket()
+Bucket for which this instance is the policy.
+
+
+* **Return type**
+
+    `Bucket`
+
+
+
+* **Returns**
+
+    the instance’s bucket.
+
+
+
+#### _property_ bucket_policy_only_enabled()
+Deprecated alias for `uniform_bucket_level_access_enabled`.
+
+
+* **Return type**
+
+    [bool](https://python.readthedocs.io/en/latest/library/functions.html#bool)
+
+
+
+* **Returns**
+
+    whether the bucket is configured to allow only IAM.
+
+
+
+#### _property_ bucket_policy_only_locked_time()
+Deprecated alias for `uniform_bucket_level_access_locked_time`.
+
+
+* **Return type**
+
+    Union[[`datetime.datetime`](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.datetime), None]
+
+
+
+* **Returns**
+
+    (readonly) Time after which `bucket_policy_only_enabled` will
+    be frozen as true.
+
+
+
+#### clear()
+
+#### copy()
+
+#### _classmethod_ from_api_repr(resource, bucket)
+Factory:  construct instance from resource.
+
+
+* **Params bucket**
+
+    Bucket for which this instance is the policy.
+
+
+
+* **Parameters**
+
+    **resource** ([*dict*](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)) – mapping as returned from API call.
+
+
+
+* **Return type**
+
+    `IAMConfiguration`
+
+
+
+* **Returns**
+
+    Instance created from resource.
+
+
+
+#### fromkeys(value=None, /)
+Create a new dictionary with keys from iterable and values set to value.
+
+
+#### get(key, default=None, /)
+Return the value for key if key is in the dictionary, else default.
+
+
+#### items()
+
+#### keys()
+
+#### pop(k, )
+If key is not found, default is returned if given, otherwise KeyError is raised
+
+
+#### popitem()
+Remove and return a (key, value) pair as a 2-tuple.
+
+Pairs are returned in LIFO (last-in, first-out) order.
+Raises KeyError if the dict is empty.
+
+
+#### _property_ public_access_prevention()
+Setting for public access prevention policy. Options are ‘inherited’ (default) or ‘enforced’.
+
+> See: [https://cloud.google.com/storage/docs/public-access-prevention](https://cloud.google.com/storage/docs/public-access-prevention)
+
+
+* **Return type**
+
+    string
+
+
+
+* **Returns**
+
+    the public access prevention status, either ‘enforced’ or ‘inherited’.
+
+
+
+#### setdefault(key, default=None, /)
+Insert key with a value of default if key is not in the dictionary.
+
+Return the value for key if key is in the dictionary, else default.
+
+
+#### _property_ uniform_bucket_level_access_enabled()
+If set, access checks only use bucket-level IAM policies or above.
+
+
+* **Return type**
+
+    [bool](https://python.readthedocs.io/en/latest/library/functions.html#bool)
+
+
+
+* **Returns**
+
+    whether the bucket is configured to allow only IAM.
+
+
+
+#### _property_ uniform_bucket_level_access_locked_time()
+Deadline for changing `uniform_bucket_level_access_enabled` from true to false.
+
+If the bucket’s `uniform_bucket_level_access_enabled` is true, this property
+is time time after which that setting becomes immutable.
+
+If the bucket’s `uniform_bucket_level_access_enabled` is false, this property
+is `None`.
+
+
+* **Return type**
+
+    Union[[`datetime.datetime`](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.datetime), None]
+
+
+
+* **Returns**
+
+    (readonly) Time after which `uniform_bucket_level_access_enabled` will
+    be frozen as true.
+
+
+
+#### update(\*\*F)
+If E is present and has a .keys() method, then does:  for k in E: D[k] = E[k]
+If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v
+In either case, this is followed by: for k in F:  D[k] = F[k]
+
+
+#### values()
+
+### _class_ google.cloud.storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload(\*\*kw)
+Bases: [`dict`](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)
+
+Map a rule aborting incomplete multipart uploads of matching items.
+
+The “age” lifecycle condition is the only supported condition for this rule.
+
+
+* **Params kw**
+
+    arguments passed to `LifecycleRuleConditions`.
+
+
+
+#### clear()
+
+#### copy()
+
+#### _classmethod_ from_api_repr(resource)
+Factory:  construct instance from resource.
+
+
+* **Parameters**
+
+    **resource** ([*dict*](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)) – mapping as returned from API call.
+
+
+
+* **Return type**
+
+    `LifecycleRuleAbortIncompleteMultipartUpload`
+
+
+
+* **Returns**
+
+    Instance created from resource.
+
+
+
+#### fromkeys(value=None, /)
+Create a new dictionary with keys from iterable and values set to value.
+
+
+#### get(key, default=None, /)
+Return the value for key if key is in the dictionary, else default.
+
+
+#### items()
+
+#### keys()
+
+#### pop(k, )
+If key is not found, default is returned if given, otherwise KeyError is raised
+
+
+#### popitem()
+Remove and return a (key, value) pair as a 2-tuple.
+
+Pairs are returned in LIFO (last-in, first-out) order.
+Raises KeyError if the dict is empty.
+
+
+#### setdefault(key, default=None, /)
+Insert key with a value of default if key is not in the dictionary.
+
+Return the value for key if key is in the dictionary, else default.
+
+
+#### update(\*\*F)
+If E is present and has a .keys() method, then does:  for k in E: D[k] = E[k]
+If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v
+In either case, this is followed by: for k in F:  D[k] = F[k]
+
+
+#### values()
+
+### _class_ google.cloud.storage.bucket.LifecycleRuleConditions(age=None, created_before=None, is_live=None, matches_storage_class=None, number_of_newer_versions=None, days_since_custom_time=None, custom_time_before=None, days_since_noncurrent_time=None, noncurrent_time_before=None, matches_prefix=None, matches_suffix=None, _factory=False)
+Bases: [`dict`](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)
+
+Map a single lifecycle rule for a bucket.
+
+See: [https://cloud.google.com/storage/docs/lifecycle](https://cloud.google.com/storage/docs/lifecycle)
+
+
+* **Parameters**
+
+    
+    * **age** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) Apply rule action to items whose age, in days,
+    exceeds this value.
+
+
+    * **created_before** ([*datetime.date*](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.date)) – (Optional) Apply rule action to items created
+    before this date.
+
+
+    * **is_live** ([*bool*](https://python.readthedocs.io/en/latest/library/functions.html#bool)) – (Optional) If true, apply rule action to non-versioned
+    items, or to items with no newer versions. If false, apply
+    rule action to versioned items with at least one newer
+    version.
+
+
+    * **matches_prefix** ([*list*](https://python.readthedocs.io/en/latest/library/stdtypes.html#list)*(*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*)*) – (Optional) Apply rule action to items which
+    any prefix matches the beginning of the item name.
+
+
+    * **matches_storage_class** (list(str), one or more of
+    `Bucket.STORAGE_CLASSES`.) – (Optional) Apply rule action to items
+    whose storage class matches this value.
+
+
+    * **matches_suffix** ([*list*](https://python.readthedocs.io/en/latest/library/stdtypes.html#list)*(*[*str*](https://python.readthedocs.io/en/latest/library/stdtypes.html#str)*)*) – (Optional) Apply rule action to items which
+    any suffix matches the end of the item name.
+
+
+    * **number_of_newer_versions** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) Apply rule action to versioned
+    items having N newer versions.
+
+
+    * **days_since_custom_time** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) Apply rule action to items whose number of days
+    elapsed since the custom timestamp. This condition is relevant
+    only for versioned objects. The value of the field must be a non
+    negative integer. If it’s zero, the object version will become
+    eligible for lifecycle action as soon as it becomes custom.
+
+
+    * **custom_time_before** ([`datetime.date`](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.date)) – (Optional)  Date object parsed from RFC3339 valid date, apply rule action
+    to items whose custom time is before this date. This condition is relevant
+    only for versioned objects, e.g., 2019-03-16.
+
+
+    * **days_since_noncurrent_time** ([*int*](https://python.readthedocs.io/en/latest/library/functions.html#int)) – (Optional) Apply rule action to items whose number of days
+    elapsed since the non current timestamp. This condition
+    is relevant only for versioned objects. The value of the field
+    must be a non negative integer. If it’s zero, the object version
+    will become eligible for lifecycle action as soon as it becomes
+    non current.
+
+
+    * **noncurrent_time_before** ([`datetime.date`](https://python.readthedocs.io/en/latest/library/datetime.html#datetime.date)) – (Optional) Date object parsed from RFC3339 valid date, apply
+    rule action to items whose non current time is before this date.
+    This condition is relevant only for versioned objects, e.g, 2019-03-16.
+
+
+
+* **Raises**
+
+    [**ValueError**](https://python.readthedocs.io/en/latest/library/exceptions.html#ValueError) – if no arguments are passed.
+
+
+
+#### _property_ age()
+Conditon’s age value.
+
+
+#### clear()
+
+#### copy()
+
+#### _property_ created_before()
+Conditon’s created_before value.
+
+
+#### _property_ custom_time_before()
+Conditon’s ‘custom_time_before’ value.
+
+
+#### _property_ days_since_custom_time()
+Conditon’s ‘days_since_custom_time’ value.
+
+
+#### _property_ days_since_noncurrent_time()
+Conditon’s ‘days_since_noncurrent_time’ value.
+
+
+#### _classmethod_ from_api_repr(resource)
+Factory:  construct instance from resource.
+
+
+* **Parameters**
+
+    **resource** ([*dict*](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)) – mapping as returned from API call.
+
+
+
+* **Return type**
+
+    `LifecycleRuleConditions`
+
+
+
+* **Returns**
+
+    Instance created from resource.
+
+
+
+#### fromkeys(value=None, /)
+Create a new dictionary with keys from iterable and values set to value.
+
+
+#### get(key, default=None, /)
+Return the value for key if key is in the dictionary, else default.
+
+
+#### _property_ is_live()
+Conditon’s ‘is_live’ value.
+
+
+#### items()
+
+#### keys()
+
+#### _property_ matches_prefix()
+Conditon’s ‘matches_prefix’ value.
+
+
+#### _property_ matches_storage_class()
+Conditon’s ‘matches_storage_class’ value.
+
+
+#### _property_ matches_suffix()
+Conditon’s ‘matches_suffix’ value.
+
+
+#### _property_ noncurrent_time_before()
+Conditon’s ‘noncurrent_time_before’ value.
+
+
+#### _property_ number_of_newer_versions()
+Conditon’s ‘number_of_newer_versions’ value.
+
+
+#### pop(k, )
+If key is not found, default is returned if given, otherwise KeyError is raised
+
+
+#### popitem()
+Remove and return a (key, value) pair as a 2-tuple.
+
+Pairs are returned in LIFO (last-in, first-out) order.
+Raises KeyError if the dict is empty.
+
+
+#### setdefault(key, default=None, /)
+Insert key with a value of default if key is not in the dictionary.
+
+Return the value for key if key is in the dictionary, else default.
+
+
+#### update(\*\*F)
+If E is present and has a .keys() method, then does:  for k in E: D[k] = E[k]
+If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v
+In either case, this is followed by: for k in F:  D[k] = F[k]
+
+
+#### values()
+
+### _class_ google.cloud.storage.bucket.LifecycleRuleDelete(\*\*kw)
+Bases: [`dict`](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)
+
+Map a lifecycle rule deleting matching items.
+
+
+* **Params kw**
+
+    arguments passed to `LifecycleRuleConditions`.
+
+
+
+#### clear()
+
+#### copy()
+
+#### _classmethod_ from_api_repr(resource)
+Factory:  construct instance from resource.
+
+
+* **Parameters**
+
+    **resource** ([*dict*](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)) – mapping as returned from API call.
+
+
+
+* **Return type**
+
+    `LifecycleRuleDelete`
+
+
+
+* **Returns**
+
+    Instance created from resource.
+
+
+
+#### fromkeys(value=None, /)
+Create a new dictionary with keys from iterable and values set to value.
+
+
+#### get(key, default=None, /)
+Return the value for key if key is in the dictionary, else default.
+
+
+#### items()
+
+#### keys()
+
+#### pop(k, )
+If key is not found, default is returned if given, otherwise KeyError is raised
+
+
+#### popitem()
+Remove and return a (key, value) pair as a 2-tuple.
+
+Pairs are returned in LIFO (last-in, first-out) order.
+Raises KeyError if the dict is empty.
+
+
+#### setdefault(key, default=None, /)
+Insert key with a value of default if key is not in the dictionary.
+
+Return the value for key if key is in the dictionary, else default.
+
+
+#### update(\*\*F)
+If E is present and has a .keys() method, then does:  for k in E: D[k] = E[k]
+If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v
+In either case, this is followed by: for k in F:  D[k] = F[k]
+
+
+#### values()
+
+### _class_ google.cloud.storage.bucket.LifecycleRuleSetStorageClass(storage_class, \*\*kw)
+Bases: [`dict`](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)
+
+Map a lifecycle rule updating storage class of matching items.
+
+
+* **Parameters**
+
+    **storage_class** (str, one of `Bucket.STORAGE_CLASSES`.) – new storage class to assign to matching items.
+
+
+
+* **Params kw**
+
+    arguments passed to `LifecycleRuleConditions`.
+
+
+
+#### clear()
+
+#### copy()
+
+#### _classmethod_ from_api_repr(resource)
+Factory:  construct instance from resource.
+
+
+* **Parameters**
+
+    **resource** ([*dict*](https://python.readthedocs.io/en/latest/library/stdtypes.html#dict)) – mapping as returned from API call.
+
+
+
+* **Return type**
+
+    `LifecycleRuleSetStorageClass`
+
+
+
+* **Returns**
+
+    Instance created from resource.
+
+
+
+#### fromkeys(value=None, /)
+Create a new dictionary with keys from iterable and values set to value.
+
+
+#### get(key, default=None, /)
+Return the value for key if key is in the dictionary, else default.
+
+
+#### items()
+
+#### keys()
+
+#### pop(k, )
+If key is not found, default is returned if given, otherwise KeyError is raised
+
+
+#### popitem()
+Remove and return a (key, value) pair as a 2-tuple.
+
+Pairs are returned in LIFO (last-in, first-out) order.
+Raises KeyError if the dict is empty.
+
+
+#### setdefault(key, default=None, /)
+Insert key with a value of default if key is not in the dictionary.
+
+Return the value for key if key is in the dictionary, else default.
+
+
+#### update(\*\*F)
+If E is present and has a .keys() method, then does:  for k in E: D[k] = E[k]
+If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v
+In either case, this is followed by: for k in F:  D[k] = F[k]
+
+
+#### values()

--- a/tests/testdata/goldens/handwritten/generation_metageneration.md
+++ b/tests/testdata/goldens/handwritten/generation_metageneration.md
@@ -1,0 +1,127 @@
+# Conditional Requests Via ETag / Generation / Metageneration Preconditions
+
+Preconditions tell Cloud Storage to only perform a request if the
+ETag, generation, or
+metageneration number of the affected object
+meets your precondition criteria. These checks of the ETag, generation, and
+metageneration numbers ensure that the object is in the expected state,
+allowing you to perform safe read-modify-write updates and conditional
+operations on objects
+
+## Concepts
+
+### ETag
+
+An ETag is returned as part of the response header whenever a resource is
+returned, as well as included in the resource itself. Users should make no
+assumptions about the value used in an ETag except that it changes whenever the
+underlying data changes, per the
+[specification](https://tools.ietf.org/html/rfc7232#section-2.3)
+
+The `ETag` attribute is set by the GCS back-end, and is read-only in the
+client library.
+
+### Metageneration
+
+When you create a [`Bucket`](buckets.md#google.cloud.storage.bucket.Bucket),
+its [`metageneration`](buckets.md#google.cloud.storage.bucket.Bucket.metageneration) is initialized
+to `1`, representing the initial version of the bucket’s metadata.
+
+When you first upload a
+[`Blob`](blobs.md#google.cloud.storage.blob.Blob) (“Object” in the GCS back-end docs),
+its [`metageneration`](blobs.md#google.cloud.storage.blob.Blob.metageneration) is likewise
+initialized to `1`.  representing the initial version of the blob’s metadata.
+
+The `metageneration` attribute is set by the GCS back-end, and is read-only
+in the client library.
+
+Each time you patch or update the bucket’s / blob’s metadata, its
+`metageneration` is incremented.
+
+### Generation
+
+Each time you upload a new version of a file to a
+[`Blob`](blobs.md#google.cloud.storage.blob.Blob) (“Object” in the GCS back-end docs),
+the Blob’s `generation` is changed, and its
+`metageneration` is reset to `1` (the first
+metadata version for that generation of the blob).
+
+The `generation` attribute is set by the GCS back-end, and is read-only
+in the client library.
+
+### See also
+
+
+* [Storage API Generation Precondition docs](https://cloud.google.com/storage/docs/generations-preconditions)
+
+## Conditional Parameters
+
+### Using `if_etag_match`
+
+Passing the `if_etag_match` parameter to a method which retrieves a
+blob resource (e.g.,
+[`Blob.reload`](blobs.md#google.cloud.storage.blob.Blob.reload))
+makes the operation conditional on whether the blob’s current `ETag` matches
+the given value. This parameter is not supported for modification (e.g.,
+[`Blob.update`](blobs.md#google.cloud.storage.blob.Blob.update)).
+
+### Using `if_etag_not_match`
+
+Passing the `if_etag_not_match` parameter to a method which retrieves a
+blob resource (e.g.,
+[`Blob.reload`](blobs.md#google.cloud.storage.blob.Blob.reload))
+makes the operation conditional on whether the blob’s current `ETag` matches
+the given value. This parameter is not supported for modification (e.g.,
+[`Blob.update`](blobs.md#google.cloud.storage.blob.Blob.update)).
+
+### Using `if_generation_match`
+
+Passing the `if_generation_match` parameter to a method which retrieves a
+blob resource (e.g.,
+[`Blob.reload`](blobs.md#google.cloud.storage.blob.Blob.reload)) or modifies
+the blob (e.g.,
+[`Blob.update`](blobs.md#google.cloud.storage.blob.Blob.update))
+makes the operation conditional on whether the blob’s current `generation`
+matches the given value.
+
+As a special case, passing `0` as the value for `if_generation_match`
+makes the operation succeed only if there are no live versions of the blob.
+
+### Using `if_generation_not_match`
+
+Passing the `if_generation_not_match` parameter to a method which retrieves
+a blob resource (e.g.,
+[`Blob.reload`](blobs.md#google.cloud.storage.blob.Blob.reload)) or modifies
+the blob (e.g.,
+[`Blob.update`](blobs.md#google.cloud.storage.blob.Blob.update))
+makes the operation conditional on whether the blob’s current `generation`
+does **not** match the given value.
+
+If no live version of the blob exists, the precondition fails.
+
+As a special case, passing `0` as the value for `if_generation_not_match`
+makes the operation succeed only if there **is** a live version of the blob.
+
+### Using `if_metageneration_match`
+
+Passing the `if_metageneration_match` parameter to a method which retrieves
+a blob or bucket resource
+(e.g., [`Blob.reload`](blobs.md#google.cloud.storage.blob.Blob.reload),
+[`Bucket.reload`](buckets.md#google.cloud.storage.bucket.Bucket.reload))
+or modifies the blob or bucket (e.g.,
+[`Blob.update`](blobs.md#google.cloud.storage.blob.Blob.update)
+[`Bucket.patch`](buckets.md#google.cloud.storage.bucket.Bucket.patch))
+makes the operation conditional on whether the resource’s current
+`metageneration` matches the given value.
+
+### Using `if_metageneration_not_match`
+
+Passing the `if_metageneration_not_match` parameter to a method which
+retrieves a blob or bucket resource
+(e.g., [`Blob.reload`](blobs.md#google.cloud.storage.blob.Blob.reload),
+[`Bucket.reload`](buckets.md#google.cloud.storage.bucket.Bucket.reload))
+or modifies the blob or bucket (e.g.,
+[`Blob.update`](blobs.md#google.cloud.storage.blob.Blob.update)
+[`Bucket.patch`](buckets.md#google.cloud.storage.bucket.Bucket.patch))
+makes the operation conditional on whether the resource’s current
+`metageneration` does **not** match the given value.

--- a/tests/testdata/goldens/handwritten/modules.md
+++ b/tests/testdata/goldens/handwritten/modules.md
@@ -1,0 +1,52 @@
+# Modules for Python Storage
+
+
+* [Storage Client](client.md)
+
+
+* [Blobs / Objects](blobs.md)
+
+
+* [Buckets](buckets.md)
+
+
+* [ACL](acl.md)
+
+
+    * [ACL Module](acl.md#module-google.cloud.storage.acl)
+
+
+* [Batches](batch.md)
+
+
+* [FileIO](fileio.md)
+
+
+* [Constants](constants.md)
+
+
+* [HMAC Key Metadata](hmac_key.md)
+
+
+* [Notification](notification.md)
+
+
+* [Retry](retry.md)
+
+
+* [Configuring Timeouts and Retries](retry_timeout.md)
+
+
+    * [Configuring Timeouts](retry_timeout.md#configuring-timeouts)
+
+
+    * [Configuring Retries](retry_timeout.md#configuring-retries)
+
+
+* [Conditional Requests Via ETag / Generation / Metageneration Preconditions](generation_metageneration.md)
+
+
+    * [Concepts](generation_metageneration.md#concepts)
+
+
+    * [Conditional Parameters](generation_metageneration.md#conditional-parameters)

--- a/tests/testdata/goldens/handwritten/retry_timeout.md
+++ b/tests/testdata/goldens/handwritten/retry_timeout.md
@@ -1,0 +1,158 @@
+# Configuring Timeouts and Retries
+
+When using object methods which invoke Google Cloud Storage API methods,
+you have several options for how the library handles timeouts and
+how it retries transient errors.
+
+## Configuring Timeouts
+
+For a number of reasons, methods which invoke API methods may take
+longer than expected or desired.  By default, such methods all time out
+after a default interval, 60.0 seconds.  Rather than blocking your application
+code for that interval, you may choose to configure explicit timeouts
+in your code, using one of three forms:
+
+
+* You can pass a single integer or float which functions as the timeout for the
+entire request. E.g.:
+
+```python
+bucket = client.get_bucket(BUCKET_NAME, timeout=300.0)  # five minutes
+```
+
+
+* You can also be passed as a two-tuple, `(connect_timeout, read_timeout)`,
+where the `connect_timeout` sets the maximum time required to establish
+the connection to the server, and the `read_timeout` sets the maximum
+time to wait for a completed response.  E.g.:
+
+```python
+bucket = client.get_bucket(BUCKET_NAME, timeout=(3, 10))
+```
+
+
+* You can also pass `None` as the timeout value:  in this case, the library
+will block indefinitely for a response.  E.g.:
+
+```python
+bucket = client.get_bucket(BUCKET_NAME, timeout=None)
+```
+
+**NOTE**: Depending on the retry strategy, a request may be
+repeated several times using the same timeout each time.
+
+See also:
+
+> [Timeouts in requests](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts)
+
+## Configuring Retries
+
+**NOTE**: For more background on retries, see also the
+[GCS Retry Strategies Document](https://cloud.google.com/storage/docs/retry-strategy#python)
+
+Methods which invoke API methods may fail for a number of reasons, some of
+which represent “transient” conditions, and thus can be retried
+automatically.  The library tries to provide a sensible default retry policy
+for each method, base on its semantics:
+
+
+* For API requests which are always idempotent, the library uses its
+[`DEFAULT_RETRY`](retry.md#google.cloud.storage.retry.DEFAULT_RETRY) policy, which
+retries any API request which returns a “transient” error.
+
+
+* For API requests which are idempotent only if the blob has
+the same “generation”, the library uses its
+[`DEFAULT_RETRY_IF_GENERATION_SPECIFIED`](retry.md#google.cloud.storage.retry.DEFAULT_RETRY_IF_GENERATION_SPECIFIED)
+policy, which retries API requests which returns a “transient” error,
+but only if the original request includes a `generation` or
+`ifGenerationMatch` header.
+
+
+* For API requests which are idempotent only if the bucket or blob has
+the same “metageneration”, the library uses its
+[`DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED`](retry.md#google.cloud.storage.retry.DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED)
+policy, which retries API requests which returns a “transient” error,
+but only if the original request includes an `ifMetagenerationMatch` header.
+
+
+* For API requests which are idempotent only if the bucket or blob has
+the same “etag”, the library uses its
+[`DEFAULT_RETRY_IF_ETAG_IN_JSON`](retry.md#google.cloud.storage.retry.DEFAULT_RETRY_IF_ETAG_IN_JSON)
+policy, which retries API requests which returns a “transient” error,
+but only if the original request includes an `ETAG` in its payload.
+
+
+* For those API requests which are never idempotent, the library passes
+`retry=None` by default, suppressing any retries.
+
+Rather than using one of the default policies, you may choose to configure an
+explicit policy in your code.
+
+
+* You can pass `None` as a retry policy to disable retries.  E.g.:
+
+```python
+bucket = client.get_bucket(BUCKET_NAME, retry=None)
+```
+
+
+* You can modify the default retry behavior and create a copy of [`DEFAULT_RETRY`](retry.md#google.cloud.storage.retry.DEFAULT_RETRY)
+by calling it with a `with_XXX` method. E.g.:
+
+```python
+from google.cloud.storage.retry import DEFAULT_RETRY
+
+# Customize retry with a deadline of 500 seconds (default=120 seconds).
+modified_retry = DEFAULT_RETRY.with_deadline(500.0)
+# Customize retry with an initial wait time of 1.5 (default=1.0).
+# Customize retry with a wait time multiplier per iteration of 1.2 (default=2.0).
+# Customize retry with a maximum wait time of 45.0 (default=60.0).
+modified_retry = modified_retry.with_delay(initial=1.5, multiplier=1.2, maximum=45.0)
+```
+
+
+* You can pass an instance of [`google.api_core.retry.Retry`](https://googleapis.dev/python/google-api-core/latest/retry.html#google.api_core.retry.Retry) to enable
+retries;  the passed object will define retriable response codes and errors,
+as well as configuring backoff and retry interval options.  E.g.:
+
+```python
+from google.api_core import exceptions
+from google.api_core.retry import Retry
+
+_MY_RETRIABLE_TYPES = [
+   exceptions.TooManyRequests,  # 429
+   exceptions.InternalServerError,  # 500
+   exceptions.BadGateway,  # 502
+   exceptions.ServiceUnavailable,  # 503
+]
+
+def is_retryable(exc):
+    return isinstance(exc, _MY_RETRIABLE_TYPES)
+
+my_retry_policy = Retry(predicate=is_retryable)
+bucket = client.get_bucket(BUCKET_NAME, retry=my_retry_policy)
+```
+
+
+* You can pass an instance of
+[`google.cloud.storage.retry.ConditionalRetryPolicy`](retry.md#google.cloud.storage.retry.ConditionalRetryPolicy), which wraps a
+`RetryPolicy`, activating it only if
+certain conditions are met. This class exists to provide safe defaults
+for RPC calls that are not technically safe to retry normally (due to
+potential data duplication or other side-effects) but become safe to retry
+if a condition such as if_metageneration_match is set.  E.g.:
+
+```python
+from google.api_core.retry import Retry
+from google.cloud.storage.retry import ConditionalRetryPolicy
+from google.cloud.storage.retry import is_etag_in_data
+
+def is_retryable(exc):
+    ... # as above
+
+my_retry_policy = Retry(predicate=is_retryable)
+my_cond_policy = ConditionalRetryPolicy(
+    my_retry_policy, conditional_predicate=is_etag_in_data, ["query_params"])
+bucket = client.get_bucket(BUCKET_NAME, retry=my_cond_policy)
+```

--- a/tests/testdata/goldens/handwritten/toc.yml
+++ b/tests/testdata/goldens/handwritten/toc.yml
@@ -4,6 +4,16 @@
   - href: changelog.md
     name: Changelog
   - items:
+    - href: blobs.md
+      name: Blobs / Objects
+    - href: buckets.md
+      name: Buckets
+    - href: generation_metageneration.md
+      name: Conditional Requests Via ETag / Generation / Metageneration Preconditions
+    - href: modules.md
+      name: Modules for Python Storage
+    - href: retry_timeout.md
+      name: Configuring Timeouts and Retries
     - items:
       - name: Overview
         uid: google.cloud.storage.acl


### PR DESCRIPTION
Recovered all markdown pages in nested directory structures. This was not correctly retrieved as I was only looking in the top directory.

Few things that's happening (happy to break down, but was hard to do so to have all the moving parts in one picture):
* Keeping track of where pages are retrieved. This is vital as we need to know where markdown pages will need to end up in the TOC
* Merging the Markdown and Package's TOC, based on the two sources pulled separately. I could choose to just move all the markdown files at the root directory, but I think a better experience will be to put the markdown pages where they are located.
* Remove unused markdown pages that are generated. These are redundant API pages that Sphinx generated but are not used by DocFX Yaml plugin.

Only the `handwritten` TOC is updated and works as expected, `gapic-combo` and `gapic-auto` doesn't contain any markdown pages in nested directories.

Some markdown pages might come with a mix of handwritten guides and autogenerated API content. I plan on working with the library maintainers to have this updated throughout (<10) for the purpose of this plugin that separates Sphinx HTML and DocFX YAML content.

**Breaking Change**: Upgrading to using 3.9. All Python client libraries are able to use 3.9, so this is not a problem, but will be a backwards incompatible change.

Fixes #217.

- [x] Tests pass
