### PR TITLE
chore(tests): run tests on each PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Presubmit tests
 
-on: [push]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Tests have been stuck on https://github.com/googleapis/sphinx-docfx-yaml/pull/406, because the test is not running. I believe that's because it's currently running on each push instead of pull_request. This PR fixes the test config
