### PR TITLE
build: update iamcredentials to iam

### DIFF
--- a/.kokoro/generate-docs.sh
+++ b/.kokoro/generate-docs.sh
@@ -127,8 +127,8 @@ for package in $(echo "${python_bucket_items}" | cut -d "-" -f 5- | rev | cut -d
     if [[ "${name}" == "clouderroreporting" ]]; then
       name="clouderrorreporting"
     fi
-    if [[ "${name}" == "iam" ]]; then
-      name="iamcredentials"
+    if [[ "${name}" == "iamcredentials" ]]; then
+      name="iam"
     fi
 
     python3 -m docuploader create-metadata \


### PR DESCRIPTION
This is to update references to `iamcredentials` client library's package name back to `iam`. This will be used for backwards compatibility for `python-iam` client library releases that's been named as `iamcredentials` instead of `iam`.

Towards b/249115548.

- [x] Tests pass
