### PR TITLE
fix: add support for return annotation in syntax

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -330,5 +330,40 @@ For example:
         self.assertEqual(summary_want, summary_got)
 
 
+    syntax_testdata = [
+        [
+            'None',
+        ],
+        [
+            \
+"""
+google.cloud.pubsub_v1.message.Message
+""",
+        ],
+        [
+            'Callable[[], int]',
+        ],
+    ]
+    @parameterized.expand(syntax_testdata)
+    def test_is_valid_python_code(self, syntax):
+        result = extension.is_valid_python_code(syntax)
+        self.assertTrue(result)
+
+
+    invalid_syntax_testdata = [
+        [
+            'This should not be considered valid Python code.',
+        ],
+        [
+            # Typo in code
+            'Callable[]',
+        ],
+    ]
+    @parameterized.expand(invalid_syntax_testdata)
+    def test_is_not_valid_python_code(self, invalid_syntax):
+        result = extension.is_valid_python_code(invalid_syntax)
+        self.assertFalse(result)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.yml
@@ -111,7 +111,7 @@ items:
 
     '
   syntax:
-    content: 'common_billing_account_path(billing_account: str)'
+    content: 'common_billing_account_path(billing_account: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.common_billing_account_path
@@ -131,7 +131,7 @@ items:
 
     '
   syntax:
-    content: 'common_folder_path(folder: str)'
+    content: 'common_folder_path(folder: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.common_folder_path
@@ -151,7 +151,7 @@ items:
 
     '
   syntax:
-    content: 'common_location_path(project: str, location: str)'
+    content: 'common_location_path(project: str, location: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.common_location_path
@@ -171,7 +171,7 @@ items:
 
     '
   syntax:
-    content: 'common_organization_path(organization: str)'
+    content: 'common_organization_path(organization: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.common_organization_path
@@ -191,7 +191,7 @@ items:
 
     '
   syntax:
-    content: 'common_project_path(project: str)'
+    content: 'common_project_path(project: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.common_project_path
@@ -347,7 +347,8 @@ items:
 
     '
   syntax:
-    content: get_transport_class()
+    content: "get_transport_class() -> typing.Type[\n    google.cloud.texttospeech_v1.services.text_to_speech.transports.base.TextToSpeechTransport\n\
+      ]"
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.get_transport_class
@@ -378,7 +379,8 @@ items:
       \ dict\n        ]\n    ] = None,\n    *,\n    language_code: typing.Optional[str]\
       \ = None,\n    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse"
     parameters:
     - defaultValue: None
       description: The request object. The top-level message sent by the client for
@@ -427,7 +429,7 @@ items:
 
     '
   syntax:
-    content: 'model_path(project: str, location: str, model: str)'
+    content: 'model_path(project: str, location: str, model: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.model_path
@@ -447,7 +449,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_billing_account_path(path: str)'
+    content: 'parse_common_billing_account_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.parse_common_billing_account_path
@@ -467,7 +469,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_folder_path(path: str)'
+    content: 'parse_common_folder_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.parse_common_folder_path
@@ -487,7 +489,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_location_path(path: str)'
+    content: 'parse_common_location_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.parse_common_location_path
@@ -507,7 +509,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_organization_path(path: str)'
+    content: 'parse_common_organization_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.parse_common_organization_path
@@ -527,7 +529,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_project_path(path: str)'
+    content: 'parse_common_project_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.parse_common_project_path
@@ -547,7 +549,7 @@ items:
 
     '
   syntax:
-    content: 'parse_model_path(path: str)'
+    content: 'parse_model_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.parse_model_path
@@ -587,7 +589,7 @@ items:
       \    ] = None,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse"
     parameters:
     - defaultValue: None
       description: The request object. The top-level message sent by the client for

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.yml
@@ -146,7 +146,7 @@ items:
 
     '
   syntax:
-    content: 'common_billing_account_path(billing_account: str)'
+    content: 'common_billing_account_path(billing_account: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.common_billing_account_path
@@ -166,7 +166,7 @@ items:
 
     '
   syntax:
-    content: 'common_folder_path(folder: str)'
+    content: 'common_folder_path(folder: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.common_folder_path
@@ -186,7 +186,7 @@ items:
 
     '
   syntax:
-    content: 'common_location_path(project: str, location: str)'
+    content: 'common_location_path(project: str, location: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.common_location_path
@@ -206,7 +206,7 @@ items:
 
     '
   syntax:
-    content: 'common_organization_path(organization: str)'
+    content: 'common_organization_path(organization: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.common_organization_path
@@ -226,7 +226,7 @@ items:
 
     '
   syntax:
