### PR TITLE
fix: format enum data into table format

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -1083,7 +1083,7 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
             summary = reformat_summary(summary)
             top_summary = _extract_docstring_info(summary_info, summary, name)
             try:
-                datam['summary'], datam['attributes'], datam['enums'] = (
+                datam['summary'], datam['attributes'], datam['enum'] = (
                     _parse_docstring_summary(top_summary)
                 )
             except ValueError:

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -426,10 +426,12 @@ def _parse_enum_content(parts: Sequence[str]) -> Sequence[Mapping[str, str]]:
                     " docstring:\n\n{}".format("\n".join(parts))
                 )
             # Add the new enum and start collecting new entry.
-            enum_content.append({
-                "var_name": enum_name,
-                "description": "".join(enum_description),
-            })
+            new_entry = {
+                "id": enum_name,
+                "description": " ".join(enum_description),
+            }
+            if all(new_entry.values()):
+                enum_content.append(new_entry)
             enum_description = []
             # Only collect the name, not the value.
             enum_name = part.split(" ")[0]
@@ -442,10 +444,12 @@ def _parse_enum_content(parts: Sequence[str]) -> Sequence[Mapping[str, str]]:
             "The enum docstring is not formatted well. Check the"
             " docstring:\n\n{}".format("\n".join(parts))
         )
-    enum_content.append({
-        "var_name": enum_name,
-        "description": "".join(enum_description),
-    })
+    new_entry = {
+        "id": enum_name,
+        "description": " ".join(enum_description),
+    }
+    if all(new_entry.values()):
+      enum_content.append(new_entry)
 
     return enum_content
 

--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -396,11 +396,82 @@ def indent_code_left(lines, tab_space):
     return "\n".join(parts)
 
 
-def _parse_docstring_summary(summary):
+def _parse_enum_content(parts: Sequence[str]) -> Sequence[Mapping[str, str]]:
+    """Parses the given content for enums.
+
+    Args:
+        parts: The content to parse, given in the form of separated by
+            newlines and left-indented.
+
+    Returns:
+        Sequence of mapping of enum entries for name and description.
+
+    Raises:
+        ValueError: If the `Values` enum docstring is malformed.
+    """
+    enum_content: MutableSequence[Mapping[str, str]] = []
+    enum_name = ""
+    enum_description = []
+    prev_tab_space = -1
+    for part in parts:
+        if (
+            (current_tab_space := len(part) - len(part.lstrip(" "))) == 0 and
+            prev_tab_space != 0
+        ):
+            if prev_tab_space != -1 and (
+                (not enum_name or not enum_description)
+            ):
+                raise ValueError(
+                    "The enum docstring is not formatted well. Check the"
+                    " docstring:\n\n{}".format("\n".join(parts))
+                )
+            # Add the new enum and start collecting new entry.
+            enum_content.append({
+                "var_name": enum_name,
+                "description": "".join(enum_description),
+            })
+            enum_description = []
+            # Only collect the name, not the value.
+            enum_name = part.split(" ")[0]
+        else:
+            enum_description.append(indent_code_left(part, current_tab_space))
+
+    # Add the last entry.
+    if not enum_name or not enum_description:
+        raise ValueError(
+            "The enum docstring is not formatted well. Check the"
+            " docstring:\n\n{}".format("\n".join(parts))
+        )
+    enum_content.append({
+        "var_name": enum_name,
+        "description": "".join(enum_description),
+    })
+
+    return enum_content
+
+
+def _parse_docstring_summary(
+    summary: str,
+) -> tuple[str, Mapping[str, str], Mapping[str, str]]:
+    """
+    Parses the docstring tokens found in the summary.
+
+    Looks for tokens such as codeblocks, attributes, notices and enums.
+
+    Args:
+        summary: The content to parse docstring for.
+
+    Returns:
+        A tuple of the following:
+        * str: The content with parsed docstrings.
+        * Mapping[str, str]: Attribute entries if found.
+        * Mapping[str, str]: Enum entries if found.
+    """
     summary_parts = []
     attributes = []
     attribute_type_token = ":type:"
     enum_type_token = "Values:"
+    enums = []
     keyword = name = description = var_type = ""
 
     notice_open_tag = '<aside class="{notice_tag}">\n<b>{notice_name}:</b>'
@@ -500,14 +571,8 @@ def _parse_docstring_summary(summary):
                 if tab_space == 0:
                     raise ValueError("Content in the block should be indented."\
                                      f"Please check the docstring: \n{summary}")
-                parts = "\n".join(
-                    [indent_code_left(part, tab_space) for part in parts]
-                )
-                summary_parts.append(
-                    "Enum values:\n\n```\n"
-                    f"{parts}"
-                    "\n```\n"
-                )
+                parts = [indent_code_left(part, tab_space) for part in parts]
+                enums = _parse_enum_content(parts)
                 continue
 
             try:
@@ -573,7 +638,7 @@ def _parse_docstring_summary(summary):
             summary_parts.append(notice_close_tag)
 
     # Requires 2 newline chars to properly show on cloud site.
-    return "\n".join(summary_parts), attributes
+    return "\n".join(summary_parts), attributes, enums
 
 
 # Given documentation docstring, parse them into summary_info.
@@ -1014,7 +1079,9 @@ def _create_datam(app, cls, module, name, _type, obj, lines=None):
             summary = reformat_summary(summary)
             top_summary = _extract_docstring_info(summary_info, summary, name)
             try:
-                datam['summary'], datam['attributes'] = _parse_docstring_summary(top_summary)
+                datam['summary'], datam['attributes'], datam['enums'] = (
+                    _parse_docstring_summary(top_summary)
+                )
             except ValueError:
                 debug_line = []
                 if path:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -6,68 +6,77 @@ from parameterized import parameterized
 from yaml import load, Loader
 
 class TestGenerate(unittest.TestCase):
-    def test_find_unique_name(self):
+    def test_finds_unique_name(self):
 
         entries = {}
 
         # Disambiguate with unique entries.
-        entry1 = "google.cloud.aiplatform.v1.schema.predict.instance_v1.types"
-        entry2 = "google.cloud.aiplatform.v1beta2.schema.predict.instance_v1.types"
-        want1 = "v1.types"
-        want2 = "v1beta2.types"
-
-        for entry in [entry1, entry2]:
+        schema_v1_entry = (
+            "google.cloud.aiplatform.v1.schema.predict.instance_v1.types"
+        )
+        schema_v1beta2_entry = (
+            "google.cloud.aiplatform.v1beta2.schema.predict.instance_v1.types"
+        )
+        for entry in [schema_v1_entry, schema_v1beta2_entry]:
             for word in entry.split("."):
                 if word not in entries:
                     entries[word] = 1
                 else:
                     entries[word] += 1
 
-        got1 = extension.find_unique_name(entry1.split("."), entries)
-        got2 = extension.find_unique_name(entry2.split("."), entries)
+        unique_v1_name = extension.find_unique_name(
+            schema_v1_entry.split("."), entries
+        )
+        unique_v1beta2_name = extension.find_unique_name(
+            schema_v1beta2_entry.split("."), entries
+        )
 
