### PR TITLE
chore(tests): run tests on each PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Presubmit tests
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Presubmit tests
 
-on: [push]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Tests have been stuck on https://github.com/googleapis/sphinx-docfx-yaml/pull/406, because the test is not running. I believe that's because cross-fork PRs don't trugger the `push` action. This PR fixes the test config to use `pull_request` instead