-    content: 'common_project_path(project: str)'
+    content: 'common_project_path(project: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.common_project_path
@@ -394,7 +394,8 @@ items:
       \ dict\n        ]\n    ] = None,\n    *,\n    language_code: typing.Optional[str]\
       \ = None,\n    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse"
     parameters:
     - defaultValue: None
       description: The request object. The top-level message sent by the client for
@@ -443,7 +444,7 @@ items:
 
     '
   syntax:
-    content: 'model_path(project: str, location: str, model: str)'
+    content: 'model_path(project: str, location: str, model: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.model_path
@@ -463,7 +464,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_billing_account_path(path: str)'
+    content: 'parse_common_billing_account_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.parse_common_billing_account_path
@@ -483,7 +484,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_folder_path(path: str)'
+    content: 'parse_common_folder_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.parse_common_folder_path
@@ -503,7 +504,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_location_path(path: str)'
+    content: 'parse_common_location_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.parse_common_location_path
@@ -523,7 +524,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_organization_path(path: str)'
+    content: 'parse_common_organization_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.parse_common_organization_path
@@ -543,7 +544,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_project_path(path: str)'
+    content: 'parse_common_project_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.parse_common_project_path
@@ -563,7 +564,7 @@ items:
 
     '
   syntax:
-    content: 'parse_model_path(path: str)'
+    content: 'parse_model_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.parse_model_path
@@ -603,7 +604,7 @@ items:
       \    ] = None,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse"
     parameters:
     - defaultValue: None
       description: The request object. The top-level message sent by the client for

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.yml
@@ -111,7 +111,7 @@ items:
 
     '
   syntax:
-    content: 'common_billing_account_path(billing_account: str)'
+    content: 'common_billing_account_path(billing_account: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.common_billing_account_path
@@ -131,7 +131,7 @@ items:
 
     '
   syntax:
-    content: 'common_folder_path(folder: str)'
+    content: 'common_folder_path(folder: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.common_folder_path
@@ -151,7 +151,7 @@ items:
 
     '
   syntax:
-    content: 'common_location_path(project: str, location: str)'
+    content: 'common_location_path(project: str, location: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.common_location_path
@@ -171,7 +171,7 @@ items:
 
     '
   syntax:
-    content: 'common_organization_path(organization: str)'
+    content: 'common_organization_path(organization: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.common_organization_path
@@ -191,7 +191,7 @@ items:
 
     '
   syntax:
-    content: 'common_project_path(project: str)'
+    content: 'common_project_path(project: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.common_project_path
@@ -347,7 +347,8 @@ items:
 
     '
   syntax:
-    content: get_transport_class()
+    content: "get_transport_class() -> typing.Type[\n    google.cloud.texttospeech_v1beta1.services.text_to_speech.transports.base.TextToSpeechTransport\n\
+      ]"
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.get_transport_class
@@ -378,7 +379,8 @@ items:
       \ dict\n        ]\n    ] = None,\n    *,\n    language_code: typing.Optional[str]\
       \ = None,\n    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse"
     parameters:
     - defaultValue: None
       description: The request object. The top-level message sent by the client for
@@ -427,7 +429,7 @@ items:
 
     '
   syntax:
-    content: 'model_path(project: str, location: str, model: str)'
+    content: 'model_path(project: str, location: str, model: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.model_path
@@ -447,7 +449,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_billing_account_path(path: str)'
+    content: 'parse_common_billing_account_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.parse_common_billing_account_path
@@ -467,7 +469,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_folder_path(path: str)'
+    content: 'parse_common_folder_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.parse_common_folder_path
@@ -487,7 +489,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_location_path(path: str)'
+    content: 'parse_common_location_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.parse_common_location_path
@@ -507,7 +509,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_organization_path(path: str)'
+    content: 'parse_common_organization_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.parse_common_organization_path
@@ -527,7 +529,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_project_path(path: str)'
+    content: 'parse_common_project_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.parse_common_project_path
@@ -547,7 +549,7 @@ items:
 
     '
   syntax:
-    content: 'parse_model_path(path: str)'
+    content: 'parse_model_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.parse_model_path
@@ -587,7 +589,7 @@ items:
       \    ] = None,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse"
     parameters:
     - defaultValue: None
       description: The request object. The top-level message sent by the client for

--- a/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.yml
+++ b/tests/testdata/goldens/gapic-auto/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.yml
@@ -146,7 +146,7 @@ items:
 
     '
   syntax:
-    content: 'common_billing_account_path(billing_account: str)'
+    content: 'common_billing_account_path(billing_account: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.common_billing_account_path
@@ -166,7 +166,7 @@ items:
 
     '
   syntax:
