### PR TITLE
fix: pin markdown builder version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ dependencies = [
     'PyYAML',
     'recommonmark',
     'sphinx==4.5.0',
-    'sphinx-markdown-builder',
+    'sphinx-markdown-builder==0.5.5',
     'sphinxcontrib.napoleon',
     'unidecode',
     'wheel>=0.24.0'


### PR DESCRIPTION
After upgrading to markdown builder 0.6.0 implicitly, this seemed to have caused issues for the docs jobs not working properly. 0.5.5 was the latest release from the original maintained version, and 0.6.0 version is the actively maintained version but causing some issues, so I'll temporarily pin to 0.5.5 while figuring out how to work with the newer version (or if we should even work with the newer version).

Fixes b/288943562.

- [x] Tests pass
