### PR TITLE
feat!: Bump minimum version to 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.10]
 
     steps:
       - uses: actions/checkout@v3

--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update \
     libssl-dev \
     libsqlite3-dev \
     portaudio19-dev \
-    python3.10-distutils \
     redis-server \
     software-properties-common \
     ssh \
@@ -53,10 +52,12 @@ RUN apt-get update \
     wget \
     zlib1g-dev \
   && add-apt-repository universe \
+  && add-apt-repository ppa:deadsnakes/ppa \
   && apt-get update \
   && apt-get -y install jq \
   && apt-get clean autoclean \
   && apt-get autoremove -y \
+  && apt install python3.10-distutils \
   && rm -rf /var/lib/apt/lists/* \
   && rm -f /var/cache/apt/archives/*.deb
 

--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update \
   && apt-get -y install jq \
   && apt-get clean autoclean \
   && apt-get autoremove -y \
-  && apt install python3.10-distutils \
+  && apt install -y python3.10-distutils \
   && rm -rf /var/lib/apt/lists/* \
   && rm -f /var/cache/apt/archives/*.deb
 
@@ -78,9 +78,7 @@ RUN ./Python-3.10.13/configure --enable-optimizations
 RUN make altinstall
 
 ###################### Install pip
-RUN wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-  && python3 /tmp/get-pip.py \
-  && rm /tmp/get-pip.py
+RUN apt install -y python3-pip
 
 # Test pip
 RUN python3.10 -m pip

--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
     libssl-dev \
     libsqlite3-dev \
     portaudio19-dev \
+    python3.10-distutils \
     redis-server \
     software-properties-common \
     ssh \

--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -83,4 +83,4 @@ RUN apt install -y python3-pip
 # Test pip
 RUN python3.10 -m pip
 
-CMD ["python3"]
+CMD ["python3.10"]

--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -59,51 +59,28 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && rm -f /var/cache/apt/archives/*.deb
 
-COPY fetch_gpg_keys.sh /tmp
-# Install the desired versions of Python.
-RUN set -ex \
-  && export GNUPGHOME="$(mktemp -d)" \
-  && echo "disable-ipv6" >> "${GNUPGHOME}/dirmngr.conf" \
-  && /tmp/fetch_gpg_keys.sh \
-  && for PYTHON_VERSION in 3.9.13; do \
-  wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-  && wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
-  && gpg --batch --verify python-${PYTHON_VERSION}.tar.xz.asc python-${PYTHON_VERSION}.tar.xz \
-  && rm -r python-${PYTHON_VERSION}.tar.xz.asc \
-  && mkdir -p /usr/src/python-${PYTHON_VERSION} \
-  && tar -xJC /usr/src/python-${PYTHON_VERSION} --strip-components=1 -f python-${PYTHON_VERSION}.tar.xz \
-  && rm python-${PYTHON_VERSION}.tar.xz \
-  && cd /usr/src/python-${PYTHON_VERSION} \
-  && ./configure \
-  --enable-shared \
-  # This works only on Python 2.7 and throws a warning on every other
-  # version, but seems otherwise harmless.
-  --enable-unicode=ucs4 \
-  --with-system-ffi \
-  --without-ensurepip \
-  && make -j$(nproc) \
-  && make install \
-  && ldconfig \
-  ; done \
-  && rm -rf "${GNUPGHOME}" \
-  && rm -rf /usr/src/python* \
-  && rm -rf ~/.cache/
-
-# Install pip on Python 3.9 only.
-# If the environment variable is called "PIP_VERSION", pip explodes with
-# "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 23.0
-RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
-  && python3.9 /tmp/get-pip.py "pip==$PYTHON_PIP_VERSION" \
-  # we use "--force-reinstall" for the case where the version of pip we're trying to install is the same as the version bundled with Python
-  # ("Requirement already up-to-date: pip==8.1.2 in /usr/local/lib/python3.10/site-packages")
-  # https://github.com/docker-library/python/pull/143#issuecomment-241032683
-  && pip3 install --no-cache-dir --upgrade --force-reinstall "pip==$PYTHON_PIP_VERSION" \
-  # then we use "pip list" to ensure we don't have more than one pip version installed
-  # https://github.com/docker-library/python/pull/100
-  && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
-
 # Install Google Cloud SDK
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
+
+
+###################### Install python 3.10.13
+
+# Download python 3.10.13
+RUN wget https://www.python.org/ftp/python/3.10.13/Python-3.10.13.tgz
+
+# Extract files
+RUN tar -xvf Python-3.10.13.tgz
+
+# Install python 3.10.13
+RUN ./Python-3.10.13/configure --enable-optimizations
+RUN make altinstall
+
+###################### Install pip
+RUN wget -O /tmp/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' \
+  && python3 /tmp/get-pip.py \
+  && rm /tmp/get-pip.py
+
+# Test pip
+RUN python3.10 -m pip
 
 CMD ["python3"]

--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -83,4 +83,10 @@ RUN apt install -y python3-pip
 # Test pip
 RUN python3.10 -m pip
 
-CMD ["python3.10"]
+# Make Python3.10 the default version
+RUN unlink /usr/bin/python3 && ln -s /usr/local/bin/python3.10 /usr/bin/python3
+
+# Test version
+RUN python3 --version
+
+CMD ["python3"]

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -47,8 +47,9 @@ from sphinx.util.console import darkgreen, bold
 from sphinx.util import ensuredir
 from sphinx.errors import ExtensionError
 from sphinx.util.nodes import make_refnode
-from sphinxcontrib.napoleon.docstring import GoogleDocstring
-from sphinxcontrib.napoleon import Config, _process_docstring
+from sphinx.ext.napoleon import GoogleDocstring
+from sphinx.ext.napoleon import Config
+from sphinx.ext.napoleon import _process_docstring
 
 from .utils import transform_node, transform_string
 from .settings import API_ROOT

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,3 @@ pytest
 # Other dependencies
 black==22.10.0
 parameterized==0.8.1
-# google-resumable-media-python requires manual update as this repo isn't templated.
-# python-api-core also requires manual update as it is not templated.
-sphinx==4.5.0
--e .

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
     package_dir={'': '.'},
     packages=packages,
     install_requires=dependencies,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     include_package_data=True,
     zip_safe=False,
     **extra_setup

--- a/tests/testdata/gapic-combo/docs/pubsub/subscriber/api/message.rst
+++ b/tests/testdata/gapic-combo/docs/pubsub/subscriber/api/message.rst
@@ -3,4 +3,3 @@ Messages
 
 .. autoclass:: google.cloud.pubsub_v1.subscriber.message.Message
   :members:
-  :noindex:

--- a/tests/testdata/gapic-combo/docs/pubsub/types.rst
+++ b/tests/testdata/gapic-combo/docs/pubsub/types.rst
@@ -3,4 +3,3 @@ Pub/Sub Client Types
 
 .. automodule:: google.cloud.pubsub_v1.types
   :members:
-  :noindex:

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.futures.Future.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.publisher.futures.Future.yml
@@ -143,7 +143,7 @@ items:
   source:
     id: done
     path: concurrent/futures/_base.py
-    startLine: 383
+    startLine: 395
   summary: 'Return True if the future was cancelled or finished executing.
 
 
@@ -163,7 +163,7 @@ items:
   source:
     id: exception
     path: concurrent/futures/_base.py
-    startLine: 453
+    startLine: 465
   summary: 'Return the exception raised by the call that the future represents.
 
     '

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.Future.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.Future.yml
@@ -68,7 +68,7 @@ items:
   source:
     id: add_done_callback
     path: concurrent/futures/_base.py
-    startLine: 398
+    startLine: 410
   summary: 'Attaches a callable that will be called when the future finishes.
 
     '
@@ -133,7 +133,7 @@ items:
   source:
     id: done
     path: concurrent/futures/_base.py
-    startLine: 383
+    startLine: 395
   summary: 'Return True if the future was cancelled or finished executing.
 
 
@@ -153,7 +153,7 @@ items:
   source:
     id: exception
     path: concurrent/futures/_base.py
-    startLine: 453
+    startLine: 465
   summary: 'Return the exception raised by the call that the future represents.
 
     '

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture.yml
@@ -72,7 +72,7 @@ items:
   source:
     id: add_done_callback
     path: concurrent/futures/_base.py
-    startLine: 398
+    startLine: 410
   summary: 'Attaches a callable that will be called when the future finishes.
 
     '
@@ -132,7 +132,7 @@ items:
   source:
     id: done
     path: concurrent/futures/_base.py
-    startLine: 383
+    startLine: 395
   summary: 'Return True if the future was cancelled or finished executing.
 
 
@@ -152,7 +152,7 @@ items:
   source:
     id: exception
     path: concurrent/futures/_base.py
-    startLine: 453
+    startLine: 465
   summary: 'Return the exception raised by the call that the future represents.
 
     '
@@ -176,7 +176,7 @@ items:
   source:
     id: result
     path: concurrent/futures/_base.py
-    startLine: 418
+    startLine: 430
   summary: 'Return the result of the call that the future represents.
 
     '

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.yml
@@ -68,7 +68,10 @@ items:
     '
   syntax:
     content: 'schedule(callback: typing.Callable, *args, **kwargs) -> None'
-    parameters: []
+    parameters:
+    - description: The function to call.
+      id: callback
+      var_type: Callable
   type: method
   uid: google.cloud.pubsub_v1.subscriber.scheduler.Scheduler.schedule
 - attributes: []

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.yml
@@ -67,7 +67,10 @@ items:
     '
   syntax:
     content: 'schedule(callback: typing.Callable, *args, **kwargs) -> None'
-    parameters: []
+    parameters:
+    - description: The function to call.
+      id: callback
+      var_type: Callable
   type: method
   uid: google.cloud.pubsub_v1.subscriber.scheduler.ThreadScheduler.schedule
 - attributes: []

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FeatureSetDefaults.FeatureSetEditionDefault.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FeatureSetDefaults.FeatureSetEditionDefault.yml
@@ -1,0 +1,20 @@
+### YamlMime:UniversalReference
+api_name: []
+items:
+- children: []
+  class: google.cloud.pubsub_v1.types.FeatureSetDefaults.FeatureSetEditionDefault
+  fullName: google.cloud.pubsub_v1.types.FeatureSetDefaults.FeatureSetEditionDefault
+  langs:
+  - python
+  module: google.cloud.pubsub_v1.types.FeatureSetDefaults
+  name: FeatureSetEditionDefault
+  source:
+    id: FeatureSetEditionDefault
+    path: null
+    startLine: null
+  summary: API documentation for `pubsub_v1.types.FeatureSetDefaults.FeatureSetEditionDefault`
+    class.
+  syntax: {}
+  type: class
+  uid: google.cloud.pubsub_v1.types.FeatureSetDefaults.FeatureSetEditionDefault
+references: []

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FeatureSetDefaults.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.FeatureSetDefaults.yml
@@ -1,0 +1,25 @@
+### YamlMime:UniversalReference
+api_name: []
+items:
+- children:
+  - google.cloud.pubsub_v1.types.FeatureSetDefaults.FeatureSetEditionDefault
+  class: google.cloud.pubsub_v1.types.FeatureSetDefaults
+  fullName: google.cloud.pubsub_v1.types.FeatureSetDefaults
+  langs:
+  - python
+  module: google.cloud.pubsub_v1.types
+  name: FeatureSetDefaults
+  source:
+    id: FeatureSetDefaults
+    path: null
+    startLine: null
+  summary: API documentation for `pubsub_v1.types.FeatureSetDefaults` class.
+  syntax: {}
+  type: class
+  uid: google.cloud.pubsub_v1.types.FeatureSetDefaults
+references:
+- fullName: google.cloud.pubsub_v1.types.FeatureSetDefaults.FeatureSetEditionDefault
+  isExternal: false
+  name: FeatureSetEditionDefault
+  parent: google.cloud.pubsub_v1.types.FeatureSetDefaults
+  uid: google.cloud.pubsub_v1.types.FeatureSetDefaults.FeatureSetEditionDefault

--- a/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.yml
+++ b/tests/testdata/goldens/gapic-combo/google.cloud.pubsub_v1.types.yml
@@ -29,6 +29,7 @@ items:
   - google.cloud.pubsub_v1.types.ExpirationPolicy
   - google.cloud.pubsub_v1.types.ExtensionRangeOptions
   - google.cloud.pubsub_v1.types.FeatureSet
+  - google.cloud.pubsub_v1.types.FeatureSetDefaults
   - google.cloud.pubsub_v1.types.FieldDescriptorProto
   - google.cloud.pubsub_v1.types.FieldMask
   - google.cloud.pubsub_v1.types.FieldOptions
@@ -242,6 +243,11 @@ references:
   name: FeatureSet
   parent: google.cloud.pubsub_v1.types
   uid: google.cloud.pubsub_v1.types.FeatureSet
+- fullName: google.cloud.pubsub_v1.types.FeatureSetDefaults
+  isExternal: false
+  name: FeatureSetDefaults
+  parent: google.cloud.pubsub_v1.types
+  uid: google.cloud.pubsub_v1.types.FeatureSetDefaults
 - fullName: google.cloud.pubsub_v1.types.FieldDescriptorProto
   isExternal: false
   name: FieldDescriptorProto

--- a/tests/testdata/goldens/gapic-combo/toc.yml
+++ b/tests/testdata/goldens/gapic-combo/toc.yml
@@ -131,6 +131,13 @@
         uid: google.cloud.pubsub_v1.types.ExtensionRangeOptions
       - name: FeatureSet
         uid: google.cloud.pubsub_v1.types.FeatureSet
+      - items:
+        - name: Overview
+          uid: google.cloud.pubsub_v1.types.FeatureSetDefaults
+        - name: FeatureSetEditionDefault
+          uid: google.cloud.pubsub_v1.types.FeatureSetDefaults.FeatureSetEditionDefault
+        name: FeatureSetDefaults
+        uid: google.cloud.pubsub_v1.types.FeatureSetDefaults
       - name: FieldDescriptorProto
         uid: google.cloud.pubsub_v1.types.FieldDescriptorProto
       - name: FieldMask

--- a/tests/testdata/goldens/handwritten/buckets.md
+++ b/tests/testdata/goldens/handwritten/buckets.md
@@ -2199,7 +2199,8 @@ Return the value for key if key is in the dictionary, else default.
 #### keys()
 
 #### pop(k, )
-If key is not found, default is returned if given, otherwise KeyError is raised
+If the key is not found, return the default if given; otherwise,
+raise a KeyError.
 
 
 #### popitem()
@@ -2333,7 +2334,8 @@ Return the value for key if key is in the dictionary, else default.
 #### keys()
 
 #### pop(k, )
-If key is not found, default is returned if given, otherwise KeyError is raised
+If the key is not found, return the default if given; otherwise,
+raise a KeyError.
 
 
 #### popitem()
@@ -2514,7 +2516,8 @@ Conditon’s ‘number_of_newer_versions’ value.
 
 
 #### pop(k, )
-If key is not found, default is returned if given, otherwise KeyError is raised
+If the key is not found, return the default if given; otherwise,
+raise a KeyError.
 
 
 #### popitem()
@@ -2589,7 +2592,8 @@ Return the value for key if key is in the dictionary, else default.
 #### keys()
 
 #### pop(k, )
-If key is not found, default is returned if given, otherwise KeyError is raised
+If the key is not found, return the default if given; otherwise,
+raise a KeyError.
 
 
 #### popitem()
@@ -2670,7 +2674,8 @@ Return the value for key if key is in the dictionary, else default.
 #### keys()
 
 #### pop(k, )
-If key is not found, default is returned if given, otherwise KeyError is raised
+If the key is not found, return the default if given; otherwise,
+raise a KeyError.
 
 
 #### popitem()

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.batch.MIMEApplicationHTTP.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.batch.MIMEApplicationHTTP.yml
@@ -51,7 +51,7 @@ items:
   summary: 'Create an application/* type MIME document.
 
 
-    _data is a string containing the raw application data.
+    _data contains the bytes for the raw application data.
 
 
     _subtype is the MIME content type subtype, defaulting to

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.IAMConfiguration.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.IAMConfiguration.yml
@@ -244,8 +244,9 @@ items:
     id: pop
     path: null
     startLine: null
-  summary: 'If key is not found, default is returned if given, otherwise KeyError
-    is raised
+  summary: 'If the key is not found, return the default if given; otherwise,
+
+    raise a KeyError.
 
 
     '

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleAbortIncompleteMultipartUpload.yml
@@ -176,8 +176,9 @@ items:
     id: pop
     path: null
     startLine: null
-  summary: 'If key is not found, default is returned if given, otherwise KeyError
-    is raised
+  summary: 'If the key is not found, return the default if given; otherwise,
+
+    raise a KeyError.
 
 
     '

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleConditions.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleConditions.yml
@@ -462,8 +462,9 @@ items:
     id: pop
     path: null
     startLine: null
-  summary: 'If key is not found, default is returned if given, otherwise KeyError
-    is raised
+  summary: 'If the key is not found, return the default if given; otherwise,
+
+    raise a KeyError.
 
 
     '

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleDelete.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleDelete.yml
@@ -169,8 +169,9 @@ items:
     id: pop
     path: null
     startLine: null
-  summary: 'If key is not found, default is returned if given, otherwise KeyError
-    is raised
+  summary: 'If the key is not found, return the default if given; otherwise,
+
+    raise a KeyError.
 
 
     '

--- a/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleSetStorageClass.yml
+++ b/tests/testdata/goldens/handwritten/google.cloud.storage.bucket.LifecycleRuleSetStorageClass.yml
@@ -176,8 +176,9 @@ items:
     id: pop
     path: null
     startLine: null
-  summary: 'If key is not found, default is returned if given, otherwise KeyError
-    is raised
+  summary: 'If the key is not found, return the default if given; otherwise,
+
+    raise a KeyError.
 
 
     '


### PR DESCRIPTION
Breaking Change: Upgrades minimum version to 3.10. All tools will need to be updated to use Python3.10 as the default version when using the plugin, otherwise 3.9 and below versions will **not** work.

Should be compatible in the future with 3.11, no deprecation warnings.

I tried to upgrade to Sphinx version 5 but ran into docutils issue that could not be solved within this repository. There's also a _lot_ of content changes between versions, so we'll have to approach it carefully.

Confirmed that the Kokoro test works for different client libraries, but do need to update them individually afterwards.

Fixes #305.

- [x] Tests pass