-    content: 'common_folder_path(folder: str)'
+    content: 'common_folder_path(folder: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.common_folder_path
@@ -186,7 +186,7 @@ items:
 
     '
   syntax:
-    content: 'common_location_path(project: str, location: str)'
+    content: 'common_location_path(project: str, location: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.common_location_path
@@ -206,7 +206,7 @@ items:
 
     '
   syntax:
-    content: 'common_organization_path(organization: str)'
+    content: 'common_organization_path(organization: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.common_organization_path
@@ -226,7 +226,7 @@ items:
 
     '
   syntax:
-    content: 'common_project_path(project: str)'
+    content: 'common_project_path(project: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.common_project_path
@@ -394,7 +394,8 @@ items:
       \ dict\n        ]\n    ] = None,\n    *,\n    language_code: typing.Optional[str]\
       \ = None,\n    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse"
     parameters:
     - defaultValue: None
       description: The request object. The top-level message sent by the client for
@@ -443,7 +444,7 @@ items:
 
     '
   syntax:
-    content: 'model_path(project: str, location: str, model: str)'
+    content: 'model_path(project: str, location: str, model: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.model_path
@@ -463,7 +464,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_billing_account_path(path: str)'
+    content: 'parse_common_billing_account_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.parse_common_billing_account_path
@@ -483,7 +484,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_folder_path(path: str)'
+    content: 'parse_common_folder_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.parse_common_folder_path
@@ -503,7 +504,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_location_path(path: str)'
+    content: 'parse_common_location_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.parse_common_location_path
@@ -523,7 +524,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_organization_path(path: str)'
+    content: 'parse_common_organization_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.parse_common_organization_path
@@ -543,7 +544,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_project_path(path: str)'
+    content: 'parse_common_project_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.parse_common_project_path
@@ -563,7 +564,7 @@ items:
 
     '
   syntax:
-    content: 'parse_model_path(path: str)'
+    content: 'parse_model_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.parse_model_path
@@ -603,7 +604,7 @@ items:
       \    ] = None,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse"
     parameters:
     - defaultValue: None
       description: The request object. The top-level message sent by the client for

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.client.Client.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.client.Client.yml
@@ -190,7 +190,7 @@ items:
 
     '
   syntax:
-    content: 'common_billing_account_path(billing_account: str)'
+    content: 'common_billing_account_path(billing_account: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.common_billing_account_path
@@ -210,7 +210,7 @@ items:
 
     '
   syntax:
-    content: 'common_folder_path(folder: str)'
+    content: 'common_folder_path(folder: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.common_folder_path
@@ -230,7 +230,7 @@ items:
 
     '
   syntax:
-    content: 'common_location_path(project: str, location: str)'
+    content: 'common_location_path(project: str, location: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.common_location_path
@@ -250,7 +250,7 @@ items:
 
     '
   syntax:
-    content: 'common_organization_path(organization: str)'
+    content: 'common_organization_path(organization: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.common_organization_path
@@ -270,7 +270,7 @@ items:
 
     '
   syntax:
