### PR TITLE
fix: update annotation name extraction logic and add unit tests

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -747,17 +747,13 @@ def _extract_type_name(annotation: Any) -> str:
     Returns:
         The extracted type hint in human-readable string format.
     """
-    type_name = ""
-    # Extract names for simple types.
-    try:
+
+    annotation_dir = dir(annotation)
+    if '__args__' not in annotation_dir:
         return annotation.__name__
-    except AttributeError:
-        pass
 
     # Try to extract names for more complicated types.
     type_name = str(annotation)
-    if not annotation.__args__:
-        return type_name
 
     # If ForwardRef references are found, recursively remove them.
     prefix_to_remove_start = "ForwardRef('"

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,0 +1,56 @@
+"""Tests for various inspect related utils."""
+from docfx_yaml import extension
+
+import inspect
+import unittest
+from parameterized import parameterized
+
+from typing import Any, Optional, Union
+
+
+class TestGenerate(unittest.TestCase):
+
+    types_to_test = [
+        [
+            # Test for a simple type without __args__.
+            str,
+            'str',
+        ],
+        [
+            # Test for a more complex type without forward reference.
+            list[str],
+            'list[str]',
+        ],
+        [
+            # Test for imported type, without forward reference.
+            dict[str, Any],
+            'dict[str, typing.Any]',
+        ],
+        [
+            # Test for forward reference.
+            Optional["ForwardClass"],
+            'typing.Optional[ForwardClass]'
+        ],
+        [
+            # Test for multiple forward references.
+            Union["ForwardClass", "ForwardClass2"],
+            'typing.Union[ForwardClass, ForwardClass2]'
+        ],
+    ]
+    @parameterized.expand(types_to_test)
+    def test_extracts_annotations(self, type_to_test, expected_type_name):
+        """Extracts annotations for ones without __args__."""
+        def test_method(name: type_to_test):
+            pass
+
+        annotations = inspect.getfullargspec(test_method).annotations
+        annotation_to_use = annotations['name']
+
+        extracted_annotation_name = extension._extract_type_name(
+            annotation_to_use)
+
+        self.assertEqual(extracted_annotation_name, expected_type_name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -39,7 +39,7 @@ class TestGenerate(unittest.TestCase):
     ]
     @parameterized.expand(types_to_test)
     def test_extracts_annotations(self, type_to_test, expected_type_name):
-        """Extracts annotations for ones without __args__."""
+        """Extracts annotations from test method, compares to expected name."""
         def test_method(name: type_to_test):
             pass
 


### PR DESCRIPTION
Adds unit test coverage. Goldens should take care of the end-to-end coverage but adding unit test does help - while adding unit test coverage, noticed the unused code and refactored the logic a bit.

Fixes #318. Towards #311.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
