### PR TITLE
chore: add comment for snapshotted versions

### DIFF
--- a/tests/testdata/handwritten/google/cloud/storage/version.py
+++ b/tests/testdata/handwritten/google/cloud/storage/version.py
@@ -12,4 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Original snapshotted version is 2.5.0.
 __version__ = "2.0.2"

--- a/tests/testdata/non-cloud/pandas_gbq/version.py
+++ b/tests/testdata/non-cloud/pandas_gbq/version.py
@@ -2,4 +2,5 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+# Original snapshotted version is 0.19.1.
 __version__ = "2.0.2"


### PR DESCRIPTION
I've decided to let the version numbers update (I couldn't find a way to make release-please ignore specific files), as well as not modifying the goldens client library more than necessary to preserve their original behaviors as much as possible.

Instead I'll leave a note on what the versions were, if I need to make any comparisons.

Fixes #284.

- [x] Tests pass