-    content: 'common_project_path(project: str)'
+    content: 'common_project_path(project: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.common_project_path
@@ -303,7 +303,7 @@ items:
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Union[\n      \
       \  int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> google.cloud.pubsub_v1.types.Topic"
     parameters:
     - defaultValue: None
       description: The request object. A topic resource.
@@ -364,7 +364,7 @@ items:
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Union[\n      \
       \  int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> None"
     parameters:
     - defaultValue: None
       description: The request object. Request for the <code>DeleteTopic</code> method.
@@ -416,7 +416,7 @@ items:
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Union[\n        int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> google.cloud.pubsub_v1.types.DetachSubscriptionResponse"
     parameters:
     - defaultValue: None
       description: The request object. Request for the DetachSubscription method.
@@ -456,7 +456,7 @@ items:
 
     '
   syntax:
-    content: ensure_cleanup_and_commit_timer_runs()
+    content: ensure_cleanup_and_commit_timer_runs() -> None
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.ensure_cleanup_and_commit_timer_runs
@@ -479,7 +479,7 @@ items:
   syntax:
     content: "from_service_account_file(\n    filename: str,\n    batch_settings:\
       \ typing.Union[\n        google.cloud.pubsub_v1.types.BatchSettings, typing.Sequence\n\
-      \    ] = (),\n    **kwargs: typing.Any\n)"
+      \    ] = (),\n    **kwargs: typing.Any\n) -> google.cloud.pubsub_v1.publisher.client.Client"
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.from_service_account_file
@@ -526,7 +526,7 @@ items:
   syntax:
     content: "from_service_account_json(\n    filename: str,\n    batch_settings:\
       \ typing.Union[\n        google.cloud.pubsub_v1.types.BatchSettings, typing.Sequence\n\
-      \    ] = (),\n    **kwargs: typing.Any\n)"
+      \    ] = (),\n    **kwargs: typing.Any\n) -> google.cloud.pubsub_v1.publisher.client.Client"
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.from_service_account_json
@@ -555,7 +555,7 @@ items:
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Union[\n        int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> google.iam.v1.policy_pb2.Policy"
     parameters:
     - defaultValue: None
       description: The request object. Request message for <code>GetIamPolicy</code>
@@ -690,7 +690,7 @@ items:
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Union[\n      \
       \  int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> google.cloud.pubsub_v1.types.Topic"
     parameters:
     - defaultValue: None
       description: The request object. Request for the GetTopic method.
@@ -748,7 +748,7 @@ items:
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Union[\n      \
       \  int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> google.pubsub_v1.services.publisher.pagers.ListTopicSnapshotsPager"
     parameters:
     - defaultValue: None
       description: The request object. Request for the <code>ListTopicSnapshots</code>
@@ -805,7 +805,7 @@ items:
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Union[\n      \
       \  int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> google.pubsub_v1.services.publisher.pagers.ListTopicSubscriptionsPager"
     parameters:
     - defaultValue: None
       description: The request object. Request for the <code>ListTopicSubscriptions</code>
@@ -862,7 +862,7 @@ items:
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Union[\n      \
       \  int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> google.pubsub_v1.services.publisher.pagers.ListTopicsPager"
     parameters:
     - defaultValue: None
       description: The request object. Request for the <code>ListTopics</code> method.
@@ -905,7 +905,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_billing_account_path(path: str)'
+    content: 'parse_common_billing_account_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.parse_common_billing_account_path
@@ -925,7 +925,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_folder_path(path: str)'
+    content: 'parse_common_folder_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.parse_common_folder_path
@@ -945,7 +945,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_location_path(path: str)'
+    content: 'parse_common_location_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.parse_common_location_path
@@ -965,7 +965,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_organization_path(path: str)'
+    content: 'parse_common_organization_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.parse_common_organization_path
@@ -985,7 +985,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_project_path(path: str)'
+    content: 'parse_common_project_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.parse_common_project_path
@@ -1005,7 +1005,7 @@ items:
 
     '
   syntax:
-    content: 'parse_schema_path(path: str)'
+    content: 'parse_schema_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.parse_schema_path
@@ -1025,7 +1025,7 @@ items:
 
     '
   syntax:
-    content: 'parse_subscription_path(path: str)'
+    content: 'parse_subscription_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.parse_subscription_path
@@ -1045,7 +1045,7 @@ items:
 
     '
   syntax:
-    content: 'parse_topic_path(path: str)'
+    content: 'parse_topic_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.parse_topic_path
@@ -1079,7 +1079,7 @@ items:
     content: "publish(\n    topic: str,\n    data: bytes,\n    ordering_key: str =\
       \ \"\",\n    retry: OptionalRetry = _MethodDefault._DEFAULT_VALUE,\n    timeout:\
       \ types.OptionalTimeout = _MethodDefault._DEFAULT_VALUE,\n    **attrs: typing.Union[bytes,\
-      \ str]\n)"
+      \ str]\n) -> pubsub_v1.publisher.futures.Future"
     exceptions:
     - description: If called after publisher has been stopped by a <code>stop()</code>
         method call.
@@ -1105,7 +1105,7 @@ items:
 
     '
   syntax:
-    content: 'resume_publish(topic: str, ordering_key: str)'
+    content: 'resume_publish(topic: str, ordering_key: str) -> None'
     exceptions:
     - description: If called after publisher has been stopped by a <code>stop()</code>
         method call.
@@ -1132,7 +1132,7 @@ items:
 
     '
   syntax:
-    content: 'schema_path(project: str, schema: str)'
+    content: 'schema_path(project: str, schema: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.schema_path
@@ -1159,7 +1159,7 @@ items:
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Union[\n        int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> google.iam.v1.policy_pb2.Policy"
     parameters:
     - defaultValue: None
       description: The request object. Request message for <code>SetIamPolicy</code>
@@ -1236,7 +1236,7 @@ items:
 
     </aside>'
   syntax:
-    content: stop()
+    content: stop() -> None
     exceptions:
     - description: If called after publisher has been stopped by a <code>stop()</code>
         method call.
@@ -1260,7 +1260,7 @@ items:
 
     '
   syntax:
-    content: 'subscription_path(project: str, subscription: str)'
+    content: 'subscription_path(project: str, subscription: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.subscription_path
@@ -1303,7 +1303,7 @@ items:
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Union[\n        int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> google.iam.v1.iam_policy_pb2.TestIamPermissionsResponse"
     parameters:
     - defaultValue: None
       description: The request object. Request message for <code>TestIamPermissions</code>
@@ -1340,7 +1340,7 @@ items:
 
     '
   syntax:
-    content: 'topic_path(project: str, topic: str)'
+    content: 'topic_path(project: str, topic: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.client.Client.topic_path
@@ -1395,7 +1395,7 @@ items:
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Union[\n        int,\n        float,\n        google.api_core.timeout.ConstantTimeout,\n\
       \        google.api_core.timeout.ExponentialTimeout,\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
-      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) -> google.cloud.pubsub_v1.types.Topic"
     parameters:
     - defaultValue: None
       description: The request object. Request for the UpdateTopic method.

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.futures.Future.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.futures.Future.yml
@@ -76,7 +76,7 @@ items:
     '
   syntax:
     content: "add_done_callback(\n    callback: typing.Callable[[pubsub_v1.publisher.futures.Future],\
-      \ typing.Any]\n)"
+      \ typing.Any]\n) -> None"
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.futures.Future.add_done_callback
@@ -99,7 +99,7 @@ items:
 
     '
   syntax:
-    content: cancel()
+    content: cancel() -> bool
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.futures.Future.cancel
@@ -122,7 +122,7 @@ items:
 
     '
   syntax:
-    content: cancelled()
+    content: cancelled() -> bool
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.futures.Future.cancelled
@@ -190,7 +190,8 @@ items:
 
     '
   syntax:
-    content: 'result(timeout: typing.Optional[typing.Union[int, float]] = None)'
+    content: 'result(timeout: typing.Optional[typing.Union[int, float]] = None) ->
+      str'
     exceptions:
     - description: If the request times out.
       var_type: concurrent.futures.TimeoutError
@@ -215,7 +216,7 @@ items:
 
     '
   syntax:
-    content: running()
+    content: running() -> bool
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.publisher.futures.Future.running
@@ -306,7 +307,7 @@ items:
 
     '
   syntax:
-    content: set_running_or_notify_cancel()
+    content: set_running_or_notify_cancel() -> typing.NoReturn
     exceptions:
     - description: if this method was already called or if set_result() or set_exception()
         was called.

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.client.Client.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.client.Client.yml
@@ -154,7 +154,8 @@ items:
       \    ack_ids: typing.Optional[typing.Sequence[str]] = None,\n    retry: typing.Union[\n\
       \        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ None"
     parameters:
     - defaultValue: None
       description: The request object. Request for the Acknowledge method.
@@ -229,7 +230,7 @@ items:
 
     '
   syntax:
-    content: close()
+    content: close() -> None
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.close
@@ -272,7 +273,7 @@ items:
 
     '
   syntax:
-    content: 'common_billing_account_path(billing_account: str)'
+    content: 'common_billing_account_path(billing_account: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.common_billing_account_path
@@ -292,7 +293,7 @@ items:
 
     '
   syntax:
-    content: 'common_folder_path(folder: str)'
+    content: 'common_folder_path(folder: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.common_folder_path
@@ -312,7 +313,7 @@ items:
 
     '
   syntax:
-    content: 'common_location_path(project: str, location: str)'
+    content: 'common_location_path(project: str, location: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.common_location_path
@@ -332,7 +333,7 @@ items:
 
     '
   syntax:
-    content: 'common_organization_path(organization: str)'
+    content: 'common_organization_path(organization: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.common_organization_path
@@ -352,7 +353,7 @@ items:
 
     '
   syntax:
-    content: 'common_project_path(project: str)'
+    content: 'common_project_path(project: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.common_project_path
@@ -396,7 +397,8 @@ items:
       \ subscription: typing.Optional[str] = None,\n    retry: typing.Union[\n   \
       \     google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.cloud.pubsub_v1.types.Snapshot"
     parameters:
     - defaultValue: None
       description: The request object. Request for the <code>CreateSnapshot</code>
@@ -475,7 +477,8 @@ items:
       \ = None,\n    ack_deadline_seconds: typing.Optional[int] = None,\n    retry:\
       \ typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.cloud.pubsub_v1.types.Subscription"
     parameters:
     - defaultValue: None
       description: The request object. A subscription resource.
@@ -574,7 +577,8 @@ items:
       \ dict]\n    ] = None,\n    *,\n    snapshot: typing.Optional[str] = None,\n\
       \    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ None"
     parameters:
     - defaultValue: None
       description: The request object. Request for the <code>DeleteSnapshot</code>
@@ -627,7 +631,8 @@ items:
       \ dict]\n    ] = None,\n    *,\n    subscription: typing.Optional[str] = None,\n\
       \    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ None"
     parameters:
     - defaultValue: None
       description: The request object. Request for the DeleteSubscription method.
@@ -666,7 +671,8 @@ items:
 
     '
   syntax:
-    content: 'from_service_account_file(filename: str, **kwargs: typing.Any)'
+    content: "from_service_account_file(\n    filename: str, **kwargs: typing.Any\n\
+      ) -> google.cloud.pubsub_v1.subscriber.client.Client"
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.from_service_account_file
@@ -711,7 +717,8 @@ items:
 
     '
   syntax:
-    content: 'from_service_account_json(filename: str, **kwargs: typing.Any)'
+    content: "from_service_account_json(\n    filename: str, **kwargs: typing.Any\n\
+      ) -> google.cloud.pubsub_v1.subscriber.client.Client"
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.from_service_account_json
@@ -739,7 +746,7 @@ items:
       \ = None,\n    *,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> google.iam.v1.policy_pb2.Policy"
     parameters:
     - defaultValue: None
       description: The request object. Request message for <code>GetIamPolicy</code>
@@ -876,7 +883,8 @@ items:
       \ dict]\n    ] = None,\n    *,\n    snapshot: typing.Optional[str] = None,\n\
       \    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.cloud.pubsub_v1.types.Snapshot"
     parameters:
     - defaultValue: None
       description: The request object. Request for the GetSnapshot method.
