### PR TITLE
fix: ignore disambiguation for repeated entries

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -53,7 +53,13 @@ class TestGenerate(unittest.TestCase):
                 "google.api_core.client_info": "client_info",
                 "google.api_core.gapic_v1.client_info": "gapic_v1.client_info",
             },
-        ]
+        ],
+        [
+            # Tests repeated duplicates in a row. No changes expected.
+            "tests/yaml_repeat_duplicate.yaml",
+            "tests/yaml_repeat_duplicate.yaml",
+            {},
+        ],
     ]
     @parameterized.expand(test_entries)
     def test_disambiguates_toc_name(

--- a/tests/yaml_repeat_duplicate.yaml
+++ b/tests/yaml_repeat_duplicate.yaml
@@ -1,0 +1,18 @@
+[
+   {
+      "name":"Services",
+      "uidname":"google.cloud.run_v2.services",
+      "items":[
+         {
+            "name":"Overview",
+            "uidname":"google.cloud.run_v2.services.services",
+            "uid":"google.cloud.run_v2.services.services",
+         },
+         {
+            "name":"Pagers",
+            "uidname":"google.cloud.run_v2.pagers",
+            "uid":"google.cloud.run_v2.pagers",
+         }
+      ]
+   },
+]


### PR DESCRIPTION
When there is a duplicate but repeated entries in a row, it can cause confusion as there is no good disambiguator to return.

For example, given
```
google.cloud.run_v2.services
google.cloud.run_v2.services.services
```
this is not really possible to disambiguate - and we don't need to. The TOC / layout should make it clear which one is which.

Fixes b/296919376. See staged example there.

- [x] Tests pass