-        self.assertEqual(want1, ".".join(got1))
-        self.assertEqual(want2, ".".join(got2))
-
-
-    def test_disambiguate_toc_name(self):
-
-        with open('tests/yaml_post.yaml', 'r') as want_file:
-            yaml_want = load(want_file, Loader=Loader)
-        disambiguated_names_want = {
-            'google.cloud.spanner_admin_database_v1.types': 'spanner_admin_database_v1.types',
-            'google.cloud.spanner_admin_instance_v1.types': 'spanner_admin_instance_v1.types',
-            'google.cloud.spanner_v1.types': 'spanner_v1.types'
-        }
-
-        with open('tests/yaml_pre.yaml', 'r') as test_file:
-            yaml_got = load(test_file, Loader=Loader)
-        disambiguated_names_got = extension.disambiguate_toc_name(yaml_got)
-
-        self.assertEqual(yaml_want, yaml_got)
-        self.assertEqual(disambiguated_names_want, disambiguated_names_got)
+        self.assertEqual("v1.types", ".".join(unique_v1_name))
+        self.assertEqual("v1beta2.types", ".".join(unique_v1beta2_name))
 
 
-    def test_disambiguate_toc_name_duplicate(self):
+    test_entries = [
+        [
+            "tests/yaml_pre.yaml",
+            "tests/yaml_post.yaml",
+            {
+                "google.cloud.spanner_admin_database_v1.types": "spanner_admin_database_v1.types",
+                "google.cloud.spanner_admin_instance_v1.types": "spanner_admin_instance_v1.types",
+                "google.cloud.spanner_v1.types": "spanner_v1.types",
+            },
+        ],
+        [
+            # Tests duplicate names
+            "tests/yaml_pre_duplicate.yaml",
+            "tests/yaml_post_duplicate.yaml",
+            {
+                "google.api_core.client_info": "client_info",
+                "google.api_core.gapic_v1.client_info": "gapic_v1.client_info",
+            },
+        ]
+    ]
+    @parameterized.expand(test_entries)
+    def test_disambiguates_toc_name(
+        self,
+        test_filename,
+        expected_filename,
+        expected_disambiguated_names,
+    ):
+        with open(test_filename, "r") as test_file:
+            test_yaml = load(test_file, Loader=Loader)
+        with open(expected_filename, "r") as expected_yaml_file:
+            expected_yaml = load(expected_yaml_file, Loader=Loader)
 
-        with open('tests/yaml_post_duplicate.yaml', 'r') as want_file:
-            yaml_want = load(want_file, Loader=Loader)
-        disambiguated_names_want = {
-            'google.api_core.client_info': 'client_info',
-            'google.api_core.gapic_v1.client_info': 'gapic_v1.client_info'
-        }
+        disambiguated_names = extension.disambiguate_toc_name(
+            test_yaml
+        )
 
-        with open('tests/yaml_pre_duplicate.yaml', 'r') as test_file:
-            yaml_got = load(test_file, Loader=Loader)
-        disambiguated_names_got = extension.disambiguate_toc_name(yaml_got)
+        self.assertEqual(expected_yaml, test_yaml)
+        self.assertEqual(expected_disambiguated_names, disambiguated_names)
 
-
-        self.assertEqual(yaml_want, yaml_got)
-        self.assertEqual(disambiguated_names_want, disambiguated_names_got)
-
-
-    def test_reference_in_summary(self):
-        lines_got = """
+    test_entries = [
+        [
+            """
 If a ``stream`` is attached to this download, then the downloaded
 resource will be written to the stream.
 
@@ -87,22 +96,12 @@ Returns:
     ~google.cloud.requests.Response: The HTTP response returned by ``transport``.
 
 Raises:
-    ~google.cloud.resumable_media.common.DataCorruption: If the download's
+    ~google.cloud.resumable_media.common.DataCorruption: If the download"s
         checksum doesn't agree with server-computed checksum.
     ValueError: If the current :class:`Download` has already
         finished.
-"""
-        lines_got = lines_got.split("\n")
-        xrefs_got = []
-        # Resolve over different regular expressions for different types of reference patterns.
-        lines_got, xrefs = extension._resolve_reference_in_module_summary(extension.REF_PATTERN, lines_got)
-        for xref in xrefs:
-            xrefs_got.append(xref)
-        lines_got, xrefs = extension._resolve_reference_in_module_summary(extension.REF_PATTERN_LAST, lines_got)
-        for xref in xrefs:
-            xrefs_got.append(xref)
-
-        lines_want = """
+            """,
+            """
 If a ``stream`` is attached to this download, then the downloaded
 resource will be written to the stream.
 
@@ -122,28 +121,20 @@ Returns:
     <xref uid="google.cloud.requests.Response">Response</xref>: The HTTP response returned by ``transport``.
 
 Raises:
-    <xref uid="google.cloud.resumable_media.common.DataCorruption">DataCorruption</xref>: If the download's
+    <xref uid="google.cloud.resumable_media.common.DataCorruption">DataCorruption</xref>: If the download"s
         checksum doesn't agree with server-computed checksum.
     ValueError: If the current `Download` has already
         finished.
-"""
-        lines_want = lines_want.split("\n")
-        xrefs_want = [
-          "google.cloud.requests.Session",
-          "google.cloud.requests.Session.request",
-          "google.cloud.requests.Response",
-          "google.cloud.resumable_media.common.DataCorruption"
-        ]
-
-        self.assertEqual(lines_got, lines_want)
-        self.assertCountEqual(xrefs_got, xrefs_want)
-        # assertCountEqual is a misleading name but checks that two lists contain
-        # same items regardless of order, as long as items in list are sortable.
-
-
-    # Test for added xref coverage and third party xrefs staying as-is
-    def test_reference_in_summary_more_xrefs(self):
-        lines_got = """
+            """,
+            [
+                "google.cloud.requests.Session",
+                "google.cloud.requests.Session.request",
+                "google.cloud.requests.Response",
+                "google.cloud.resumable_media.common.DataCorruption",
+            ],
+        ],
+        [
+            """
 If a ~dateutil.time.stream() is attached to this download, then the downloaded
 resource will be written to the stream.
 
@@ -158,18 +149,8 @@ Args:
 
         Can also be passed as a :func:`~google.cloud.requests.tuple()` (connect_timeout, read_timeout).
         See :meth:`google.cloud.requests.Session.request()` documentation for details.
-"""
-        lines_got = lines_got.split("\n")
-        xrefs_got = []
-        # Resolve over different regular expressions for different types of reference patterns.
-        lines_got, xrefs = extension._resolve_reference_in_module_summary(extension.REF_PATTERN, lines_got)
-        for xref in xrefs:
-            xrefs_got.append(xref)
-        lines_got, xrefs = extension._resolve_reference_in_module_summary(extension.REF_PATTERN_LAST, lines_got)
-        for xref in xrefs:
-            xrefs_got.append(xref)
-
-        lines_want = """
+            """,
+            """
 If a `dateutil.time.stream()` is attached to this download, then the downloaded
 resource will be written to the stream.
 
