### PR TITLE
Refactor visit_productionlist method for improved efficiency

### DIFF
--- a/docfx_yaml/writer.py
+++ b/docfx_yaml/writer.py
@@ -438,18 +438,24 @@ class MarkdownTranslator(nodes.NodeVisitor):
 
     def visit_productionlist(self, node):
         self.new_state()
-        names = []
-        for production in node:
-            names.append(production['tokenname'])
-        maxlen = max(len(name) for name in names)
+        maxlen = 0
         lastname = None
+
         for production in node:
-            if production['tokenname']:
-                self.add_text(production['tokenname'].ljust(maxlen) + ' ::=')
-                lastname = production['tokenname']
+            tokenname = production['tokenname']
+            astext = production.astext()
+
+            if tokenname:
+                self.add_text(tokenname.ljust(maxlen) + ' ::=')
+                lastname = tokenname
             elif lastname is not None:
-                self.add_text('%s    ' % (' '*len(lastname)))
-            self.add_text(production.astext() + self.nl)
+                self.add_text('%s    ' % (' ' * len(lastname)))
+
+            self.add_text(astext + self.nl)
+
+            if tokenname:
+                maxlen = max(maxlen, len(tokenname))
+
         self.end_state(wrap=False)
         raise nodes.SkipNode
 


### PR DESCRIPTION
Simplify the visit_productionlist method by combining logic and iterating through the 'node' list only once. This refactoring eliminates the need for a separate loop to gather token names and dynamically calculates the maximum length ('maxlen') within the loop. The modified code maintains efficiency.