@@ -930,7 +938,8 @@ items:
       \ dict]\n    ] = None,\n    *,\n    subscription: typing.Optional[str] = None,\n\
       \    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.cloud.pubsub_v1.types.Subscription"
     parameters:
     - defaultValue: None
       description: The request object. Request for the GetSubscription method.
@@ -985,7 +994,8 @@ items:
       \ dict]\n    ] = None,\n    *,\n    project: typing.Optional[str] = None,\n\
       \    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.pubsub_v1.services.subscriber.pagers.ListSnapshotsPager"
     parameters:
     - defaultValue: None
       description: The request object. Request for the <code>ListSnapshots</code>
@@ -1040,7 +1050,8 @@ items:
       \ dict]\n    ] = None,\n    *,\n    project: typing.Optional[str] = None,\n\
       \    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.pubsub_v1.services.subscriber.pagers.ListSubscriptionsPager"
     parameters:
     - defaultValue: None
       description: The request object. Request for the <code>ListSubscriptions</code>
@@ -1101,7 +1112,7 @@ items:
       \ typing.Optional[int] = None,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> None"
     parameters:
     - defaultValue: None
       description: The request object. Request for the ModifyAckDeadline method.
@@ -1171,7 +1182,8 @@ items:
       \    push_config: typing.Optional[google.cloud.pubsub_v1.types.PushConfig] =\
       \ None,\n    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ None"
     parameters:
     - defaultValue: None
       description: The request object. Request for the ModifyPushConfig method.