@@ -184,92 +165,82 @@ Args:
 
         Can also be passed as a <xref uid="google.cloud.requests.tuple">tuple()</xref> (connect_timeout, read_timeout).
         See <xref uid="google.cloud.requests.Session.request">request()</xref> documentation for details.
-"""
-        lines_want = lines_want.split("\n")
-        xrefs_want = [
-          "google.cloud.requests.Session",
-          "google.cloud.requests.tuple",
-          "google.cloud.requests.Session.request"
-        ]
-
-        self.assertEqual(lines_got, lines_want)
-        self.assertCountEqual(xrefs_got, xrefs_want)
-        # assertCountEqual is a misleading name but checks that two lists contain
-        # same items regardless of order, as long as items in list are sortable.
-
-
-    # Variables used for testing _extract_docstring_info
-    top_summary1_want = "\nSimple test for docstring.\n\n"
-    summary_info1_want = {
-        'variables': {
-            'arg1': {
-                'var_type': 'int',
-                'description': 'simple description.'
-            },
-            'arg2': {
-                'var_type': 'str',
-                'description': 'simple description for `arg2`.'
-            }
-        },
-        'returns': [
-            {
-                'var_type': 'str', 
-                'description': 'simple description for return value.'
-            }
+            """,
+            [
+              "google.cloud.requests.Session",
+              "google.cloud.requests.tuple",
+              "google.cloud.requests.Session.request",
+            ],
         ],
