### PR TITLE
chore: update owlbot template for release file

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 
 # Start the releasetool reporter
-python3 -m pip install --require-hashes -r github/sphinx-docfx-yaml/.kokoro/requirements.txt
+python3 -m pip install --no-deps --require-hashes -r github/sphinx-docfx-yaml/.kokoro/requirements.txt
 python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
 
 # Disable buffering, so that the logs stream through.

--- a/owlbot.py
+++ b/owlbot.py
@@ -53,3 +53,9 @@ s.move(
     ],
 )
 
+# Diable the dependency resolver.
+s.replace(
+    ".kokoro/release.sh",
+    "python3 -m pip install --require-hashes",
+    "python3 -m pip install --no-deps --require-hashes",
+)


### PR DESCRIPTION
Previously the dependency resolver was disabled for Kokoro job scripts when using pip install in #295 and #296, however this was left out of the template file settings for `release.sh`.

Fixes #303.

- [x] Tests pass
