### PR TITLE
fix: build Markdown relative to input directory

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -182,7 +182,7 @@ def build_init(app):
         print("Successfully retrieved repository metadata.")
         app.env.library_shortname = repo_metadata["name"]
     print("Running sphinx-build with Markdown first...")
-    markdown_utils.run_sphinx_markdown()
+    markdown_utils.run_sphinx_markdown(app)
     print("Completed running sphinx-build with Markdown files.")
 
     """

--- a/docfx_yaml/markdown_utils.py
+++ b/docfx_yaml/markdown_utils.py
@@ -485,9 +485,11 @@ def remove_unused_pages(
             print(f"Could not delete {page}.")
 
 
-def run_sphinx_markdown() -> None:
+def run_sphinx_markdown(app: sphinx.application) -> None:
     """Runs sphinx-build with Markdown builder in the plugin."""
     cwd = os.getcwd()
+    relative_srcdir = app.srcdir.removeprefix(f"{cwd}/")
+    relative_outdir = app.outdir.removeprefix(f"{cwd}/").removesuffix("/html")
     # Skip running sphinx-build for Markdown for some unit tests.
     # Not required other than to output DocFX YAML.
     if "docs" in cwd:
@@ -498,8 +500,8 @@ def run_sphinx_markdown() -> None:
             "sphinx-build",
             "-M",
             "markdown",
-            "docs/",
-            "docs/_build",
+            relative_srcdir,
+            relative_outdir,
         ],
         hide_output=False
     )


### PR DESCRIPTION
The markdown builder was hardcoded with the pre-templated `docs/_build/html` format. However, folks are allowed to use whatever directory they choose, so the markdown builder should reflect that as well.

Verified locally that the build works when supplied a different directory.

Fixes b/338608643.

- [x] Tests pass
