### PR TITLE
build: update release script to disable dependency resolver

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 
 # Start the releasetool reporter
-python3 -m pip install --require-hashes -r github/sphinx-docfx-yaml/.kokoro/requirements.txt
+python3 -m pip install --no-deps --require-hashes -r github/sphinx-docfx-yaml/.kokoro/requirements.txt
 python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
 
 # Disable buffering, so that the logs stream through.


### PR DESCRIPTION
Forgot this on `release.sh` script, fixing it with same reason for #295.

Towards #293.

- [x] Tests pass
