### PR TITLE
fix: remove inheritance details

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1101,7 +1101,6 @@ def process_docstring(app, _type, name, obj, options, lines):
         else:
             app.env.docfx_yaml_functions[cls].append(datam)
 
-    insert_inheritance(app, _type, obj, datam)
     insert_children_on_module(app, _type, datam)
     insert_children_on_class(app, _type, datam)
     insert_children_on_function(app, _type, datam)
@@ -1127,25 +1126,6 @@ def process_signature(app, _type, name, obj, options, signature, return_annotati
         except InvalidInput as e:
             print(f"Could not format the given code: \n{e})")
         app.env.docfx_signature_funcs_methods[name] = signature
-
-
-def insert_inheritance(app, _type, obj, datam):
-
-    def collect_inheritance(base, to_add):
-        for new_base in base.__bases__:
-            new_add = {'type': _fullname(new_base)}
-            collect_inheritance(new_base, new_add)
-            if 'inheritance' not in to_add:
-                to_add['inheritance'] = []
-            to_add['inheritance'].append(new_add)
-
-    if hasattr(obj, '__bases__'):
-        if 'inheritance' not in datam:
-            datam['inheritance'] = []
-        for base in obj.__bases__:
-            to_add = {'type': _fullname(base)}
-            collect_inheritance(base, to_add)
-            datam['inheritance'].append(to_add)
 
 
 def insert_children_on_module(app, _type, datam):
@@ -1717,18 +1697,6 @@ def build_finished(app, exception):
                 # To distinguish distribution package and import package
                 if obj.get('type', '') == 'package' and obj.get('kind', '') != 'distribution':
                     obj['kind'] = 'import'
-
-                try:
-                    if remove_inheritance_for_notfound_class:
-                        if 'inheritance' in obj:
-                            python_sdk_name = obj['uid'].split('.')[0]
-                            obj['inheritance'] = [n for n in obj['inheritance'] if not n['type'].startswith(python_sdk_name) or
-                                                  n['type'] in app.env.docfx_info_uid_types]
-                            if not obj['inheritance']:
-                                obj.pop('inheritance')
-
-                except NameError:
-                    pass
 
                 # Extract any missing cross references where applicable.
                 # Potential targets are instances of full uid shown, or

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.yml
@@ -26,8 +26,6 @@ items:
   - google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.transport
   class: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient
   fullName: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.texttospeech_v1.services.text_to_speech
@@ -52,8 +50,6 @@ items:
 - attributes: []
   class: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient
   fullName: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.texttospeech_v1.services.text_to_speech

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.yml
@@ -26,8 +26,6 @@ items:
   - google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.transport
   class: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient
   fullName: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.texttospeech_v1.services.text_to_speech
@@ -52,8 +50,6 @@ items:
 - attributes: []
   class: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient
   fullName: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.texttospeech_v1.services.text_to_speech

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.AudioConfig.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.AudioConfig.yml
@@ -46,10 +46,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.AudioConfig
   fullName: google.cloud.texttospeech_v1.types.AudioConfig
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.AudioEncoding.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.AudioEncoding.yml
@@ -5,17 +5,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.AudioEncoding
   fullName: google.cloud.texttospeech_v1.types.AudioEncoding
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: builtins.int
-      - inheritance:
-        - type: builtins.object
-        type: enum.Enum
-      type: enum.IntEnum
-    type: proto.enums.Enum
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.CustomVoiceParams.ReportedUsage.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.CustomVoiceParams.ReportedUsage.yml
@@ -5,17 +5,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.CustomVoiceParams.ReportedUsage
   fullName: google.cloud.texttospeech_v1.types.CustomVoiceParams.ReportedUsage
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: builtins.int
-      - inheritance:
-        - type: builtins.object
-        type: enum.Enum
-      type: enum.IntEnum
-    type: proto.enums.Enum
   langs:
   - python
   module: google.cloud.texttospeech_v1.types.CustomVoiceParams

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.CustomVoiceParams.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.CustomVoiceParams.yml
@@ -13,10 +13,6 @@ items:
   - google.cloud.texttospeech_v1.types.CustomVoiceParams.ReportedUsage
   class: google.cloud.texttospeech_v1.types.CustomVoiceParams
   fullName: google.cloud.texttospeech_v1.types.CustomVoiceParams
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.ListVoicesRequest.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.ListVoicesRequest.yml
@@ -14,10 +14,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.ListVoicesRequest
   fullName: google.cloud.texttospeech_v1.types.ListVoicesRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.ListVoicesResponse.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.ListVoicesResponse.yml
@@ -8,10 +8,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.ListVoicesResponse
   fullName: google.cloud.texttospeech_v1.types.ListVoicesResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SsmlVoiceGender.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SsmlVoiceGender.yml
@@ -5,17 +5,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.SsmlVoiceGender
   fullName: google.cloud.texttospeech_v1.types.SsmlVoiceGender
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: builtins.int
-      - inheritance:
-        - type: builtins.object
-        type: enum.Enum
-      type: enum.IntEnum
-    type: proto.enums.Enum
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesisInput.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesisInput.yml
@@ -15,10 +15,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.SynthesisInput
   fullName: google.cloud.texttospeech_v1.types.SynthesisInput
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesizeSpeechRequest.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesizeSpeechRequest.yml
@@ -15,10 +15,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.SynthesizeSpeechRequest
   fullName: google.cloud.texttospeech_v1.types.SynthesizeSpeechRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesizeSpeechResponse.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.SynthesizeSpeechResponse.yml
@@ -12,10 +12,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.SynthesizeSpeechResponse
   fullName: google.cloud.texttospeech_v1.types.SynthesizeSpeechResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.Voice.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.Voice.yml
@@ -19,10 +19,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.Voice
   fullName: google.cloud.texttospeech_v1.types.Voice
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.VoiceSelectionParams.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.types.VoiceSelectionParams.yml
@@ -34,10 +34,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1.types.VoiceSelectionParams
   fullName: google.cloud.texttospeech_v1.types.VoiceSelectionParams
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.yml
@@ -26,8 +26,6 @@ items:
   - google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.transport
   class: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient
   fullName: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.services.text_to_speech
@@ -52,8 +50,6 @@ items:
 - attributes: []
   class: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient
   fullName: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.services.text_to_speech

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.yml
@@ -26,8 +26,6 @@ items:
   - google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.transport
   class: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient
   fullName: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.services.text_to_speech
@@ -52,8 +50,6 @@ items:
 - attributes: []
   class: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient
   fullName: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.services.text_to_speech

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.AudioConfig.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.AudioConfig.yml
@@ -46,10 +46,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.AudioConfig
   fullName: google.cloud.texttospeech_v1beta1.types.AudioConfig
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.AudioEncoding.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.AudioEncoding.yml
@@ -5,17 +5,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.AudioEncoding
   fullName: google.cloud.texttospeech_v1beta1.types.AudioEncoding
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: builtins.int
-      - inheritance:
-        - type: builtins.object
-        type: enum.Enum
-      type: enum.IntEnum
-    type: proto.enums.Enum
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.ReportedUsage.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.ReportedUsage.yml
@@ -5,17 +5,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.ReportedUsage
   fullName: google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.ReportedUsage
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: builtins.int
-      - inheritance:
-        - type: builtins.object
-        type: enum.Enum
-      type: enum.IntEnum
-    type: proto.enums.Enum
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types.CustomVoiceParams

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.yml
@@ -13,10 +13,6 @@ items:
   - google.cloud.texttospeech_v1beta1.types.CustomVoiceParams.ReportedUsage
   class: google.cloud.texttospeech_v1beta1.types.CustomVoiceParams
   fullName: google.cloud.texttospeech_v1beta1.types.CustomVoiceParams
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.ListVoicesRequest.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.ListVoicesRequest.yml
@@ -14,10 +14,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.ListVoicesRequest
   fullName: google.cloud.texttospeech_v1beta1.types.ListVoicesRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.ListVoicesResponse.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.ListVoicesResponse.yml
@@ -8,10 +8,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.ListVoicesResponse
   fullName: google.cloud.texttospeech_v1beta1.types.ListVoicesResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SsmlVoiceGender.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SsmlVoiceGender.yml
@@ -5,17 +5,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.SsmlVoiceGender
   fullName: google.cloud.texttospeech_v1beta1.types.SsmlVoiceGender
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: builtins.int
-      - inheritance:
-        - type: builtins.object
-        type: enum.Enum
-      type: enum.IntEnum
-    type: proto.enums.Enum
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesisInput.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesisInput.yml
@@ -15,10 +15,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.SynthesisInput
   fullName: google.cloud.texttospeech_v1beta1.types.SynthesisInput
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType.yml
@@ -5,17 +5,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType
   fullName: google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: builtins.int
-      - inheritance:
-        - type: builtins.object
-        type: enum.Enum
-      type: enum.IntEnum
-    type: proto.enums.Enum
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.yml
@@ -19,10 +19,6 @@ items:
   - google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType
   class: google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest
   fullName: google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechResponse.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechResponse.yml
@@ -20,10 +20,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechResponse
   fullName: google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.Timepoint.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.Timepoint.yml
@@ -12,10 +12,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.Timepoint
   fullName: google.cloud.texttospeech_v1beta1.types.Timepoint
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.Voice.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.Voice.yml
@@ -19,10 +19,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.Voice
   fullName: google.cloud.texttospeech_v1beta1.types.Voice
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.VoiceSelectionParams.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.types.VoiceSelectionParams.yml
@@ -34,10 +34,6 @@ items:
   children: []
   class: google.cloud.texttospeech_v1beta1.types.VoiceSelectionParams
   fullName: google.cloud.texttospeech_v1beta1.types.VoiceSelectionParams
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.texttospeech_v1beta1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.client.Client.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.client.Client.yml
@@ -45,10 +45,6 @@ items:
   - google.cloud.pubsub_v1.publisher.client.Client.update_topic
   class: google.cloud.pubsub_v1.publisher.client.Client
   fullName: google.cloud.pubsub_v1.publisher.client.Client
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.pubsub_v1.services.publisher.client.PublisherClient
   langs:
   - python
   module: google.cloud.pubsub_v1.publisher.client
@@ -78,10 +74,6 @@ items:
 - attributes: []
   class: google.cloud.pubsub_v1.publisher.client.Client
   fullName: google.cloud.pubsub_v1.publisher.client.Client
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.pubsub_v1.services.publisher.client.PublisherClient
   langs:
   - python
   module: google.cloud.pubsub_v1.publisher.client

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.futures.Future.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.futures.Future.yml
@@ -16,15 +16,6 @@ items:
   - google.cloud.pubsub_v1.publisher.futures.Future.set_running_or_notify_cancel
   class: google.cloud.pubsub_v1.publisher.futures.Future
   fullName: google.cloud.pubsub_v1.publisher.futures.Future
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - type: builtins.object
-      type: concurrent.futures._base.Future
-    - inheritance:
-      - type: builtins.object
-      type: google.api_core.future.base.Future
-    type: google.cloud.pubsub_v1.futures.Future
   langs:
   - python
   module: google.cloud.pubsub_v1.publisher.futures
@@ -52,15 +43,6 @@ items:
 - attributes: []
   class: google.cloud.pubsub_v1.publisher.futures.Future
   fullName: google.cloud.pubsub_v1.publisher.futures.Future
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - type: builtins.object
-      type: concurrent.futures._base.Future
-    - inheritance:
-      - type: builtins.object
-      type: google.api_core.future.base.Future
-    type: google.cloud.pubsub_v1.futures.Future
   langs:
   - python
   module: google.cloud.pubsub_v1.publisher.futures

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.client.Client.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.client.Client.yml
@@ -51,10 +51,6 @@ items:
   - google.cloud.pubsub_v1.subscriber.client.Client.update_subscription
   class: google.cloud.pubsub_v1.subscriber.client.Client
   fullName: google.cloud.pubsub_v1.subscriber.client.Client
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.pubsub_v1.services.subscriber.client.SubscriberClient
   langs:
   - python
   module: google.cloud.pubsub_v1.subscriber.client
@@ -81,10 +77,6 @@ items:
 - attributes: []
   class: google.cloud.pubsub_v1.subscriber.client.Client
   fullName: google.cloud.pubsub_v1.subscriber.client.Client
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.pubsub_v1.services.subscriber.client.SubscriberClient
   langs:
   - python
   module: google.cloud.pubsub_v1.subscriber.client

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.Future.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.Future.yml
@@ -16,15 +16,6 @@ items:
   - google.cloud.pubsub_v1.subscriber.futures.Future.set_running_or_notify_cancel
   class: google.cloud.pubsub_v1.subscriber.futures.Future
   fullName: google.cloud.pubsub_v1.subscriber.futures.Future
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - type: builtins.object
-      type: concurrent.futures._base.Future
-    - inheritance:
-      - type: builtins.object
-      type: google.api_core.future.base.Future
-    type: google.cloud.pubsub_v1.futures.Future
   langs:
   - python
   module: google.cloud.pubsub_v1.subscriber.futures
@@ -50,15 +41,6 @@ items:
 - attributes: []
   class: google.cloud.pubsub_v1.subscriber.futures.Future
   fullName: google.cloud.pubsub_v1.subscriber.futures.Future
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - type: builtins.object
-      type: concurrent.futures._base.Future
-    - inheritance:
-      - type: builtins.object
-      type: google.api_core.future.base.Future
-    type: google.cloud.pubsub_v1.futures.Future
   langs:
   - python
   module: google.cloud.pubsub_v1.subscriber.futures

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.yml
@@ -16,15 +16,6 @@ items:
   - google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.set_running_or_notify_cancel
   class: google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture
   fullName: google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - type: builtins.object
-      type: concurrent.futures._base.Future
-    - inheritance:
-      - type: builtins.object
-      type: google.api_core.future.base.Future
-    type: google.cloud.pubsub_v1.futures.Future
   langs:
   - python
   module: google.cloud.pubsub_v1.subscriber.futures
@@ -54,15 +45,6 @@ items:
 - attributes: []
   class: google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture
   fullName: google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - type: builtins.object
-      type: concurrent.futures._base.Future
-    - inheritance:
-      - type: builtins.object
-      type: google.api_core.future.base.Future
-    type: google.cloud.pubsub_v1.futures.Future
   langs:
   - python
   module: google.cloud.pubsub_v1.subscriber.futures

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.message.Message.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.message.Message.yml
@@ -20,8 +20,6 @@ items:
   - google.cloud.pubsub_v1.subscriber.message.Message.size
   class: google.cloud.pubsub_v1.subscriber.message.Message
   fullName: google.cloud.pubsub_v1.subscriber.message.Message
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.pubsub_v1.subscriber.message
@@ -47,8 +45,6 @@ items:
 - attributes: []
   class: google.cloud.pubsub_v1.subscriber.message.Message
   fullName: google.cloud.pubsub_v1.subscriber.message.Message
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.pubsub_v1.subscriber.message

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.yml
@@ -8,8 +8,6 @@ items:
   - google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.shutdown
   class: google.cloud.pubsub_v1.subscriber.scheduler.Scheduler
   fullName: google.cloud.pubsub_v1.subscriber.scheduler.Scheduler
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.pubsub_v1.subscriber.scheduler

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.yml
@@ -8,10 +8,6 @@ items:
   - google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.shutdown
   class: google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler
   fullName: google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.cloud.pubsub_v1.subscriber.scheduler.Scheduler
   langs:
   - python
   module: google.cloud.pubsub_v1.subscriber.scheduler

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AcknowledgeRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AcknowledgeRequest.yml
@@ -14,10 +14,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.AcknowledgeRequest
   fullName: google.cloud.pubsub_v1.types.AcknowledgeRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditConfig.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditConfig.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.AuditConfig
   fullName: google.cloud.pubsub_v1.types.AuditConfig
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditConfigDelta.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditConfigDelta.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.AuditConfigDelta
   fullName: google.cloud.pubsub_v1.types.AuditConfigDelta
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditData.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditData.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.AuditData
   fullName: google.cloud.pubsub_v1.types.AuditData
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditLogConfig.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.AuditLogConfig.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.AuditLogConfig
   fullName: google.cloud.pubsub_v1.types.AuditLogConfig
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BatchSettings.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BatchSettings.yml
@@ -9,10 +9,6 @@ items:
   - google.cloud.pubsub_v1.types.BatchSettings.max_messages
   class: google.cloud.pubsub_v1.types.BatchSettings
   fullName: google.cloud.pubsub_v1.types.BatchSettings
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.tuple
   langs:
   - python
   module: google.cloud.pubsub_v1.types
@@ -34,10 +30,6 @@ items:
 - attributes: []
   class: google.cloud.pubsub_v1.types.BatchSettings
   fullName: google.cloud.pubsub_v1.types.BatchSettings
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.tuple
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BigQueryConfig.State.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BigQueryConfig.State.yml
@@ -5,17 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.BigQueryConfig.State
   fullName: google.cloud.pubsub_v1.types.BigQueryConfig.State
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: builtins.int
-      - inheritance:
-        - type: builtins.object
-        type: enum.Enum
-      type: enum.IntEnum
-    type: proto.enums.Enum
   langs:
   - python
   module: google.cloud.pubsub_v1.types.BigQueryConfig

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BigQueryConfig.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BigQueryConfig.yml
@@ -31,10 +31,6 @@ items:
   - google.cloud.pubsub_v1.types.BigQueryConfig.State
   class: google.cloud.pubsub_v1.types.BigQueryConfig
   fullName: google.cloud.pubsub_v1.types.BigQueryConfig
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Binding.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Binding.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.Binding
   fullName: google.cloud.pubsub_v1.types.Binding
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BindingDelta.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.BindingDelta.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.BindingDelta
   fullName: google.cloud.pubsub_v1.types.BindingDelta
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CreateSnapshotRequest.LabelsEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CreateSnapshotRequest.LabelsEntry.yml
@@ -5,10 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.CreateSnapshotRequest.LabelsEntry
   fullName: google.cloud.pubsub_v1.types.CreateSnapshotRequest.LabelsEntry
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.CreateSnapshotRequest

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CreateSnapshotRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CreateSnapshotRequest.yml
@@ -26,10 +26,6 @@ items:
   - google.cloud.pubsub_v1.types.CreateSnapshotRequest.LabelsEntry
   class: google.cloud.pubsub_v1.types.CreateSnapshotRequest
   fullName: google.cloud.pubsub_v1.types.CreateSnapshotRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CustomHttpPattern.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.CustomHttpPattern.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.CustomHttpPattern
   fullName: google.cloud.pubsub_v1.types.CustomHttpPattern
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeadLetterPolicy.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeadLetterPolicy.yml
@@ -25,10 +25,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.DeadLetterPolicy
   fullName: google.cloud.pubsub_v1.types.DeadLetterPolicy
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteSnapshotRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteSnapshotRequest.yml
@@ -8,10 +8,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.DeleteSnapshotRequest
   fullName: google.cloud.pubsub_v1.types.DeleteSnapshotRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteSubscriptionRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteSubscriptionRequest.yml
@@ -8,10 +8,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.DeleteSubscriptionRequest
   fullName: google.cloud.pubsub_v1.types.DeleteSubscriptionRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteTopicRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DeleteTopicRequest.yml
@@ -8,10 +8,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.DeleteTopicRequest
   fullName: google.cloud.pubsub_v1.types.DeleteTopicRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.ExtensionRange.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.ExtensionRange.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.DescriptorProto.ExtensionRange
   fullName: google.cloud.pubsub_v1.types.DescriptorProto.ExtensionRange
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.DescriptorProto

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.ReservedRange.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.ReservedRange.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.DescriptorProto.ReservedRange
   fullName: google.cloud.pubsub_v1.types.DescriptorProto.ReservedRange
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.DescriptorProto

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DescriptorProto.yml
@@ -6,13 +6,6 @@ items:
   - google.cloud.pubsub_v1.types.DescriptorProto.ReservedRange
   class: google.cloud.pubsub_v1.types.DescriptorProto
   fullName: google.cloud.pubsub_v1.types.DescriptorProto
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DetachSubscriptionRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DetachSubscriptionRequest.yml
@@ -8,10 +8,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.DetachSubscriptionRequest
   fullName: google.cloud.pubsub_v1.types.DetachSubscriptionRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DetachSubscriptionResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.DetachSubscriptionResponse.yml
@@ -5,10 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.DetachSubscriptionResponse
   fullName: google.cloud.pubsub_v1.types.DetachSubscriptionResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Duration.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Duration.yml
@@ -4,16 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.Duration
   fullName: google.cloud.pubsub_v1.types.Duration
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.internal.well_known_types.Duration
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Empty.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Empty.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.Empty
   fullName: google.cloud.pubsub_v1.types.Empty
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumDescriptorProto.EnumReservedRange.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumDescriptorProto.EnumReservedRange.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.EnumDescriptorProto.EnumReservedRange
   fullName: google.cloud.pubsub_v1.types.EnumDescriptorProto.EnumReservedRange
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.EnumDescriptorProto

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumDescriptorProto.yml
@@ -5,13 +5,6 @@ items:
   - google.cloud.pubsub_v1.types.EnumDescriptorProto.EnumReservedRange
   class: google.cloud.pubsub_v1.types.EnumDescriptorProto
   fullName: google.cloud.pubsub_v1.types.EnumDescriptorProto
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumOptions.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.EnumOptions
   fullName: google.cloud.pubsub_v1.types.EnumOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumValueDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumValueDescriptorProto.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.EnumValueDescriptorProto
   fullName: google.cloud.pubsub_v1.types.EnumValueDescriptorProto
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumValueOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.EnumValueOptions.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.EnumValueOptions
   fullName: google.cloud.pubsub_v1.types.EnumValueOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ExpirationPolicy.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ExpirationPolicy.yml
@@ -13,10 +13,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ExpirationPolicy
   fullName: google.cloud.pubsub_v1.types.ExpirationPolicy
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ExtensionRangeOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ExtensionRangeOptions.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.ExtensionRangeOptions
   fullName: google.cloud.pubsub_v1.types.ExtensionRangeOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldDescriptorProto.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.FieldDescriptorProto
   fullName: google.cloud.pubsub_v1.types.FieldDescriptorProto
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldMask.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldMask.yml
@@ -4,16 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.FieldMask
   fullName: google.cloud.pubsub_v1.types.FieldMask
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.internal.well_known_types.FieldMask
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FieldOptions.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.FieldOptions
   fullName: google.cloud.pubsub_v1.types.FieldOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileDescriptorProto.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.FileDescriptorProto
   fullName: google.cloud.pubsub_v1.types.FileDescriptorProto
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileDescriptorSet.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileDescriptorSet.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.FileDescriptorSet
   fullName: google.cloud.pubsub_v1.types.FileDescriptorSet
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FileOptions.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.FileOptions
   fullName: google.cloud.pubsub_v1.types.FileOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FlowControl.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FlowControl.yml
@@ -11,10 +11,6 @@ items:
   - google.cloud.pubsub_v1.types.FlowControl.min_duration_per_lease_extension
   class: google.cloud.pubsub_v1.types.FlowControl
   fullName: google.cloud.pubsub_v1.types.FlowControl
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.tuple
   langs:
   - python
   module: google.cloud.pubsub_v1.types
@@ -39,10 +35,6 @@ items:
 - attributes: []
   class: google.cloud.pubsub_v1.types.FlowControl
   fullName: google.cloud.pubsub_v1.types.FlowControl
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.tuple
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GeneratedCodeInfo.Annotation.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GeneratedCodeInfo.Annotation.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.GeneratedCodeInfo.Annotation
   fullName: google.cloud.pubsub_v1.types.GeneratedCodeInfo.Annotation
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.GeneratedCodeInfo

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GeneratedCodeInfo.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GeneratedCodeInfo.yml
@@ -5,13 +5,6 @@ items:
   - google.cloud.pubsub_v1.types.GeneratedCodeInfo.Annotation
   class: google.cloud.pubsub_v1.types.GeneratedCodeInfo
   fullName: google.cloud.pubsub_v1.types.GeneratedCodeInfo
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetIamPolicyRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetIamPolicyRequest.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.GetIamPolicyRequest
   fullName: google.cloud.pubsub_v1.types.GetIamPolicyRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetSnapshotRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetSnapshotRequest.yml
@@ -8,10 +8,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.GetSnapshotRequest
   fullName: google.cloud.pubsub_v1.types.GetSnapshotRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetSubscriptionRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetSubscriptionRequest.yml
@@ -8,10 +8,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.GetSubscriptionRequest
   fullName: google.cloud.pubsub_v1.types.GetSubscriptionRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetTopicRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.GetTopicRequest.yml
@@ -8,10 +8,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.GetTopicRequest
   fullName: google.cloud.pubsub_v1.types.GetTopicRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Http.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Http.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.Http
   fullName: google.cloud.pubsub_v1.types.Http
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.HttpRule.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.HttpRule.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.HttpRule
   fullName: google.cloud.pubsub_v1.types.HttpRule
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.LimitExceededBehavior.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.LimitExceededBehavior.yml
@@ -5,13 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.LimitExceededBehavior
   fullName: google.cloud.pubsub_v1.types.LimitExceededBehavior
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.str
-  - inheritance:
-    - type: builtins.object
-    type: enum.Enum
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSnapshotsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSnapshotsRequest.yml
@@ -17,10 +17,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ListSnapshotsRequest
   fullName: google.cloud.pubsub_v1.types.ListSnapshotsRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSnapshotsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSnapshotsResponse.yml
@@ -12,10 +12,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ListSnapshotsResponse
   fullName: google.cloud.pubsub_v1.types.ListSnapshotsResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSubscriptionsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSubscriptionsRequest.yml
@@ -17,10 +17,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ListSubscriptionsRequest
   fullName: google.cloud.pubsub_v1.types.ListSubscriptionsRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSubscriptionsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListSubscriptionsResponse.yml
@@ -13,10 +13,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ListSubscriptionsResponse
   fullName: google.cloud.pubsub_v1.types.ListSubscriptionsResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSnapshotsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSnapshotsRequest.yml
@@ -17,10 +17,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ListTopicSnapshotsRequest
   fullName: google.cloud.pubsub_v1.types.ListTopicSnapshotsRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSnapshotsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSnapshotsResponse.yml
@@ -13,10 +13,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ListTopicSnapshotsResponse
   fullName: google.cloud.pubsub_v1.types.ListTopicSnapshotsResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSubscriptionsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSubscriptionsRequest.yml
@@ -17,10 +17,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ListTopicSubscriptionsRequest
   fullName: google.cloud.pubsub_v1.types.ListTopicSubscriptionsRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSubscriptionsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicSubscriptionsResponse.yml
@@ -14,10 +14,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ListTopicSubscriptionsResponse
   fullName: google.cloud.pubsub_v1.types.ListTopicSubscriptionsResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicsRequest.yml
@@ -17,10 +17,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ListTopicsRequest
   fullName: google.cloud.pubsub_v1.types.ListTopicsRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ListTopicsResponse.yml
@@ -12,10 +12,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ListTopicsResponse
   fullName: google.cloud.pubsub_v1.types.ListTopicsResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MessageOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MessageOptions.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.MessageOptions
   fullName: google.cloud.pubsub_v1.types.MessageOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MessageStoragePolicy.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MessageStoragePolicy.yml
@@ -12,10 +12,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.MessageStoragePolicy
   fullName: google.cloud.pubsub_v1.types.MessageStoragePolicy
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MethodDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MethodDescriptorProto.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.MethodDescriptorProto
   fullName: google.cloud.pubsub_v1.types.MethodDescriptorProto
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MethodOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.MethodOptions.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.MethodOptions
   fullName: google.cloud.pubsub_v1.types.MethodOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ModifyAckDeadlineRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ModifyAckDeadlineRequest.yml
@@ -21,10 +21,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ModifyAckDeadlineRequest
   fullName: google.cloud.pubsub_v1.types.ModifyAckDeadlineRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ModifyPushConfigRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ModifyPushConfigRequest.yml
@@ -15,10 +15,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ModifyPushConfigRequest
   fullName: google.cloud.pubsub_v1.types.ModifyPushConfigRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.OneofDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.OneofDescriptorProto.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.OneofDescriptorProto
   fullName: google.cloud.pubsub_v1.types.OneofDescriptorProto
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.OneofOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.OneofOptions.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.OneofOptions
   fullName: google.cloud.pubsub_v1.types.OneofOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Policy.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Policy.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.Policy
   fullName: google.cloud.pubsub_v1.types.Policy
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PolicyDelta.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PolicyDelta.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.PolicyDelta
   fullName: google.cloud.pubsub_v1.types.PolicyDelta
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishFlowControl.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishFlowControl.yml
@@ -9,10 +9,6 @@ items:
   - google.cloud.pubsub_v1.types.PublishFlowControl.message_limit
   class: google.cloud.pubsub_v1.types.PublishFlowControl
   fullName: google.cloud.pubsub_v1.types.PublishFlowControl
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.tuple
   langs:
   - python
   module: google.cloud.pubsub_v1.types
@@ -35,10 +31,6 @@ items:
 - attributes: []
   class: google.cloud.pubsub_v1.types.PublishFlowControl
   fullName: google.cloud.pubsub_v1.types.PublishFlowControl
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.tuple
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishRequest.yml
@@ -12,10 +12,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.PublishRequest
   fullName: google.cloud.pubsub_v1.types.PublishRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublishResponse.yml
@@ -10,10 +10,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.PublishResponse
   fullName: google.cloud.pubsub_v1.types.PublishResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublisherOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PublisherOptions.yml
@@ -10,10 +10,6 @@ items:
   - google.cloud.pubsub_v1.types.PublisherOptions.timeout
   class: google.cloud.pubsub_v1.types.PublisherOptions
   fullName: google.cloud.pubsub_v1.types.PublisherOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.tuple
   langs:
   - python
   module: google.cloud.pubsub_v1.types
@@ -38,10 +34,6 @@ items:
 - attributes: []
   class: google.cloud.pubsub_v1.types.PublisherOptions
   fullName: google.cloud.pubsub_v1.types.PublisherOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.tuple
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PubsubMessage.AttributesEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PubsubMessage.AttributesEntry.yml
@@ -5,10 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.PubsubMessage.AttributesEntry
   fullName: google.cloud.pubsub_v1.types.PubsubMessage.AttributesEntry
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.PubsubMessage

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PubsubMessage.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PubsubMessage.yml
@@ -36,10 +36,6 @@ items:
   - google.cloud.pubsub_v1.types.PubsubMessage.AttributesEntry
   class: google.cloud.pubsub_v1.types.PubsubMessage
   fullName: google.cloud.pubsub_v1.types.PubsubMessage
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PullRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PullRequest.yml
@@ -23,10 +23,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.PullRequest
   fullName: google.cloud.pubsub_v1.types.PullRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PullResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PullResponse.yml
@@ -11,10 +11,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.PullResponse
   fullName: google.cloud.pubsub_v1.types.PullResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.AttributesEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.AttributesEntry.yml
@@ -5,10 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.PushConfig.AttributesEntry
   fullName: google.cloud.pubsub_v1.types.PushConfig.AttributesEntry
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.PushConfig

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.OidcToken.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.OidcToken.yml
@@ -19,10 +19,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.PushConfig.OidcToken
   fullName: google.cloud.pubsub_v1.types.PushConfig.OidcToken
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.PushConfig

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.PushConfig.yml
@@ -34,10 +34,6 @@ items:
   - google.cloud.pubsub_v1.types.PushConfig.OidcToken
   class: google.cloud.pubsub_v1.types.PushConfig
   fullName: google.cloud.pubsub_v1.types.PushConfig
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ReceivedMessage.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ReceivedMessage.yml
@@ -24,10 +24,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.ReceivedMessage
   fullName: google.cloud.pubsub_v1.types.ReceivedMessage
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.RetryPolicy.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.RetryPolicy.yml
@@ -15,10 +15,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.RetryPolicy
   fullName: google.cloud.pubsub_v1.types.RetryPolicy
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SchemaSettings.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SchemaSettings.yml
@@ -14,10 +14,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.SchemaSettings
   fullName: google.cloud.pubsub_v1.types.SchemaSettings
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SeekRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SeekRequest.yml
@@ -26,10 +26,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.SeekRequest
   fullName: google.cloud.pubsub_v1.types.SeekRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SeekResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SeekResponse.yml
@@ -5,10 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.SeekResponse
   fullName: google.cloud.pubsub_v1.types.SeekResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ServiceDescriptorProto.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ServiceDescriptorProto.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.ServiceDescriptorProto
   fullName: google.cloud.pubsub_v1.types.ServiceDescriptorProto
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ServiceOptions.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.ServiceOptions.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.ServiceOptions
   fullName: google.cloud.pubsub_v1.types.ServiceOptions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SetIamPolicyRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SetIamPolicyRequest.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.SetIamPolicyRequest
   fullName: google.cloud.pubsub_v1.types.SetIamPolicyRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Snapshot.LabelsEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Snapshot.LabelsEntry.yml
@@ -5,10 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.Snapshot.LabelsEntry
   fullName: google.cloud.pubsub_v1.types.Snapshot.LabelsEntry
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.Snapshot

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Snapshot.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Snapshot.yml
@@ -28,10 +28,6 @@ items:
   - google.cloud.pubsub_v1.types.Snapshot.LabelsEntry
   class: google.cloud.pubsub_v1.types.Snapshot
   fullName: google.cloud.pubsub_v1.types.Snapshot
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SourceCodeInfo.Location.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SourceCodeInfo.Location.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.SourceCodeInfo.Location
   fullName: google.cloud.pubsub_v1.types.SourceCodeInfo.Location
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.SourceCodeInfo

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SourceCodeInfo.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.SourceCodeInfo.yml
@@ -5,13 +5,6 @@ items:
   - google.cloud.pubsub_v1.types.SourceCodeInfo.Location
   class: google.cloud.pubsub_v1.types.SourceCodeInfo
   fullName: google.cloud.pubsub_v1.types.SourceCodeInfo
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullRequest.yml
@@ -74,10 +74,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.StreamingPullRequest
   fullName: google.cloud.pubsub_v1.types.StreamingPullRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.AcknowledgeConfirmation.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.AcknowledgeConfirmation.yml
@@ -15,10 +15,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.StreamingPullResponse.AcknowledgeConfirmation
   fullName: google.cloud.pubsub_v1.types.StreamingPullResponse.AcknowledgeConfirmation
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.StreamingPullResponse

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.ModifyAckDeadlineConfirmation.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.ModifyAckDeadlineConfirmation.yml
@@ -12,10 +12,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.StreamingPullResponse.ModifyAckDeadlineConfirmation
   fullName: google.cloud.pubsub_v1.types.StreamingPullResponse.ModifyAckDeadlineConfirmation
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.StreamingPullResponse

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.SubscriptionProperties.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.SubscriptionProperties.yml
@@ -11,10 +11,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.StreamingPullResponse.SubscriptionProperties
   fullName: google.cloud.pubsub_v1.types.StreamingPullResponse.SubscriptionProperties
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.StreamingPullResponse

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.StreamingPullResponse.yml
@@ -22,10 +22,6 @@ items:
   - google.cloud.pubsub_v1.types.StreamingPullResponse.SubscriptionProperties
   class: google.cloud.pubsub_v1.types.StreamingPullResponse
   fullName: google.cloud.pubsub_v1.types.StreamingPullResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.LabelsEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.LabelsEntry.yml
@@ -5,10 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.Subscription.LabelsEntry
   fullName: google.cloud.pubsub_v1.types.Subscription.LabelsEntry
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.Subscription

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.State.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.State.yml
@@ -5,17 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.Subscription.State
   fullName: google.cloud.pubsub_v1.types.Subscription.State
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: builtins.int
-      - inheritance:
-        - type: builtins.object
-        type: enum.Enum
-      type: enum.IntEnum
-    type: proto.enums.Enum
   langs:
   - python
   module: google.cloud.pubsub_v1.types.Subscription

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Subscription.yml
@@ -137,10 +137,6 @@ items:
   - google.cloud.pubsub_v1.types.Subscription.State
   class: google.cloud.pubsub_v1.types.Subscription
   fullName: google.cloud.pubsub_v1.types.Subscription
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.TestIamPermissionsRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.TestIamPermissionsRequest.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.TestIamPermissionsRequest
   fullName: google.cloud.pubsub_v1.types.TestIamPermissionsRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.TestIamPermissionsResponse.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.TestIamPermissionsResponse.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.TestIamPermissionsResponse
   fullName: google.cloud.pubsub_v1.types.TestIamPermissionsResponse
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Timestamp.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Timestamp.yml
@@ -4,16 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.Timestamp
   fullName: google.cloud.pubsub_v1.types.Timestamp
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.internal.well_known_types.Timestamp
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Topic.LabelsEntry.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Topic.LabelsEntry.yml
@@ -5,10 +5,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.Topic.LabelsEntry
   fullName: google.cloud.pubsub_v1.types.Topic.LabelsEntry
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.Topic

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Topic.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.Topic.yml
@@ -45,10 +45,6 @@ items:
   - google.cloud.pubsub_v1.types.Topic.LabelsEntry
   class: google.cloud.pubsub_v1.types.Topic
   fullName: google.cloud.pubsub_v1.types.Topic
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UninterpretedOption.NamePart.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UninterpretedOption.NamePart.yml
@@ -4,13 +4,6 @@ items:
 - children: []
   class: google.cloud.pubsub_v1.types.UninterpretedOption.NamePart
   fullName: google.cloud.pubsub_v1.types.UninterpretedOption.NamePart
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types.UninterpretedOption

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UninterpretedOption.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UninterpretedOption.yml
@@ -5,13 +5,6 @@ items:
   - google.cloud.pubsub_v1.types.UninterpretedOption.NamePart
   class: google.cloud.pubsub_v1.types.UninterpretedOption
   fullName: google.cloud.pubsub_v1.types.UninterpretedOption
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google._upb._message.Message
-  - inheritance:
-    - type: builtins.object
-    type: google.protobuf.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateSnapshotRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateSnapshotRequest.yml
@@ -12,10 +12,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.UpdateSnapshotRequest
   fullName: google.cloud.pubsub_v1.types.UpdateSnapshotRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateSubscriptionRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateSubscriptionRequest.yml
@@ -12,10 +12,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.UpdateSubscriptionRequest
   fullName: google.cloud.pubsub_v1.types.UpdateSubscriptionRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateTopicRequest.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.UpdateTopicRequest.yml
@@ -16,10 +16,6 @@ items:
   children: []
   class: google.cloud.pubsub_v1.types.UpdateTopicRequest
   fullName: google.cloud.pubsub_v1.types.UpdateTopicRequest
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: proto.message.Message
   langs:
   - python
   module: google.cloud.pubsub_v1.types

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsAsyncPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsAsyncPager.yml
@@ -6,8 +6,6 @@ items:
   - google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsAsyncPager
   class: google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsAsyncPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsAsyncPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers
@@ -57,8 +55,6 @@ items:
 - attributes: []
   class: google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsAsyncPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsAsyncPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager.yml
@@ -6,8 +6,6 @@ items:
   - google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager
   class: google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers
@@ -56,8 +54,6 @@ items:
 - attributes: []
   class: google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsAsyncPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsAsyncPager.yml
@@ -6,8 +6,6 @@ items:
   - google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsAsyncPager
   class: google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsAsyncPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsAsyncPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers
@@ -57,8 +55,6 @@ items:
 - attributes: []
   class: google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsAsyncPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsAsyncPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager.yml
@@ -6,8 +6,6 @@ items:
   - google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager
   class: google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers
@@ -57,8 +55,6 @@ items:
 - attributes: []
   class: google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicsAsyncPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicsAsyncPager.yml
@@ -6,8 +6,6 @@ items:
   - google.pubsub_v1.services.publisher.pagers.ListTopicsAsyncPager
   class: google.pubsub_v1.services.publisher.pagers.ListTopicsAsyncPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicsAsyncPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers
@@ -57,8 +55,6 @@ items:
 - attributes: []
   class: google.pubsub_v1.services.publisher.pagers.ListTopicsAsyncPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicsAsyncPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicsPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.publisher.pagers.ListTopicsPager.yml
@@ -6,8 +6,6 @@ items:
   - google.pubsub_v1.services.publisher.pagers.ListTopicsPager
   class: google.pubsub_v1.services.publisher.pagers.ListTopicsPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicsPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers
@@ -56,8 +54,6 @@ items:
 - attributes: []
   class: google.pubsub_v1.services.publisher.pagers.ListTopicsPager
   fullName: google.pubsub_v1.services.publisher.pagers.ListTopicsPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.publisher.pagers

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSnapshotsAsyncPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSnapshotsAsyncPager.yml
@@ -6,8 +6,6 @@ items:
   - google.pubsub_v1.services.subscriber.pagers.ListSnapshotsAsyncPager
   class: google.pubsub_v1.services.subscriber.pagers.ListSnapshotsAsyncPager
   fullName: google.pubsub_v1.services.subscriber.pagers.ListSnapshotsAsyncPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.subscriber.pagers
@@ -57,8 +55,6 @@ items:
 - attributes: []
   class: google.pubsub_v1.services.subscriber.pagers.ListSnapshotsAsyncPager
   fullName: google.pubsub_v1.services.subscriber.pagers.ListSnapshotsAsyncPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.subscriber.pagers

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager.yml
@@ -6,8 +6,6 @@ items:
   - google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager
   class: google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager
   fullName: google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.subscriber.pagers
@@ -56,8 +54,6 @@ items:
 - attributes: []
   class: google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager
   fullName: google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.subscriber.pagers

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsAsyncPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsAsyncPager.yml
@@ -6,8 +6,6 @@ items:
   - google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsAsyncPager
   class: google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsAsyncPager
   fullName: google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsAsyncPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.subscriber.pagers
@@ -57,8 +55,6 @@ items:
 - attributes: []
   class: google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsAsyncPager
   fullName: google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsAsyncPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.subscriber.pagers

--- a/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager.yml
+++ b/tests/testdata/goldens/gapic-combo/google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager.yml
@@ -6,8 +6,6 @@ items:
   - google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager
   class: google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager
   fullName: google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.subscriber.pagers
@@ -56,8 +54,6 @@ items:
 - attributes: []
   class: google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager
   fullName: google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.pubsub_v1.services.subscriber.pagers

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.acl.ACL.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.acl.ACL.yml
@@ -24,8 +24,6 @@ items:
   - google.cloud.storage.acl.ACL.validate_predefined
   class: google.cloud.storage.acl.ACL
   fullName: google.cloud.storage.acl.ACL
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.storage.acl

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.acl.BucketACL.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.acl.BucketACL.yml
@@ -9,10 +9,6 @@ items:
   - google.cloud.storage.acl.BucketACL.user_project
   class: google.cloud.storage.acl.BucketACL
   fullName: google.cloud.storage.acl.BucketACL
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.cloud.storage.acl.ACL
   langs:
   - python
   module: google.cloud.storage.acl

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.acl.DefaultObjectACL.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.acl.DefaultObjectACL.yml
@@ -5,12 +5,6 @@ items:
   children: []
   class: google.cloud.storage.acl.DefaultObjectACL
   fullName: google.cloud.storage.acl.DefaultObjectACL
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - type: builtins.object
-      type: google.cloud.storage.acl.ACL
-    type: google.cloud.storage.acl.BucketACL
   langs:
   - python
   module: google.cloud.storage.acl

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.acl.ObjectACL.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.acl.ObjectACL.yml
@@ -9,10 +9,6 @@ items:
   - google.cloud.storage.acl.ObjectACL.user_project
   class: google.cloud.storage.acl.ObjectACL
   fullName: google.cloud.storage.acl.ObjectACL
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.cloud.storage.acl.ACL
   langs:
   - python
   module: google.cloud.storage.acl

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.batch.Batch.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.batch.Batch.yml
@@ -7,14 +7,6 @@ items:
   - google.cloud.storage.batch.Batch.finish
   class: google.cloud.storage.batch.Batch
   fullName: google.cloud.storage.batch.Batch
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: google.cloud._http.Connection
-      type: google.cloud._http.JSONConnection
-    type: google.cloud.storage._http.Connection
   langs:
   - python
   module: google.cloud.storage.batch

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.batch.MIMEApplicationHTTP.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.batch.MIMEApplicationHTTP.yml
@@ -6,16 +6,6 @@ items:
   - google.cloud.storage.batch.MIMEApplicationHTTP
   class: google.cloud.storage.batch.MIMEApplicationHTTP
   fullName: google.cloud.storage.batch.MIMEApplicationHTTP
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - inheritance:
-          - type: builtins.object
-          type: email.message.Message
-        type: email.mime.base.MIMEBase
-      type: email.mime.nonmultipart.MIMENonMultipart
-    type: email.mime.application.MIMEApplication
   langs:
   - python
   module: google.cloud.storage.batch
@@ -50,16 +40,6 @@ items:
 - attributes: []
   class: google.cloud.storage.batch.MIMEApplicationHTTP
   fullName: google.cloud.storage.batch.MIMEApplicationHTTP
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - inheritance:
-          - type: builtins.object
-          type: email.message.Message
-        type: email.mime.base.MIMEBase
-      type: email.mime.nonmultipart.MIMENonMultipart
-    type: email.mime.application.MIMEApplication
   langs:
   - python
   module: google.cloud.storage.batch

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.blob.Blob.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.blob.Blob.yml
@@ -67,10 +67,6 @@ items:
   - google.cloud.storage.blob.Blob.user_project
   class: google.cloud.storage.blob.Blob
   fullName: google.cloud.storage.blob.Blob
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.cloud.storage._helpers._PropertyMixin
   langs:
   - python
   module: google.cloud.storage.blob
@@ -117,10 +113,6 @@ items:
 - attributes: []
   class: google.cloud.storage.blob.Blob
   fullName: google.cloud.storage.blob.Blob
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.cloud.storage._helpers._PropertyMixin
   langs:
   - python
   module: google.cloud.storage.blob

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.Bucket.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.Bucket.yml
@@ -70,10 +70,6 @@ items:
   - google.cloud.storage.bucket.Bucket.versioning_enabled
   class: google.cloud.storage.bucket.Bucket
   fullName: google.cloud.storage.bucket.Bucket
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.cloud.storage._helpers._PropertyMixin
   langs:
   - python
   module: google.cloud.storage.bucket
@@ -105,10 +101,6 @@ items:
 - attributes: []
   class: google.cloud.storage.bucket.Bucket
   fullName: google.cloud.storage.bucket.Bucket
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: google.cloud.storage._helpers._PropertyMixin
   langs:
   - python
   module: google.cloud.storage.bucket

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.IAMConfiguration.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.IAMConfiguration.yml
@@ -23,10 +23,6 @@ items:
   - google.cloud.storage.bucket.IAMConfiguration.values
   class: google.cloud.storage.bucket.IAMConfiguration
   fullName: google.cloud.storage.bucket.IAMConfiguration
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.dict
   langs:
   - python
   module: google.cloud.storage.bucket

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.yml
@@ -17,10 +17,6 @@ items:
   - google.cloud.storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.values
   class: google.cloud.storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload
   fullName: google.cloud.storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.dict
   langs:
   - python
   module: google.cloud.storage.bucket

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleConditions.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleConditions.yml
@@ -28,10 +28,6 @@ items:
   - google.cloud.storage.bucket.LifecycleRuleConditions.values
   class: google.cloud.storage.bucket.LifecycleRuleConditions
   fullName: google.cloud.storage.bucket.LifecycleRuleConditions
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.dict
   langs:
   - python
   module: google.cloud.storage.bucket

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleDelete.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleDelete.yml
@@ -17,10 +17,6 @@ items:
   - google.cloud.storage.bucket.LifecycleRuleDelete.values
   class: google.cloud.storage.bucket.LifecycleRuleDelete
   fullName: google.cloud.storage.bucket.LifecycleRuleDelete
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.dict
   langs:
   - python
   module: google.cloud.storage.bucket

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleSetStorageClass.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleSetStorageClass.yml
@@ -17,10 +17,6 @@ items:
   - google.cloud.storage.bucket.LifecycleRuleSetStorageClass.values
   class: google.cloud.storage.bucket.LifecycleRuleSetStorageClass
   fullName: google.cloud.storage.bucket.LifecycleRuleSetStorageClass
-  inheritance:
-  - inheritance:
-    - type: builtins.object
-    type: builtins.dict
   langs:
   - python
   module: google.cloud.storage.bucket

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.client.Client.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.client.Client.yml
@@ -21,17 +21,6 @@ items:
   - google.cloud.storage.client.Client.lookup_bucket
   class: google.cloud.storage.client.Client
   fullName: google.cloud.storage.client.Client
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: google.cloud.client._ClientFactoryMixin
-      type: google.cloud.client.Client
-    - inheritance:
-      - type: builtins.object
-      type: google.cloud.client._ClientProjectMixin
-    type: google.cloud.client.ClientWithProject
   langs:
   - python
   module: google.cloud.storage.client

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.BlobReader.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.BlobReader.yml
@@ -12,19 +12,6 @@ items:
   - google.cloud.storage.fileio.BlobReader.writable
   class: google.cloud.storage.fileio.BlobReader
   fullName: google.cloud.storage.fileio.BlobReader
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: _io._IOBase
-      type: _io._BufferedIOBase
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: _io._IOBase
-      type: io.IOBase
-    type: io.BufferedIOBase
   langs:
   - python
   module: google.cloud.storage.fileio

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.BlobWriter.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.BlobWriter.yml
@@ -12,19 +12,6 @@ items:
   - google.cloud.storage.fileio.BlobWriter.write
   class: google.cloud.storage.fileio.BlobWriter
   fullName: google.cloud.storage.fileio.BlobWriter
-  inheritance:
-  - inheritance:
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: _io._IOBase
-      type: _io._BufferedIOBase
-    - inheritance:
-      - inheritance:
-        - type: builtins.object
-        type: _io._IOBase
-      type: io.IOBase
-    type: io.BufferedIOBase
   langs:
   - python
   module: google.cloud.storage.fileio

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.SlidingBuffer.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.fileio.SlidingBuffer.yml
@@ -11,8 +11,6 @@ items:
   - google.cloud.storage.fileio.SlidingBuffer.write
   class: google.cloud.storage.fileio.SlidingBuffer
   fullName: google.cloud.storage.fileio.SlidingBuffer
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.storage.fileio

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.hmac_key.HMACKeyMetadata.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.hmac_key.HMACKeyMetadata.yml
@@ -22,8 +22,6 @@ items:
   - google.cloud.storage.hmac_key.HMACKeyMetadata.user_project
   class: google.cloud.storage.hmac_key.HMACKeyMetadata
   fullName: google.cloud.storage.hmac_key.HMACKeyMetadata
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.storage.hmac_key

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.notification.BucketNotification.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.notification.BucketNotification.yml
@@ -22,8 +22,6 @@ items:
   - google.cloud.storage.notification.BucketNotification.topic_project
   class: google.cloud.storage.notification.BucketNotification
   fullName: google.cloud.storage.notification.BucketNotification
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.storage.notification

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.retry.ConditionalRetryPolicy.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.retry.ConditionalRetryPolicy.yml
@@ -5,8 +5,6 @@ items:
   children: []
   class: google.cloud.storage.retry.ConditionalRetryPolicy
   fullName: google.cloud.storage.retry.ConditionalRetryPolicy
-  inheritance:
-  - type: builtins.object
   langs:
   - python
   module: google.cloud.storage.retry


### PR DESCRIPTION
We've gotten multiple reports that the inheritance detail is (1) hard to see them in a nicely formatted way, but also (2) they are not accurate. This was code that existed since the plugin was forked and I'm not sure how this can be fixed. While I figure this out, I'm going to temporarily remove this part to not confuse the users. The mentioned bug will be used to follow up in the future and have this fixed.

Verified that all the updates only remove inheritance details and nothing else.

Towards b/208867713.

- [x] Tests pass