@@ -1218,7 +1230,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_billing_account_path(path: str)'
+    content: 'parse_common_billing_account_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.parse_common_billing_account_path
@@ -1238,7 +1250,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_folder_path(path: str)'
+    content: 'parse_common_folder_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.parse_common_folder_path
@@ -1258,7 +1270,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_location_path(path: str)'
+    content: 'parse_common_location_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.parse_common_location_path
@@ -1278,7 +1290,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_organization_path(path: str)'
+    content: 'parse_common_organization_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.parse_common_organization_path
@@ -1298,7 +1310,7 @@ items:
 
     '
   syntax:
-    content: 'parse_common_project_path(path: str)'
+    content: 'parse_common_project_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.parse_common_project_path
@@ -1318,7 +1330,7 @@ items:
 
     '
   syntax:
-    content: 'parse_snapshot_path(path: str)'
+    content: 'parse_snapshot_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.parse_snapshot_path
@@ -1338,7 +1350,7 @@ items:
 
     '
   syntax:
-    content: 'parse_subscription_path(path: str)'
+    content: 'parse_subscription_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.parse_subscription_path
@@ -1358,7 +1370,7 @@ items:
 
     '
   syntax:
-    content: 'parse_topic_path(path: str)'
+    content: 'parse_topic_path(path: str) -> typing.Dict[str, str]'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.parse_topic_path
@@ -1392,7 +1404,8 @@ items:
       \    return_immediately: typing.Optional[bool] = None,\n    max_messages: typing.Optional[int]\
       \ = None,\n    retry: typing.Union[\n        google.api_core.retry.Retry, google.api_core.gapic_v1.method._MethodDefault\n\
       \    ] = _MethodDefault._DEFAULT_VALUE,\n    timeout: typing.Optional[float]\