-        'exceptions': [
-            {
-                'var_type': 'AttributeError', 
-                'description': 'if `condition x`.'
-            }
-        ]
-    }
+    ]
+    @parameterized.expand(test_entries)
+    def test_resolves_references_in_summary(
+        self,
+        test_docstring,
+        expected_content,
+        expected_xrefs,
+    ):
+        xrefs_to_check = []
+        # Resolve over different regular expressions for different types of reference patterns.
+        content_to_resolve, xrefs = (
+            extension._resolve_reference_in_module_summary(
+                extension.REF_PATTERN,
+                test_docstring.split("\n"),
+            )
+        )
+        xrefs_to_check.extend(xrefs)
+
+        resolved_content, xrefs = (
+            extension._resolve_reference_in_module_summary(
+                extension.REF_PATTERN_LAST,
+                content_to_resolve,
+            )
+        )
+        xrefs_to_check.extend(xrefs)
+
+        self.assertEqual(resolved_content, expected_content.split("\n"))
+        self.assertCountEqual(xrefs_to_check, expected_xrefs)
 
 
-    # Test for resolving square bracketed references.
-    def test_reference_square_brackets(self):
-        xrefs_want = [
-            'google.cloud.kms.v1.KeyRing.name',
-            'google.cloud.kms.v1.KeyRing',
-            'google.cloud.kms.v1.ImportJob',
+    def test_resolves_square_bracket_references(self):
+        expected_xrefs = [
+            "google.cloud.kms.v1.KeyRing.name",
+            "google.cloud.kms.v1.KeyRing",
+            "google.cloud.kms.v1.ImportJob",
         ]
-        summary_want = """Required.
+        summary_expected = """Required.
 
 The <xref uid="google.cloud.kms.v1.KeyRing.name">name</xref> of the <xref uid="google.cloud.kms.v1.KeyRing">KeyRing</xref> associated with the <xref uid="google.cloud.kms.v1.ImportJob">ImportJobs</xref>.
 """
-        summary_want = summary_want.split("\n")
-
         summary = """Required.
 
 The [name][google.cloud.kms.v1.KeyRing.name] of the [KeyRing][google.cloud.kms.v1.KeyRing] associated with the [ImportJobs][google.cloud.kms.v1.ImportJob].
 """
-        summary = summary.split("\n")
+        resolved_summary, xrefs = (
+            extension._resolve_reference_in_module_summary(
+                extension.REF_PATTERN_BRACKETS,
+                summary.split("\n"),
+            )
+        )
 
-        summary_got, xrefs_got = extension._resolve_reference_in_module_summary(extension.REF_PATTERN_BRACKETS, summary)
-
-        self.assertEqual(summary_got, summary_want)
-        self.assertCountEqual(xrefs_got, xrefs_want)
+        self.assertEqual(resolved_summary, summary_expected.split("\n"))
+        self.assertCountEqual(xrefs, expected_xrefs)
 
 
-    # Check that other patterns throws an exception.
-    def test_reference_check_error(self):
+    def test_raises_error_for_invalid_references(self):
         with self.assertRaises(ValueError):
-            extension._resolve_reference_in_module_summary('.*', 'not a valid ref line'.split('\n'))
+            extension._resolve_reference_in_module_summary(
+                ".*",
+                "not a valid ref line".split("\n"),
+            )
 
 
-    def test_extract_docstring_info_normal_input(self):
-
-        ## Test for normal input
-        summary_info1_got = {
-            'variables': {},
-            'returns': [],
-            'exceptions': []
-        }
-
-        summary1 = """
+    test_entries = [
+        [
+            """
 Simple test for docstring.
 
-Args: 
+Args:
     arg1(int): simple description.
     arg2(str): simple description for `arg2`.
 
@@ -278,17 +249,32 @@ Returns:
 
 Raises:
     AttributeError: if `condition x`.
-"""
-
-        top_summary1_got = extension._extract_docstring_info(summary_info1_got, summary1, "")
-
-        self.assertEqual(top_summary1_got, self.top_summary1_want)
-        self.assertEqual(summary_info1_got, self.summary_info1_want)
-
-
-    def test_extract_docstring_info_mixed_format(self):
-        ## Test for input coming in mixed format.
-        summary2 = """
+            """,
+            "\nSimple test for docstring.\n\n",
+            {
+                "variables": {
+                    "arg1": {
+                        "var_type": "int",
+                        "description": "simple description.",
+                    },
+                    "arg2": {
+                        "var_type": "str",
+                        "description": "simple description for `arg2`.",
+                    },
+                },
+                "returns": [{
+                    "var_type": "str",
+                    "description": "simple description for return value.",
+                }],
+                "exceptions": [{
+                    "var_type": "AttributeError",
+                    "description": "if `condition x`.",
+                }],
+            },
+        ],
+        [
+            # Tests summary in mixed format
+            """
 Simple test for docstring.
 
 :type arg1: int
@@ -299,102 +285,58 @@ Simple test for docstring.
 :rtype: str
 :returns: simple description for return value.
 
-:raises AttributeError: if `condition x`. 
-"""
+:raises AttributeError: if `condition x`.
+            """,
+            "\nSimple test for docstring.\n\n",
+            {
+                "variables": {
+                    "arg1": {
+                        "var_type": "int",
+                        "description": "simple description.",
+                    },
+                    "arg2": {
+                        "var_type": "str",
+                        "description": "simple description for `arg2`.",
+                    },
+                },
+                "returns": [{
+                    "var_type": "str",
+                    "description": "simple description for return value.",
+                }],
+                "exceptions": [{
+                    "var_type": "AttributeError",
+                    "description": "if `condition x`.",
+                }],
+            },
 
-        summary_info2_got = {
-            'variables': {},
-            'returns': [],
-            'exceptions': []
-        }
-
-        top_summary2_got = extension._extract_docstring_info(summary_info2_got, summary2, "")
-        
-        # Output should be same as test 1 with normal input.
-        self.assertEqual(top_summary2_got, self.top_summary1_want)
-        self.assertEqual(summary_info2_got, self.summary_info1_want)
-
-        
-    def test_extract_docstring_info_check_parser(self):
-        ## Test for parser to correctly scan docstring tokens and not custom fields
-        summary_info3_want = {
-            'variables': {},
-            'returns': [],
-            'exceptions': []
-        }
-
-        summary3 = """
+        ],
+        [
+            # Tests summary for docstring tokens and not custom fields
+            """
 Union[int, None]: Expiration time in milliseconds for a partition.
 
 If :attr:`partition_expiration` is set and <xref:type_> is
 not set, :attr:`type_` will default to
 :attr:`~google.cloud.bigquery.table.TimePartitioningType.DAY`.
 It could return :param: with :returns as well.
-"""
+            """,
+            """
+Union[int, None]: Expiration time in milliseconds for a partition.
 
-        summary_info3_got = {
-            'variables': {},
-            'returns': [],
-            'exceptions': []
-        }
-
-        # Nothing should change
-        top_summary3_want = summary3
-
-        top_summary3_got = extension._extract_docstring_info(summary_info3_got, summary3, "")
-
-        self.assertEqual(top_summary3_got, top_summary3_want)
-        self.assertEqual(summary_info3_got, summary_info3_want)
-
-
-    def test_extract_docstring_info_check_error(self):
-        ## Test for incorrectly formmatted docstring raising error
-        summary4 = """
-Description of docstring which should fail. 
-
-:returns:param:
-"""
-        with self.assertRaises(ValueError):
-            extension._extract_docstring_info({}, summary4, "error string")
-
-        summary5 = """
-Description of malformed docstring.
-
-Raises:
-    Error that should fail: if condition `x`.
-"""
-        with self.assertRaises(KeyError):
-            extension._extract_docstring_info({}, summary5, "malformed docstring")
-
-
-    def test_extract_docstring_info_with_xref(self):
-        ## Test with xref included in the summary, ensure they're processed as-is
-        summary_info_want = {
-            'variables': {
-                'arg1': {
-                    'var_type': '<xref uid="google.spanner_v1.type.Type">Type</xref>',
-                    'description': 'simple description.'
-                },
-                'arg2': {
-                    'var_type': '~google.spanner_v1.type.dict',
-                    'description': 'simple description for `arg2`.'
-                }
-            },
-            'returns': [
-                {
-                    'var_type': '<xref uid="Pair">Pair</xref>', 
-                    'description': 'simple description for return value.'
-                }
-            ],
-            'exceptions': [
-                {
-                    'var_type': '<xref uid="SpannerException">SpannerException</xref>', 
-                    'description': 'if `condition x`.'
-                }
-            ]
-        }
-
-        summary = """
+If :attr:`partition_expiration` is set and <xref:type_> is
+not set, :attr:`type_` will default to
+:attr:`~google.cloud.bigquery.table.TimePartitioningType.DAY`.
+It could return :param: with :returns as well.
+            """,
+            {
+                "variables": {},
+                "returns": [],
+                "exceptions": [],
+            }
+        ],
+        [
+            # Tests summary with xrefs
+            """
 Simple test for docstring.
 
 :type arg1: <xref uid="google.spanner_v1.type.Type">Type</xref>
@@ -405,25 +347,34 @@ Simple test for docstring.
 :rtype: <xref uid="Pair">Pair</xref>
 :returns: simple description for return value.
 
-:raises <xref uid="SpannerException">SpannerException</xref>: if `condition x`. 
-"""
-
-        summary_info_got = {
-            'variables': {},
-            'returns': [],
-            'exceptions': []
-        }
-
-        top_summary_got = extension._extract_docstring_info(summary_info_got, summary, "")
-        # Same as the top summary from previous example, compare with that
-        self.assertEqual(top_summary_got, self.top_summary1_want)
-        self.assertDictEqual(summary_info_got, summary_info_want)
-
-
-    def test_extract_docstring_info_no_summary(self):
-        ## Test parsing docstring with no summary.
-        summary =(
-"""Args:
+:raises <xref uid="SpannerException">SpannerException</xref>: if `condition x`.
+            """,
+            "\nSimple test for docstring.\n\n",
+            {
+                "variables": {
+                    "arg1": {
+                        "var_type": "<xref uid=\"google.spanner_v1.type.Type\">Type</xref>",
+                        "description": "simple description.",
+                    },
+                    "arg2": {
+                        "var_type": "~google.spanner_v1.type.dict",
+                        "description": "simple description for `arg2`.",
+                    },
+                },
+                "returns": [{
+                    "var_type": "<xref uid=\"Pair\">Pair</xref>",
+                    "description": "simple description for return value.",
+                }],
+                "exceptions": [{
+                    "var_type": "<xref uid=\"SpannerException\">SpannerException</xref>",
+                    "description": "if `condition x`.",
+                }],
+            },
+        ],
+        [
+            # Tests docstring without a summary
+            """
+Args:
     arg1(int): simple description.
     arg2(str): simple description for `arg2`.
 
@@ -432,37 +383,102 @@ Returns:
 
 Raises:
     AttributeError: if `condition x`.
-"""
-        )
-        summary_info_got = {
-            'variables': {},
-            'returns': [],
-            'exceptions': []
+            """,
+            "\n",
+            {
+                "variables": {
+                    "arg1": {
+                        "var_type": "int",
+                        "description": "simple description.",
+                    },
+                    "arg2": {
+                        "var_type": "str",
+                        "description": "simple description for `arg2`.",
+                    },
+                },
+                "returns": [{
+                    "var_type": "str",
+                    "description": "simple description for return value.",
+                }],
+                "exceptions": [{
+                    "var_type": "AttributeError",
+                    "description": "if `condition x`.",
+                }],
+            },
+
+        ],
+    ]
+    @parameterized.expand(test_entries)
+    def test_extracts_docstring_info(
+        self,
+        summary,
+        expected_top_summary,
+        expected_summary_info
+    ):
+        summary_info = {
+            "variables": {},
+            "returns": [],
+            "exceptions": []
         }
 
-        top_summary_got = extension._extract_docstring_info(summary_info_got, summary, "")
-        self.assertEqual(top_summary_got, "")
-        self.assertDictEqual(summary_info_got, self.summary_info1_want)
+        top_summary = extension._extract_docstring_info(
+            summary_info,
+            summary,
+            "",
+        )
+
+        self.assertEqual(top_summary, expected_top_summary)
+        self.assertDictEqual(summary_info, expected_summary_info)
 
 
-    def test_find_package_group(self):
-        package_group_want = "google.cloud.spanner_v1beta2"
+    test_entries = [
+        [
+            """
+Description of docstring which should fail.
+
+:returns:param:
+            """,
+            ValueError,
+            "Error string",
+        ],
+        [
+            """
+Description of malformed docstring.
+
+Raises:
+    Error that should fail: if condition `x`.
+            """,
+            KeyError,
+            "Malformed docstring",
+        ],
+    ]
+    @parameterized.expand(test_entries)
+    def test_raises_error_extracting_malformed_docstring(
+        self,
+        summary,
+        error_type,
+        error_string,
+    ):
+        with self.assertRaises(error_type):
+            extension._extract_docstring_info({}, summary, error_string)
+
+
+    def test_finds_package_group(self):
         uid = "google.cloud.spanner_v1beta2.services.admin_database_v1.types"
 
-        package_group_got = extension.find_package_group(uid)
-        self.assertEqual(package_group_got, package_group_want)
+        package_group = extension.find_package_group(uid)
+        self.assertEqual(package_group, "google.cloud.spanner_v1beta2")
 
 
-    def test_pretty_package_name(self):
-        package_name_want = "Spanner V1beta2"
+    def test_finds_pretty_package_name(self):
         package_group = "google.cloud.spanner_v1beta2"
 
-        package_name_got = extension.pretty_package_name(package_group)
-        self.assertEqual(package_name_got, package_name_want)
+        package_name = extension.pretty_package_name(package_group)
+        self.assertEqual(package_name, "Spanner V1beta2")
 
 
-    def test_group_by_package(self):
-        toc_yaml_want = [
+    def test_groups_by_package(self):
+        [
             {
                 "name": "Spanner Admin Database V1",
                 "uidname":"google.cloud.spanner_admin_database_v1",
@@ -576,15 +592,97 @@ Raises:
             }
         ]
 
-        toc_yaml_got = extension.group_by_package(toc_yaml)
+        toc_yaml = extension.group_by_package(toc_yaml)
 
-        self.assertCountEqual(toc_yaml_got, toc_yaml_want)
+        self.assertCountEqual(
+            toc_yaml,
+            [
+                {
+                    "name": "Spanner Admin Database V1",
+                    "uidname":"google.cloud.spanner_admin_database_v1",
+                    "items": [{
+                        "name":"database_admin",
+                        "uidname":"google.cloud.spanner_admin_database_v1.services.database_admin",
+                        "items": [{
+                            "name":"Overview",
+                            "uidname":"google.cloud.spanner_admin_database_v1.services.database_admin",
+                            "uid":"google.cloud.spanner_admin_database_v1.services.database_admin"
+                        },
+                        {
+                            "name":"ListBackupOperationsAsyncPager",
+                            "uidname":"google.cloud.spanner_admin_database_v1.services.database_admin.pagers.ListBackupOperationsAsyncPager",
+                            "uid":"google.cloud.spanner_admin_database_v1.services.database_admin.pagers.ListBackupOperationsAsyncPager",
+                        }],
+                    },
+                    {
+                        "name":"spanner_admin_database_v1.types",
+                        "uidname":"google.cloud.spanner_admin_database_v1.types",
+                        "items": [{
+                            "name":"Overview",
+                            "uidname":"google.cloud.spanner_admin_database_v1.types",
+                            "uid":"google.cloud.spanner_admin_database_v1.types",
+                        },
+                        {
+                            "name":"BackupInfo",
+                            "uidname":"google.cloud.spanner_admin_database_v1.types.BackupInfo",
+                            "uid":"google.cloud.spanner_admin_database_v1.types.BackupInfo",
+                        }],
+                    }],
+                },
+                {
+                    "name": "Spanner V1",
+                    "uidname":"google.cloud.spanner_v1",
+                    "items": [{
+                        "name":"pool",
+                        "uidname":"google.cloud.spanner_v1.pool",
+                        "items": [{
+                            "name":"Overview",
+                            "uidname":"google.cloud.spanner_v1.pool",
+                            "uid":"google.cloud.spanner_v1.pool"
+                        },
+                        {
+                            "name":"AbstractSessionPool",
+                            "uidname":"google.cloud.spanner_v1.pool.AbstractSessionPool",
+                            "uid":"google.cloud.spanner_v1.pool.AbstractSessionPool",
+                        }],
+                    }],
+                },
+            ]
+        )
 
 
-    def test_parse_docstring_summary(self):
-        # Check that the summary gets parsed correctly.
-        attributes_want = []
-        summary_want = \
+    test_entries = [
+        [
+            (\
+"""
+
+
+.. code-block:: python
+
+\n    from google.api_core.client_options import ClientOptions
+\n    from google.cloud.vision_v1 import ImageAnnotatorClient
+\n    def get_client_cert():
+\n        # code to load client certificate and private key.
+\n        return client_cert_bytes, client_private_key_bytes
+\n    options = ClientOptions(api_endpoint=\"foo.googleapis.com\",
+\n        client_cert_source=get_client_cert)
+\n    client = ImageAnnotatorClient(client_options=options)
+
+
+You can also pass a mapping object.
+
+
+\n.. code-block:: ruby
+
+\n    from google.cloud.vision_v1 import ImageAnnotatorClient
+\n    client = ImageAnnotatorClient(
+\n        client_options={
+\n            \"api_endpoint\": \"foo.googleapis.com\",
+\n            \"client_cert_source\" : get_client_cert
+\n        })
+"""
+            ),
+            (\
 """```python
 from google.api_core.client_options import ClientOptions
 
@@ -620,86 +718,31 @@ client = ImageAnnotatorClient(
 
 ```
 """
-        summary = \
-"""
-
-
-.. code-block:: python
-
-\n    from google.api_core.client_options import ClientOptions
-\n    from google.cloud.vision_v1 import ImageAnnotatorClient
-\n    def get_client_cert():
-\n        # code to load client certificate and private key.
-\n        return client_cert_bytes, client_private_key_bytes
-\n    options = ClientOptions(api_endpoint=\"foo.googleapis.com\",
-\n        client_cert_source=get_client_cert)
-\n    client = ImageAnnotatorClient(client_options=options)
-
-
-You can also pass a mapping object.
-
-
-\n.. code-block:: ruby
-
-\n    from google.cloud.vision_v1 import ImageAnnotatorClient
-\n    client = ImageAnnotatorClient(
-\n        client_options={
-\n            \"api_endpoint\": \"foo.googleapis.com\",
-\n            \"client_cert_source\" : get_client_cert
-\n        })
-"""
-        summary_got, attributes_got, enums_got = (
-            extension._parse_docstring_summary(summary)
-        )
-        self.assertEqual(summary_got, summary_want)
-        self.assertEqual(attributes_got, attributes_want)
-
-        # Check that nothing much changes otherwise.
-        summary = \
+            ),
+        ],
+        [
+            # Check that nothing changes for literalincludes.
+            (\
 """
 .. literalinclude::
     note that these are not supported yet, so they will be ignored for now.
 
 And any other documentation that the source code would have could go here.
 """
-        summary_want = summary + "\n"
-
-        summary_got, attributes_got, enums_got = (
-            extension._parse_docstring_summary(summary)
-        )
-        self.assertEqual(summary_got, summary_want)
-        self.assertEqual(attributes_got, attributes_want)
-
-        # Check that exception is raised if code block is not indented.
-        summary = \
+            ),
+            (\
 """
+.. literalinclude::
+    note that these are not supported yet, so they will be ignored for now.
 
+And any other documentation that the source code would have could go here.
 
-.. code:: python
-
-\nprint("This should throw an exception.")
-\nfor i in range(10):
-\n    print(i)
 """
-        with self.assertRaises(ValueError):
-            extension._parse_docstring_summary(summary)
-
-        # Check that notices are processed properly.
-        summary_want = \
-"""<aside class="note">
-<b>Note:</b>
-this is a note.
-</aside>
-<aside class="caution">
-<b>Caution:</b>
-another type of notice.
-</aside>
-<aside class="key-term">
-<b>Key Term:</b>
-hyphenated term notice.
-</aside>"""
-
-        summary = \
+            ),
+        ],
+        [
+            # Tests notices are processed properly.
+            (\
 """
 .. note::
 \n    this is a note.
@@ -712,33 +755,84 @@ hyphenated term notice.
 .. key-term::
 \n    hyphenated term notice.
 """
-
-        summary_got, attributes_got, enums_got = (
+            ),
+            (\
+"""<aside class="note">
+<b>Note:</b>
+this is a note.
+</aside>
+<aside class="caution">
+<b>Caution:</b>
+another type of notice.
+</aside>
+<aside class="key-term">
+<b>Key Term:</b>
+hyphenated term notice.
+</aside>"""
+            ),
+        ],
+    ]
+    @parameterized.expand(test_entries)
+    def test_parses_docstring_summary(
+        self,
+        summary,
+        expected_summary,
+    ):
+        parsed_summary, attributes, enums = (
             extension._parse_docstring_summary(summary)
         )
-        self.assertEqual(summary_got, summary_want)
-        self.assertEqual(attributes_got, attributes_want)
+        self.assertEqual(parsed_summary, expected_summary)
+        self.assertEqual(attributes, [])
+        self.assertEqual(enums, [])
 
-        # Check that exception is raised if block is not formatted properly.
 
-        summary = \
+    test_entries = [
+        [
+            (\
+"""
+
+
+.. code:: python
+
+\nprint("This should throw an exception.")
+\nfor i in range(10):
+\n    print(i)
+"""
+            ),
+            ValueError,
+        ],
+        [
+            (\
 """
 .. warning::
 this is not a properly formatted warning.
 """
-        with self.assertRaises(ValueError):
+            ),
+            ValueError,
+        ],
+        [
+            (\
+"""
+Values:
+BAD_FORMATTING (-1): this is not properly formatted enum.
+"""
+            ),
+            ValueError,
+        ],
+    ]
+    @parameterized.expand(test_entries)
+    def test_raises_error_parsing_malformed_docstring(
+        self,
+        summary,
+        error_type
+    ):
+        with self.assertRaises(error_type):
             extension._parse_docstring_summary(summary)
 
-    def test_parse_docstring_summary_attributes(self):
-        # Test parsing docstring with attributes.
-        attributes_want = [
-            {
-                "id": "simple name",
-                "description": "simple description",
-                "var_type": 'str'
-            }
-        ]
-        summary = \
+
+    test_entries = [
+        [
+            (\
 """
 
 
@@ -748,27 +842,17 @@ this is not a properly formatted warning.
 
 \n:type: str
 """
-
-        summary_got, attributes_got, enums_got = (
-            extension._parse_docstring_summary(summary)
-        )
-        self.assertCountEqual(attributes_got, attributes_want)
-
-        # Check multiple attributes are parsed.
-        attributes_want = [
-            {
+            ),
+            [{
                 "id": "simple name",
                 "description": "simple description",
-                "var_type": "str"
-            },
-            {
-                "id": "table_insert_request",
-                "description": "Table insert request.",
-                "var_type": "google.cloud.bigquery_logging_v1.types.TableInsertRequest"
-            }
-        ]
-
-        summary = \
+                "var_type": "str",
+            }],
+            [],
+        ],
+        [
+            # Tests for multiple attributes.
+            (\
 """
 
 
@@ -785,23 +869,22 @@ this is not a properly formatted warning.
 
 \n:type: google.cloud.bigquery_logging_v1.types.TableInsertRequest
 """
-        summary_got, attributes_got, enums_got = (
-            extension._parse_docstring_summary(summary)
-        )
-
-        self.assertCountEqual(attributes_got, attributes_want)
-        for attribute_got, attribute_want in zip(attributes_got, attributes_want):
-            self.assertDictEqual(attribute_got, attribute_want)
-
-        # Check only attributes in valid format gets parsed.
-        attributes_want = [
+            ),
+            [{
+                "id": "simple name",
+                "description": "simple description",
+                "var_type": "str",
+            },
             {
-                "id": "proper name",
-                "description": "proper description.",
-                "var_type": "str"
-            }
-        ]
-        summary = \
+                "id": "table_insert_request",
+                "description": "Table insert request.",
+                "var_type": "google.cloud.bigquery_logging_v1.types.TableInsertRequest",
+            }],
+            [],
+        ],
+        [
+            # Tests only attributes in valid format are parsed.
+            (\
 """
 
 
@@ -818,84 +901,339 @@ this is not a properly formatted warning.
 
 \n:type: str
 """
-        summary_got, attributes_got, enums_got = (
-            extension._parse_docstring_summary(summary)
-        )
+            ),
+            [{
+                "id": "proper name",
+                "description": "proper description.",
+                "var_type": "str",
+            }],
+            [],
+        ],
+        [
+            # Tests enums are parsed.
+            (\
+"""
+Values:
+    EMPLOYMENT_TYPE_UNSPECIFIED (0):
+        The default value if the employment type isn't specified.
+    FULL_TIME (1):
+        The job requires working a number of hours that constitute full time
+        employment, typically 40 or more hours per week.
+    PART_TIME (2):
+        The job entails working fewer hours than a full time job,
+        typically less than 40 hours a week.
+"""
+            ),
+            [],
+            [
+                {
+                    "id": "EMPLOYMENT_TYPE_UNSPECIFIED",
+                    "description": (
+                        "The default value if the employment type isn't"
+                        " specified."
+                    ),
+                },
+                {
+                    "id": "FULL_TIME",
+                    "description": (
+                        "The job requires working a number of hours that"
+                        " constitute full time employment, typically 40 or"
+                        " more hours per week."
+                    ),
+                },
+                {
+                    "id": "PART_TIME",
+                    "description": (
+                        "The job entails working fewer hours than a full"
+                        " time job, typically less than 40 hours a week."
+                    ),
+                },
 
-        # Check that we are returned only one item.
-        self.assertCountEqual(attributes_got, attributes_want)
-        for attribute_got, attribute_want in zip(attributes_got, attributes_want):
-            self.assertDictEqual(attribute_got, attribute_want)
+            ],
+        ],
+    ]
+    @parameterized.expand(test_entries)
+    def test_parses_docstring_summary_for_attributes_and_enums(
+        self,
+        summary,
+        expected_attributes,
+        expected_enums,
+    ):
+        self.maxDiff = None
+        _, attributes, enums = extension._parse_docstring_summary(summary)
+
+        self.assertCountEqual(attributes, expected_attributes)
+        self.assertCountEqual(enums, expected_enums)
+
+        for attribute, expected_attribute in zip(
+            attributes, expected_attributes
+        ):
+            self.assertDictEqual(attribute, expected_attribute)
+        for enum, expected_enum in zip(
+            enums, expected_enums
+        ):
+            self.assertDictEqual(enum, expected_enum)
 
 
-    def test_merge_markdown_and_package_toc(self):
-        known_uids = {'acl','batch','blob','client','constants','fileio','hmac_key','notification','retry'}
+    def test_merges_markdown_and_package_toc(self):
+        known_uids = {
+            "acl",
+            "batch",
+            "blob",
+            "client",
+            "constants",
+            "fileio",
+            "hmac_key",
+            "notification",
+            "retry",
+        }
         markdown_pages = {
-            'storage': [
-                {'name': 'FileIO', 'href': 'fileio.md'},
-                {'name': 'Retry', 'href': 'retry.md'},
-                {'name': 'Notification', 'href': 'notification.md'},
-                {'name': 'HMAC Key Metadata', 'href': 'hmac_key.md'},
-                {'name': 'Batches', 'href': 'batch.md'},
-                {'name': 'Constants', 'href': 'constants.md'},
-                {'name': 'Storage Client', 'href': 'client.md'},
-                {'name': 'Blobs / Objects', 'href': 'blobs.md'}
+            "storage": [
+                {"name": "FileIO", "href": "fileio.md"},
+                {"name": "Retry", "href": "retry.md"},
+                {"name": "Notification", "href": "notification.md"},
+                {"name": "HMAC Key Metadata", "href": "hmac_key.md"},
+                {"name": "Batches", "href": "batch.md"},
+                {"name": "Constants", "href": "constants.md"},
+                {"name": "Storage Client", "href": "client.md"},
+                {"name": "Blobs / Objects", "href": "blobs.md"}
             ],
-            'acl': [
-                {'name': 'ACL', 'href': 'acl.md'},
-                {'name': 'ACL guide', 'href': 'acl_guide.md'}
+            "acl": [
+                {"name": "ACL", "href": "acl.md"},
+                {"name": "ACL guide", "href": "acl_guide.md"}
             ],
-            '/': [
-                {'name': 'Overview', 'href': 'index.md'},
-                {'name': 'Changelog', 'href': 'changelog.md'}
+            "/": [
+                {"name": "Overview", "href": "index.md"},
+                {"name": "Changelog", "href": "changelog.md"}
             ],
         }
         pkg_toc_yaml = [
-            {'name': 'Storage',
-                'items': [
-                    {'name': 'acl', 'uid': 'google.cloud.storage.acl', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.acl'}]},
-                    {'name': 'batch', 'uid': 'google.cloud.storage.batch', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.batch'}]},
-                    {'name': 'blob', 'uid': 'google.cloud.storage.blob', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.blob'}]},
-                    {'name': 'bucket', 'uid': 'google.cloud.storage.bucket', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.bucket'}]},
-                    {'name': 'client', 'uid': 'google.cloud.storage.client', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.client'}]},
-                    {'name': 'constants', 'uid': 'google.cloud.storage.constants'},
-                    {'name': 'fileio', 'uid': 'google.cloud.storage.fileio', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.fileio'}]},
-                    {'name': 'hmac_key', 'uid': 'google.cloud.storage.hmac_key', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.hmac_key'}]},
-                    {'name': 'notification', 'uid': 'google.cloud.storage.notification', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.notification'}]},
-                    {'name': 'retry', 'uid': 'google.cloud.storage.retry', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.retry'}]},
-                ]
+            {"name": "Storage",
+                "items": [
+                    {
+                        "name": "acl",
+                        "uid": "google.cloud.storage.acl",
+                        "items": [
+                            {
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.acl",
+                            },
+                        ],
+                    },
+                    {
+                        "name": "batch",
+                        "uid": "google.cloud.storage.batch",
+                        "items": [
+                            {
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.batch",
+                            },
+                        ],
+                    },
+                    {
+                        "name": "blob",
+                        "uid": "google.cloud.storage.blob",
+                        "items": [
+                            {
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.blob",
+                            },
+                        ],
+                    },
+                    {
+                        "name": "bucket",
+                        "uid": "google.cloud.storage.bucket",
+                        "items": [
+                            {
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.bucket",
+                            },
+                        ],
+                    },
+                    {
+                        "name": "client",
+                        "uid": "google.cloud.storage.client",
+                        "items": [
+                            {
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.client",
+                            },
+                        ],
+                    },
+                    {
+                        "name": "constants",
+                        "uid": "google.cloud.storage.constants",
+                    },
+                    {
+                        "name": "fileio",
+                        "uid": "google.cloud.storage.fileio",
+                        "items": [
+                            {
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.fileio",
+                            },
+                        ],
+                    },
+                    {
+                        "name": "hmac_key",
+                        "uid": "google.cloud.storage.hmac_key",
+                        "items": [
+                            {
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.hmac_key",
+                            },
+                        ],
+                    },
+                    {
+                        "name": "notification",
+                        "uid": "google.cloud.storage.notification",
+                        "items": [
+                            {
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.notification"},
+                        ],
+                    },
+                    {
+                        "name": "retry",
+                        "uid": "google.cloud.storage.retry",
+                        "items": [
+                            {
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.retry",
+                            },
+                        ],
+                    },
+                ],
              },
         ]
 
         added_pages, merged_pkg_toc_yaml = extension.merge_markdown_and_package_toc(
-            pkg_toc_yaml, markdown_pages, known_uids)
+            pkg_toc_yaml, markdown_pages, known_uids
+        )
 
-        expected_added_pages = {'index.md', 'changelog.md', 'blobs.md', 'acl_guide.md'}
         expected_merged_pkg_toc_yaml = [
-            {'name': 'Overview', 'href': 'index.md'},
-            {'name': 'Changelog', 'href': 'changelog.md'},
-            {'name': 'Storage',
-                'items': [
-                    {'name': 'Blobs / Objects', 'href': 'blobs.md'},
-                    {'name': 'acl', 'uid': 'google.cloud.storage.acl', 'items': [
-                        {'name': 'ACL guide', 'href': 'acl_guide.md'},
-                        {'name': 'Overview', 'uid': 'google.cloud.storage.acl'},
+            {"name": "Overview", "href": "index.md"},
+            {"name": "Changelog", "href": "changelog.md"},
+            {"name": "Storage",
+                "items": [
+                    {"name": "Blobs / Objects", "href": "blobs.md"},
+                    {"name": "acl", "uid": "google.cloud.storage.acl", "items": [
+                        {"name": "ACL guide", "href": "acl_guide.md"},
+                        {"name": "Overview", "uid": "google.cloud.storage.acl"},
                     ]},
-                    {'name': 'batch', 'uid': 'google.cloud.storage.batch', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.batch'}]},
-                    {'name': 'blob', 'uid': 'google.cloud.storage.blob', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.blob'}]},
-                    {'name': 'bucket', 'uid': 'google.cloud.storage.bucket', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.bucket'}]},
-                    {'name': 'client', 'uid': 'google.cloud.storage.client', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.client'}]},
-                    {'name': 'constants', 'uid': 'google.cloud.storage.constants'},
-                    {'name': 'fileio', 'uid': 'google.cloud.storage.fileio', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.fileio'}]},
-                    {'name': 'hmac_key', 'uid': 'google.cloud.storage.hmac_key', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.hmac_key'}]},
-                    {'name': 'notification', 'uid': 'google.cloud.storage.notification', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.notification'}]},
-                    {'name': 'retry', 'uid': 'google.cloud.storage.retry', 'items': [{'name': 'Overview', 'uid': 'google.cloud.storage.retry'}]},
+                    {"name": "batch", "uid": "google.cloud.storage.batch", "items": [{"name": "Overview", "uid": "google.cloud.storage.batch"}]},
+                    {"name": "blob", "uid": "google.cloud.storage.blob", "items": [{"name": "Overview", "uid": "google.cloud.storage.blob"}]},
+                    {"name": "bucket", "uid": "google.cloud.storage.bucket", "items": [{"name": "Overview", "uid": "google.cloud.storage.bucket"}]},
+                    {"name": "client", "uid": "google.cloud.storage.client", "items": [{"name": "Overview", "uid": "google.cloud.storage.client"}]},
+                    {"name": "constants", "uid": "google.cloud.storage.constants"},
+                    {"name": "fileio", "uid": "google.cloud.storage.fileio", "items": [{"name": "Overview", "uid": "google.cloud.storage.fileio"}]},
+                    {"name": "hmac_key", "uid": "google.cloud.storage.hmac_key", "items": [{"name": "Overview", "uid": "google.cloud.storage.hmac_key"}]},
+                    {"name": "notification", "uid": "google.cloud.storage.notification", "items": [{"name": "Overview", "uid": "google.cloud.storage.notification"}]},
+                    {"name": "retry", "uid": "google.cloud.storage.retry", "items": [{"name": "Overview", "uid": "google.cloud.storage.retry"}]},
                 ]
              },
         ]
-        self.assertSetEqual(added_pages, expected_added_pages)
-        self.assertListEqual(merged_pkg_toc_yaml, expected_merged_pkg_toc_yaml)
+        self.assertSetEqual(
+            added_pages,
+            {
+                "index.md",
+                "changelog.md",
+                "blobs.md",
+                "acl_guide.md",
+            }
+        )
+        self.assertListEqual(
+            merged_pkg_toc_yaml,
+            [
+                {"name": "Overview", "href": "index.md"},
+                {"name": "Changelog", "href": "changelog.md"},
+                {"name": "Storage",
+                    "items": [
+                        {"name": "Blobs / Objects", "href": "blobs.md"},
+                        {
+                            "name": "acl",
+                            "uid": "google.cloud.storage.acl",
+                            "items": [
+                                {"name": "ACL guide", "href": "acl_guide.md"},
+                                {
+                                    "name": "Overview",
+                                    "uid": "google.cloud.storage.acl",
+                                },
+                            ],
+                        },
+                        {
+                            "name": "batch",
+                            "uid": "google.cloud.storage.batch",
+                            "items": [{
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.batch",
+                            }],
+                        },
+                        {
+                            "name": "blob",
+                            "uid": "google.cloud.storage.blob",
+                            "items": [{
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.blob",
+                            }],
+                        },
+                        {
+                            "name": "bucket",
+                            "uid": "google.cloud.storage.bucket",
+                            "items": [{
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.bucket",
+                            }],
+                        },
+                        {
+                            "name": "client",
+                            "uid": "google.cloud.storage.client",
+                            "items": [{
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.client",
+                            }],
+                        },
+                        {
+                            "name": "constants",
+                            "uid": "google.cloud.storage.constants",
+                        },
+                        {
+                            "name": "fileio",
+                            "uid": "google.cloud.storage.fileio",
+                            "items": [{
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.fileio",
+                            }],
+                        },
+                        {
+                            "name": "hmac_key",
+                            "uid": "google.cloud.storage.hmac_key",
+                            "items": [{
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.hmac_key",
+                            }],
+                        },
+                        {
+                            "name": "notification",
+                            "uid": "google.cloud.storage.notification",
+                            "items": [{
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.notification",
+                            }],
+                        },
+                        {
+                            "name": "retry",
+                            "uid": "google.cloud.storage.retry",
+                            "items": [{
+                                "name": "Overview",
+                                "uid": "google.cloud.storage.retry",
+                            }],
+                        },
+                    ],
+                },
+            ],
+        ),
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -648,7 +648,9 @@ You can also pass a mapping object.
 \n            \"client_cert_source\" : get_client_cert
 \n        })
 """
-        summary_got, attributes_got = extension._parse_docstring_summary(summary)
+        summary_got, attributes_got, enums_got = (
+            extension._parse_docstring_summary(summary)
+        )
         self.assertEqual(summary_got, summary_want)
         self.assertEqual(attributes_got, attributes_want)
 
@@ -662,7 +664,9 @@ And any other documentation that the source code would have could go here.
 """
         summary_want = summary + "\n"
 
-        summary_got, attributes_got = extension._parse_docstring_summary(summary)
+        summary_got, attributes_got, enums_got = (
+            extension._parse_docstring_summary(summary)
+        )
         self.assertEqual(summary_got, summary_want)
         self.assertEqual(attributes_got, attributes_want)
 
@@ -709,7 +713,9 @@ hyphenated term notice.
 \n    hyphenated term notice.
 """
 
-        summary_got, attributes_got = extension._parse_docstring_summary(summary)
+        summary_got, attributes_got, enums_got = (
+            extension._parse_docstring_summary(summary)
+        )
         self.assertEqual(summary_got, summary_want)
         self.assertEqual(attributes_got, attributes_want)
 
@@ -743,7 +749,9 @@ this is not a properly formatted warning.
 \n:type: str
 """
 
-        summary_got, attributes_got = extension._parse_docstring_summary(summary)
+        summary_got, attributes_got, enums_got = (
+            extension._parse_docstring_summary(summary)
+        )
         self.assertCountEqual(attributes_got, attributes_want)
 
         # Check multiple attributes are parsed.
@@ -777,7 +785,9 @@ this is not a properly formatted warning.
 
 \n:type: google.cloud.bigquery_logging_v1.types.TableInsertRequest
 """
-        summary_got, attributes_got = extension._parse_docstring_summary(summary)
+        summary_got, attributes_got, enums_got = (
+            extension._parse_docstring_summary(summary)
+        )
 
         self.assertCountEqual(attributes_got, attributes_want)
         for attribute_got, attribute_want in zip(attributes_got, attributes_want):
@@ -808,7 +818,9 @@ this is not a properly formatted warning.
 
 \n:type: str
 """
-        summary_got, attributes_got = extension._parse_docstring_summary(summary)
+        summary_got, attributes_got, enums_got = (
+            extension._parse_docstring_summary(summary)
+        )
 
         # Check that we are returned only one item.
         self.assertCountEqual(attributes_got, attributes_want)


### PR DESCRIPTION
Instead of a codeblocked format for enum, use table formatting.

Corresponding doc-pipeline support for enum table in Python: https://github.com/googleapis/doc-pipeline/pull/642

See b/338431108 for a staged example.
Fixes b/338431108.

- [x] Tests pass
