### PR TITLE
feat: grab repository metadata

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -2032,18 +2032,19 @@ def build_finished(app, exception):
         markdown_utils.remove_unused_pages(
             added_pages, app.env.moved_markdown_pages, normalized_outdir)
 
-    # Add summary pages as the second entry into the table of contents.
-    pkg_toc_yaml.insert(
-        1,
-        {
-            "name": f"{app.env.library_shortname} APIs",
-            "items": [
-                {"name": "Classes", "href": "summary_class.yml"},
-                {"name": "Methods", "href": "summary_method.yml"},
-                {"name": "Properties and Attributes", "href": "summary_property.yml"},
-            ],
-        }
-    )
+    if app.env.library_shortname:
+        # Add summary pages as the second entry into the table of contents.
+        pkg_toc_yaml.insert(
+            1,
+            {
+                "name": f"{app.env.library_shortname} APIs",
+                "items": [
+                    {"name": "Classes", "href": "summary_class.yml"},
+                    {"name": "Methods", "href": "summary_method.yml"},
+                    {"name": "Properties and Attributes", "href": "summary_property.yml"},
+                ],
+            }
+        )
 
     toc_file = os.path.join(normalized_outdir, 'toc.yml')
     with open(toc_file, 'w') as writable:
@@ -2105,9 +2106,11 @@ def build_finished(app, exception):
         file_name_set.add(filename)
 
         for entry in yaml_data:
+            if not app.env.library_shortname:
+                continue
             summary_type = _SUMMARY_TYPE_BY_ITEM_TYPE.get(entry.get("type"))
             if not (summary_type):
-              continue
+                continue
 
             _find_and_add_summary_details(entry, summary_type, cgc_url)
 

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -18,22 +18,22 @@ Sphinx DocFX YAML Top-level Extension.
 
 This extension allows you to automagically generate DocFX YAML from your Python AutoAPI docs.
 """
-import ast
-import os
-import inspect
-import re
-import copy
-import shutil
-import black
-import logging
-import json
 
+import ast
 from collections import defaultdict
-from collections.abc import MutableSet, Mapping, Sequence
-from pathlib import Path
+from collections.abc import Mapping, MutableSet, Sequence
+import copy
 from functools import partial
+import inspect
 from itertools import zip_longest
+import json
+import logging
+import os
+from pathlib import Path
+import re
+import shutil
 from typing import Any, Dict, Iterable, List, Optional
+import black
 from black import InvalidInput
 
 try:
@@ -2107,7 +2107,7 @@ def build_finished(app, exception):
 
         for entry in yaml_data:
             if not app.env.library_shortname:
-                continue
+                break
             summary_type = _SUMMARY_TYPE_BY_ITEM_TYPE.get(entry.get("type"))
             if not (summary_type):
                 continue


### PR DESCRIPTION
I've noticed an issue with the rest of the libraries not being able to properly find the library names from the given Sphinx info.

Seems like I need to extract the `.repo-metadata.json` file directly to source this information - Sphinx has very limited ways to deliver this information through `docs/conf.py`.

Based on the `googleapis/` [repo search](https://github.com/search?q=path%3A**%2F.repo-metadata.json+org%3Agoogleapis+%22%5C%22language%5C%22%3A+%5C%22python%5C%22%2C%22+%22%5C%22name%5C%22%3A+%22+%22%5C%22api_shortname%5C%22%3A+%22&type=code&ref=advsearch&p=1), it seems that using `name` suffices for shortname for the library. If I encounter ones that don't work, I'll create an exception around those few. I've sampled ~100 and seems to work with using `name` instead of `api_shortname`.

Verified that existing library generation demo for bigframes and logging still works.

If the repository metadata could not be retrieved, skip over getting the summary page details.

Fixes b/331977022.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