-      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n)"
+      \ = None,\n    metadata: typing.Sequence[typing.Tuple[str, str]] = ()\n) ->\
+      \ google.cloud.pubsub_v1.types.PullResponse"
     parameters:
     - defaultValue: None
       description: The request object. Request for the <code>Pull</code> method.
@@ -1467,7 +1480,7 @@ items:
       \ dict]\n    ] = None,\n    *,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> google.cloud.pubsub_v1.types.SeekResponse"
     parameters:
     - defaultValue: None
       description: The request object. Request for the <code>Seek</code> method.
@@ -1509,7 +1522,7 @@ items:
       \ = None,\n    *,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> google.iam.v1.policy_pb2.Policy"
     parameters:
     - defaultValue: None
       description: The request object. Request message for <code>SetIamPolicy</code>
@@ -1567,7 +1580,7 @@ items:
 
     '
   syntax:
-    content: 'snapshot_path(project: str, snapshot: str)'
+    content: 'snapshot_path(project: str, snapshot: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.snapshot_path
@@ -1608,7 +1621,7 @@ items:
       \    ] = None,\n    *,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> typing.Iterable[google.cloud.pubsub_v1.types.StreamingPullResponse]"
     parameters:
     - defaultValue: None
       description: The request object iterator. Request for the <code>StreamingPull</code>
@@ -1677,7 +1690,7 @@ items:
       \ typing.Any],\n    flow_control: typing.Union[\n        google.cloud.pubsub_v1.types.FlowControl,\
       \ typing.Sequence\n    ] = (),\n    scheduler: typing.Optional[subscriber.scheduler.ThreadScheduler]\
       \ = None,\n    use_legacy_flow_control: bool = False,\n    await_callbacks_on_shutdown:\
-      \ bool = False,\n)"
+      \ bool = False,\n) -> google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture"
     parameters:
     - defaultValue: 'False'
       description: If set to <code>True</code>, flow control at the Cloud Pub/Sub
@@ -1704,7 +1717,7 @@ items:
 
     '
   syntax:
-    content: 'subscription_path(project: str, subscription: str)'
+    content: 'subscription_path(project: str, subscription: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.subscription_path
@@ -1746,7 +1759,7 @@ items:
       \    ] = None,\n    *,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> google.iam.v1.iam_policy_pb2.TestIamPermissionsResponse"
     parameters:
     - defaultValue: None
       description: The request object. Request message for <code>TestIamPermissions</code>
@@ -1783,7 +1796,7 @@ items:
 
     '
   syntax:
-    content: 'topic_path(project: str, topic: str)'
+    content: 'topic_path(project: str, topic: str) -> str'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.client.Client.topic_path
@@ -1838,7 +1851,7 @@ items:
       \ dict]\n    ] = None,\n    *,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> google.cloud.pubsub_v1.types.Snapshot"
     parameters:
     - defaultValue: None
       description: The request object. Request for the UpdateSnapshot method.
@@ -1890,7 +1903,7 @@ items:
       \ dict]\n    ] = None,\n    *,\n    retry: typing.Union[\n        google.api_core.retry.Retry,\
       \ google.api_core.gapic_v1.method._MethodDefault\n    ] = _MethodDefault._DEFAULT_VALUE,\n\
       \    timeout: typing.Optional[float] = None,\n    metadata: typing.Sequence[typing.Tuple[str,\
-      \ str]] = ()\n)"
+      \ str]] = ()\n) -> google.cloud.pubsub_v1.types.Subscription"
     parameters:
     - defaultValue: None
       description: The request object. Request for the UpdateSubscription method.

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.Future.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.Future.yml
@@ -96,7 +96,7 @@ items:
 
     '
   syntax:
-    content: cancel()
+    content: cancel() -> bool
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.futures.Future.cancel
@@ -119,7 +119,7 @@ items:
 
     '
   syntax:
-    content: cancelled()
+    content: cancelled() -> bool
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.futures.Future.cancelled
@@ -187,7 +187,8 @@ items:
 
     '
   syntax:
-    content: 'result(timeout: typing.Optional[typing.Union[int, float]] = None)'
+    content: "result(\n    timeout: typing.Optional[typing.Union[int, float]] = None\n\
+      ) -> google.cloud.pubsub_v1.subscriber.exceptions.AcknowledgeStatus"
     exceptions:
     - description: If the request times out.
       var_type: concurrent.futures.TimeoutError
@@ -212,7 +213,7 @@ items:
 
     '
   syntax:
-    content: running()
+    content: running() -> bool
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.futures.Future.running
@@ -303,7 +304,7 @@ items:
 
     '
   syntax:
