### PR TITLE
fix: handle unidentified objects in format_code

### DIFF
--- a/docfx_yaml/extension.py
+++ b/docfx_yaml/extension.py
@@ -103,6 +103,9 @@ REF_PATTERNS = [
     REF_PATTERN_BRACKETS,
 ]
 
+# Regex expression for removing formatting around unidentified objects.
+_UNIDENTIFIED_CODE_REGEX = re.compile(r'<[a-zA-Z\._\-]+\ object>')
+
 PROPERTY = 'property'
 CODEBLOCK = "code-block"
 CODE = "code"
@@ -1292,6 +1295,10 @@ def format_code(code: str) -> str:
         Formatted code with `black.format_str()`. May not format if there is
             an error.
     """
+    matched_objs = list(_UNIDENTIFIED_CODE_REGEX.finditer(code))
+    for matched_obj in matched_objs:
+        content = matched_obj.group()
+        code = code.replace(content, content.split(' ')[0][1:])
     # Signature code comes in raw text without formatting, to run black it
     # requires the code to look like actual function declaration in code.
     # Returns the original formatted code without the added bits.
@@ -1308,7 +1315,7 @@ def process_signature(app, _type, name, obj, options, signature, return_annotati
         try:
             signature = format_code(signature)
         except InvalidInput as e:
-            print(f"Could not format the given code: \n{e})")
+            print(f"Could not format the given code: \n{e}")
         app.env.docfx_signature_funcs_methods[name] = signature
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -227,15 +227,47 @@ for i in range(10):
 
         self.assertEqual(yaml_pre, yaml_post)
 
-
-    def test_format_code(self):
-        # Test to ensure black formats strings properly.
-        code_want = 'batch_predict(\n    *,\n    gcs_source: Optional[Union[str, Sequence[str]]] = None,\n    instances_format: str = "jsonl",\n    gcs_destination_prefix: Optional[str] = None,\n    predictions_format: str = "jsonl",\n    model_parameters: Optional[Dict] = None,\n    machine_type: Optional[str] = None,\n    accelerator_type: Optional[str] = None,\n    explanation_parameters: Optional[\n        google.cloud.aiplatform_v1.types.explanation.ExplanationParameters\n    ] = None,\n    labels: Optional[Dict[str, str]] = None,\n    sync: bool = True,\n)'
-
-        code = 'batch_predict(*, gcs_source: Optional[Union[str, Sequence[str]]] = None, instances_format: str = "jsonl", gcs_destination_prefix: Optional[str] = None, predictions_format: str = "jsonl", model_parameters: Optional[Dict] = None, machine_type: Optional[str] = None, accelerator_type: Optional[str] = None, explanation_parameters: Optional[google.cloud.aiplatform_v1.types.explanation.ExplanationParameters] = None, labels: Optional[Dict[str, str]] = None, sync: bool = True,)'
-
+    test_codes = [
+        [
+            "batch_predict(*, gcs_source: Optional[Union[str, Sequence[str]]] = None, instances_format: str = 'jsonl', gcs_destination_prefix: Optional[str] = None, predictions_format: str = 'jsonl', model_parameters: Optional[Dict] = None, machine_type: Optional[str] = None, accelerator_type: Optional[str] = None, explanation_parameters: Optional[google.cloud.aiplatform_v1.types.explanation.ExplanationParameters] = None, labels: Optional[Dict[str, str]] = None, sync: bool = True,)",
+            ("batch_predict(\n"
+             "    *,\n"
+             "    gcs_source: Optional[Union[str, Sequence[str]]] = None,\n"
+             "    instances_format: str = \"jsonl\",\n"
+             "    gcs_destination_prefix: Optional[str] = None,\n"
+             "    predictions_format: str = \"jsonl\",\n"
+             "    model_parameters: Optional[Dict] = None,\n"
+             "    machine_type: Optional[str] = None,\n"
+             "    accelerator_type: Optional[str] = None,\n"
+             "    explanation_parameters: Optional[\n"
+             "        google.cloud.aiplatform_v1.types.explanation.ExplanationParameters\n"
+             "    ] = None,\n"
+             "    labels: Optional[Dict[str, str]] = None,\n"
+             "    sync: bool = True,\n"
+             ")"),
+        ],
+        [
+            # Includes unidentified object
+            "upload_chunks_concurrently(filename, blob, content_type=None, chunk_size=33554432, deadline=None, worker_type='process', max_workers=8, *, checksum='auto', timeout=60, retry=<google.api_core.retry.retry_unary.Retry object>)",
+            ("upload_chunks_concurrently(\n"
+             "    filename,\n"
+             "    blob,\n"
+             "    content_type=None,\n"
+             "    chunk_size=33554432,\n"
+             "    deadline=None,\n"
+             "    worker_type=\"process\",\n"
+             "    max_workers=8,\n"
+             "    *,\n"
+             "    checksum=\"auto\",\n"
+             "    timeout=60,\n"
+             "    retry=google.api_core.retry.retry_unary.Retry\n"
+             ")"),
+        ],
+    ]
+    @parameterized.expand(test_codes)
+    def test_format_code(self, code, code_expected):
         code_got = extension.format_code(code)
-        self.assertEqual(code_want, code_got)
+        self.assertEqual(code_expected, code_got)
 
 
     def test_extract_product_name(self):


### PR DESCRIPTION
Updating the black formatter to be able to handle angled bracket items. Most of the content can be thrown away, just keeping the type that's found in this format: `<type object>`.

The gapic objects / references appearing like that has been an issue since #151 which I still can't figure out how to solve. Instead, fixed the black so that the signature can be readable once again.

Fixes b/367426932.

- [x] Tests pass