-    content: set_running_or_notify_cancel()
+    content: set_running_or_notify_cancel() -> typing.NoReturn
     exceptions:
     - description: if this method was already called or if set_result() or set_exception()
         was called.

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.yml
@@ -101,7 +101,7 @@ items:
     \ cancelling the future.\n\n.. versionchanged:: 2.10.0\n   The method always returns\
     \ `True` instead of `None`.\n\n"
   syntax:
-    content: cancel()
+    content: cancel() -> bool
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.cancel
@@ -118,7 +118,7 @@ items:
     startLine: 78
   summary: ''
   syntax:
-    content: cancelled()
+    content: cancelled() -> bool
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.cancelled
@@ -208,7 +208,7 @@ items:
 
     '
   syntax:
-    content: running()
+    content: running() -> bool
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.running
@@ -299,7 +299,7 @@ items:
 
     '
   syntax:
-    content: set_running_or_notify_cancel()
+    content: set_running_or_notify_cancel() -> typing.NoReturn
     exceptions:
     - description: if this method was already called or if set_result() or set_exception()
         was called.

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.message.Message.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.message.Message.yml
@@ -119,7 +119,7 @@ items:
 
     </aside>'
   syntax:
-    content: ack()
+    content: ack() -> None
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.message.Message.ack
@@ -202,7 +202,7 @@ items:
 
     '
   syntax:
-    content: ack_with_response()
+    content: ack_with_response() -> google.cloud.pubsub_v1.subscriber.futures.Future
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.message.Message.ack_with_response
@@ -335,7 +335,7 @@ items:
 
     </aside>'
   syntax:
-    content: drop()
+    content: drop() -> None
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.message.Message.drop
@@ -368,7 +368,7 @@ items:
 
     '
   syntax:
-    content: 'modify_ack_deadline(seconds: int)'
+    content: 'modify_ack_deadline(seconds: int) -> None'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.message.Message.modify_ack_deadline
@@ -434,7 +434,7 @@ items:
 
     '
   syntax:
-    content: 'modify_ack_deadline_with_response(seconds: int)'
+    content: "modify_ack_deadline_with_response(\n    seconds: int,\n) -> google.cloud.pubsub_v1.subscriber.futures.Future"
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.message.Message.modify_ack_deadline_with_response
@@ -461,7 +461,7 @@ items:
 
     '
   syntax:
-    content: nack()
+    content: nack() -> None
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.message.Message.nack
@@ -513,7 +513,7 @@ items:
 
     '
   syntax:
-    content: nack_with_response()
+    content: nack_with_response() -> google.cloud.pubsub_v1.subscriber.futures.Future
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.message.Message.nack_with_response

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.yml
@@ -67,7 +67,7 @@ items:
 
     '
   syntax:
-    content: 'schedule(callback: typing.Callable, *args, **kwargs)'
+    content: 'schedule(callback: typing.Callable, *args, **kwargs) -> None'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.schedule
@@ -86,7 +86,7 @@ items:
 
     '
   syntax:
-    content: 'shutdown(await_msg_callbacks: bool = False)'
+    content: "shutdown(\n    await_msg_callbacks: bool = False,\n) -> typing.List[pubsub_v1.subscriber.message.Message]"
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.shutdown

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.yml
@@ -61,7 +61,7 @@ items:
 
     '
   syntax:
-    content: 'schedule(callback: typing.Callable, *args, **kwargs)'
+    content: 'schedule(callback: typing.Callable, *args, **kwargs) -> None'
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.schedule
@@ -80,7 +80,7 @@ items:
 
     '
   syntax:
-    content: 'shutdown(await_msg_callbacks: bool = False)'
+    content: "shutdown(\n    await_msg_callbacks: bool = False,\n) -> typing.List[pubsub_v1.subscriber.message.Message]"
     parameters: []
   type: method
   uid: google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.shutdown


### PR DESCRIPTION
The documentation was lacking return types in the syntax even though it existed in the source code. This adds returns such as `-> None` portion:
```
def foo(a: str) -> None
```

If the syntax is missing the annotation, even though the docstring may have information about the returns, it will not try to add them to the documentation. Although that might be possible, I don't think the plugin should try to add content that isn't present in the source.

There seems to be an issue with how `return_annotation` is populated for inherited members, and extracts additional wording that isn't valid Python code. To prevent this, and to potentially prevent bad code being present in the source, I've added `Is_valid_python_code()` to ensure it only takes in proper return annotations and not a random string. Updated docstrings for `format_code` as well.

Removed unused references related to signatures - verified that the content remains unchanged. This is an artifact from the upstream that is not used in this plugin.

Updated unit tests & goldens.

Fixes #290.

- [x] Tests pass
